### PR TITLE
fix(ui): 修复顶部标题与状态栏重叠

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuHost.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuHost.kt
@@ -1,13 +1,46 @@
 package io.github.xgl34222220.luoshu
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.xgl34222220.luoshu.ui.appearance.AppearanceViewModel
+import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
+import io.github.xgl34222220.luoshu.ui.theme.LocalMiuixTokens
+import io.github.xgl34222220.luoshu.ui.theme.LuoShuTheme
 
 @Composable
 internal fun LuoShuHost() {
     val model: LuoShuViewModel = viewModel()
     val features: Alpha15FeatureViewModel = viewModel()
-    val appearance: AppearanceViewModel = viewModel()
-    LuoShuAppShell(model, features, appearance)
+    val appearanceViewModel: AppearanceViewModel = viewModel()
+    val appearance by appearanceViewModel.settings.collectAsStateWithLifecycle()
+
+    LuoShuTheme(appearance) {
+        val pageBackground = if (appearance.uiStyle == UiStyle.MIUIX) {
+            LocalMiuixTokens.current.pageBackground
+        } else {
+            MaterialTheme.colorScheme.background
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(pageBackground),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .statusBarsPadding(),
+            ) {
+                LuoShuAppShell(model, features, appearanceViewModel)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 问题

启用 edge-to-edge 后，页面内容没有统一消费状态栏安全区，导致 Miuix 首页的 `FONT ENGINE` 与界面设置页的 `APPEARANCE` 进入系统状态栏并和时间、信号图标重叠。

## 修复

- 在 App 根内容容器统一应用 `statusBarsPadding()`，覆盖首页、字体库、组合、日志、设置五个一级页面。
- 根背景继续按 Material / Miuix 当前皮肤绘制，避免状态栏安全区出现突兀色块。
- 保留底部 edge-to-edge 与现有导航栏 inset 逻辑，不修改版本号、不创建标签、不发布 Release。

## 验证重点

- 首页与界面设置页英文眉题应完整位于状态栏下方。
- Material / Miuix 切换后顶部间距正常。
- 底部悬浮 Dock 和导航栏间距不应发生变化。
- 横屏、挖孔屏以及不同状态栏高度下不应再次重叠。
