### PR TITLE
ci: trigger v14.2 RC1 release repair

### DIFF
--- a/.release-trigger-v14.2-rc1
+++ b/.release-trigger-v14.2-rc1
@@ -1,0 +1,1 @@
+This temporary branch exists only to trigger the one-shot v14.2 RC1 release repair.


### PR DESCRIPTION
一次性触发已修复的签名发布流程：删除失败遗留标签、重建 v14.2-RC1，并发布已验证的 APK、Full/Lite ZIP 与 SHA-256 附件。触发分支会由工作流自动删除。