### PR TITLE
fix(release): 验证完成后再创建 Tag 和 Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,10 @@
 name: Publish signed release
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
-    paths:
-      - module.prop
-      - 'RELEASE_NOTES_*.md'
-      - .github/workflows/release.yml
   workflow_dispatch:
     inputs:
-      tag:
-        description: Existing immutable tag to publish (for example v14.3.3)
+      confirm_tag:
+        description: Confirm the exact tag from module.prop (for example v14.3.4)
         required: true
         type: string
 
@@ -21,26 +12,66 @@ permissions:
   contents: write
 
 concurrency:
-  group: luoshu-release-${{ github.ref }}
+  group: luoshu-immutable-release
   cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Read and verify release identity
+        id: version
+        shell: bash
+        env:
+          CONFIRM_TAG: ${{ inputs.confirm_tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == 'refs/heads/main' ]] || {
+            echo 'Publish signed release must be started from the main branch.' >&2
+            exit 2
+          }
+          . ./scripts/version.sh
+          expected_tag="$LUOSHU_ARTIFACT_VERSION"
+          [[ "$CONFIRM_TAG" == "$expected_tag" ]] || {
+            echo "Confirmation tag $CONFIRM_TAG does not match module.prop ($expected_tag)." >&2
+            exit 2
+          }
+          notes_file="RELEASE_NOTES_${LUOSHU_VERSION// /_}.md"
+          [[ -s "$notes_file" ]] || {
+            echo "Missing release notes: $notes_file" >&2
+            exit 2
+          }
+          git fetch --force origin main --tags
+          release_sha="$(git rev-parse HEAD)"
+          main_sha="$(git rev-parse origin/main)"
+          [[ "$release_sha" == "$main_sha" ]] || {
+            echo "Checked-out commit $release_sha is not current origin/main $main_sha." >&2
+            exit 2
+          }
+          if git ls-remote --exit-code --tags origin "refs/tags/$expected_tag" >/dev/null 2>&1; then
+            echo "Tag already exists and will not be moved: $expected_tag" >&2
+            exit 2
+          fi
+          if gh release view "$expected_tag" >/dev/null 2>&1; then
+            echo "Release already exists and will not be overwritten: $expected_tag" >&2
+            exit 2
+          fi
+          echo "tag=$expected_tag" >> "$GITHUB_OUTPUT"
+          echo "version=$LUOSHU_VERSION" >> "$GITHUB_OUTPUT"
+          echo "artifact_version=$LUOSHU_ARTIFACT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "notes_file=$notes_file" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
 
       - uses: android-actions/setup-android@v3
 
@@ -48,71 +79,31 @@ jobs:
         with:
           gradle-version: '9.5.0'
 
-      - name: Read and verify release version
-        id: version
-        shell: bash
-        env:
-          INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-          . ./scripts/version.sh
-          expected_tag="$LUOSHU_ARTIFACT_VERSION"
-          tag="${GITHUB_REF_NAME}"
-
-          if [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' ]]; then
-            tag="$INPUT_TAG"
-            git fetch --force --tags origin
-            tag_sha="$(git rev-list -n1 "$tag" 2>/dev/null || true)"
-            [[ -n "$tag_sha" ]] || { echo "Tag does not exist: $tag" >&2; exit 2; }
-            [[ "$tag_sha" == "$GITHUB_SHA" ]] || { echo "Run this workflow from the existing tag $tag" >&2; exit 2; }
-          elif [[ "${GITHUB_REF_TYPE}" == 'branch' ]]; then
-            [[ "${GITHUB_REF_NAME}" == 'main' ]] || { echo "Stable branch publishing only supports main" >&2; exit 2; }
-            case "$LUOSHU_VERSION" in
-              *Alpha*|*Beta*|*RC*)
-                echo "Pre-release versions must be published from an explicit immutable tag" >&2
-                exit 2
-                ;;
-            esac
-            tag="$expected_tag"
-            git fetch --force --tags origin
-            tag_sha="$(git rev-list -n1 "$tag" 2>/dev/null || true)"
-            if [[ -n "$tag_sha" && "$tag_sha" != "$GITHUB_SHA" ]]; then
-              echo "Tag $tag already points to $tag_sha, not $GITHUB_SHA" >&2
-              exit 2
-            fi
-            if [[ -z "$tag_sha" ]]; then
-              git config user.name 'github-actions[bot]'
-              git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-              git tag "$tag" "$GITHUB_SHA"
-              git push origin "refs/tags/$tag"
-            fi
-          fi
-
-          [[ "$tag" == "$expected_tag" ]] || {
-            echo "Tag $tag does not match module.prop ($expected_tag)" >&2
-            exit 2
-          }
-          notes_file="RELEASE_NOTES_${LUOSHU_VERSION// /_}.md"
-          [[ -s "$notes_file" ]] || { echo "Missing release notes: $notes_file" >&2; exit 2; }
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=$LUOSHU_VERSION" >> "$GITHUB_OUTPUT"
-          echo "artifact_version=$LUOSHU_ARTIFACT_VERSION" >> "$GITHUB_OUTPUT"
-          echo "notes_file=$notes_file" >> "$GITHUB_OUTPUT"
-
-      - name: Require signing secrets
+      - name: Require fixed signing identity
         shell: bash
         env:
           KEYSTORE_BASE64: ${{ secrets.LUOSHU_KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.LUOSHU_KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.LUOSHU_KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.LUOSHU_KEY_PASSWORD }}
+          RELEASE_CERT_SHA256: ${{ secrets.LUOSHU_RELEASE_CERT_SHA256 }}
         run: |
           set -euo pipefail
-          for value in KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; do
-            [[ -n "${!value}" ]] || { echo "Missing repository secret: LUOSHU_${value}" >&2; exit 3; }
+          for value in KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD RELEASE_CERT_SHA256; do
+            [[ -n "${!value}" ]] || {
+              echo "Missing release signing secret: $value" >&2
+              exit 3
+            }
           done
+          expected_cert="$(printf '%s' "$RELEASE_CERT_SHA256" | tr -d '[:space:]:' | tr '[:upper:]' '[:lower:]')"
+          [[ "$expected_cert" =~ ^[0-9a-f]{64}$ ]] || {
+            echo 'LUOSHU_RELEASE_CERT_SHA256 must contain one SHA-256 certificate fingerprint.' >&2
+            exit 3
+          }
+          echo "::add-mask::$expected_cert"
           printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/luoshu-release.jks"
-          keytool -list -keystore "$RUNNER_TEMP/luoshu-release.jks" -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" >/dev/null
+          keytool -list -keystore "$RUNNER_TEMP/luoshu-release.jks" \
+            -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" >/dev/null
 
       - name: Install module build dependencies
         run: |
@@ -131,7 +122,7 @@ jobs:
             sh ./scripts/prepare_composite_runtime.sh
           fi
 
-      - name: Run complete source and module checks
+      - name: Run complete App-only source checks
         shell: bash
         run: sh ./scripts/check.sh
 
@@ -144,8 +135,10 @@ jobs:
           LUOSHU_KEY_PASSWORD: ${{ secrets.LUOSHU_KEY_PASSWORD }}
         run: gradle --no-daemon --stacktrace :app:lintRelease :app:testDebugUnitTest :app:assembleRelease
 
-      - name: Verify APK signature certificate
+      - name: Verify exact APK signing certificate
         shell: bash
+        env:
+          RELEASE_CERT_SHA256: ${{ secrets.LUOSHU_RELEASE_CERT_SHA256 }}
         run: |
           set -euo pipefail
           apk='android-app/app/build/outputs/apk/release/app-release.apk'
@@ -154,48 +147,122 @@ jobs:
           test -x "$apksigner"
           "$apksigner" verify --verbose --print-certs "$apk" | tee "$RUNNER_TEMP/apk-signature.txt"
           grep -Eq '^Verified using v(2|3|3\.1|3\.2) scheme.*: true$' "$RUNNER_TEMP/apk-signature.txt"
-          grep -Eq '^Number of signers: [1-9][0-9]*$' "$RUNNER_TEMP/apk-signature.txt"
-          grep -Eq 'certificate SHA-256 digest:' "$RUNNER_TEMP/apk-signature.txt"
+          grep -qx 'Number of signers: 1' "$RUNNER_TEMP/apk-signature.txt"
+          actual_cert="$(sed -n 's/^Signer #1 certificate SHA-256 digest: //p' "$RUNNER_TEMP/apk-signature.txt" | head -n1 | tr -d '[:space:]:' | tr '[:upper:]' '[:lower:]')"
+          expected_cert="$(printf '%s' "$RELEASE_CERT_SHA256" | tr -d '[:space:]:' | tr '[:upper:]' '[:lower:]')"
+          [[ "$actual_cert" =~ ^[0-9a-f]{64}$ ]] || {
+            echo 'Unable to read the APK signer SHA-256 fingerprint.' >&2
+            exit 4
+          }
+          [[ "$actual_cert" == "$expected_cert" ]] || {
+            echo 'APK certificate does not match LUOSHU_RELEASE_CERT_SHA256.' >&2
+            exit 4
+          }
 
-      - name: Build App and single module package
+      - name: Build and verify the four release assets
+        id: assets
         shell: bash
         run: |
           set -euo pipefail
           . ./scripts/version.sh
           apk='android-app/app/build/outputs/apk/release/app-release.apk'
-          test -s "$apk"
+          rm -rf dist
           mkdir -p dist
           app="dist/LuoShu-App-${LUOSHU_ARTIFACT_VERSION}.apk"
+          module="dist/LuoShu-${LUOSHU_ARTIFACT_VERSION}.zip"
           cp -f "$apk" "$app"
           (cd dist && sha256sum "$(basename "$app")" > "$(basename "$app").sha256")
           LUOSHU_APP_APK="$apk" sh ./scripts/build.sh
-          module="dist/LuoShu-${LUOSHU_ARTIFACT_VERSION}.zip"
           test -s "$module"
+          test -s "$module.sha256"
+          test -s "$app"
+          test -s "$app.sha256"
           unzip -t "$module" >/dev/null
-          unzip -Z1 "$module" | grep -qx 'bundled/LuoShu-App.apk'
-          ! unzip -Z1 "$module" | grep -qE '(^|/)webroot(/|$)'
+          unzip -Z1 "$module" > "$RUNNER_TEMP/module-files.txt"
+          grep -qx 'bundled/LuoShu-App.apk' "$RUNNER_TEMP/module-files.txt"
+          ! grep -qE '(^|/)webroot(/|$)' "$RUNNER_TEMP/module-files.txt"
+          ! unzip -p "$module" module.prop | grep -q '^webroot='
           unzip -p "$module" bundled/LuoShu-App.apk > "$RUNNER_TEMP/embedded.apk"
           cmp -s "$apk" "$RUNNER_TEMP/embedded.apk"
           (cd dist && sha256sum -c "$(basename "$module").sha256")
           (cd dist && sha256sum -c "$(basename "$app").sha256")
+          mapfile -t actual_files < <(find dist -maxdepth 1 -type f -printf '%f\n' | LC_ALL=C sort)
+          expected_files=(
+            "LuoShu-${LUOSHU_ARTIFACT_VERSION}.zip"
+            "LuoShu-${LUOSHU_ARTIFACT_VERSION}.zip.sha256"
+            "LuoShu-App-${LUOSHU_ARTIFACT_VERSION}.apk"
+            "LuoShu-App-${LUOSHU_ARTIFACT_VERSION}.apk.sha256"
+          )
+          mapfile -t expected_files < <(printf '%s\n' "${expected_files[@]}" | LC_ALL=C sort)
+          [[ "${actual_files[*]}" == "${expected_files[*]}" ]] || {
+            printf 'Unexpected release asset set:\n' >&2
+            printf '  %s\n' "${actual_files[@]}" >&2
+            exit 5
+          }
+          echo "module=$module" >> "$GITHUB_OUTPUT"
+          echo "module_sha=$module.sha256" >> "$GITHUB_OUTPUT"
+          echo "app=$app" >> "$GITHUB_OUTPUT"
+          echo "app_sha=$app.sha256" >> "$GITHUB_OUTPUT"
 
-      - name: Publish immutable GitHub release
+      - name: Preserve verified release candidates
+        uses: actions/upload-artifact@v4
+        with:
+          name: VERIFIED-LuoShu-${{ steps.version.outputs.tag }}
+          path: |
+            ${{ steps.assets.outputs.module }}
+            ${{ steps.assets.outputs.module_sha }}
+            ${{ steps.assets.outputs.app }}
+            ${{ steps.assets.outputs.app_sha }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Recheck immutable publication target
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_SHA: ${{ steps.version.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --force origin main --tags
+          [[ "$(git rev-parse origin/main)" == "$RELEASE_SHA" ]] || {
+            echo 'main changed while release candidates were building; restart the release workflow.' >&2
+            exit 6
+          }
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag appeared during the build and will not be overwritten: $TAG" >&2
+            exit 6
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release appeared during the build and will not be overwritten: $TAG" >&2
+            exit 6
+          fi
+
+      - name: Create immutable Tag and GitHub Release
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
           NOTES_FILE: ${{ steps.version.outputs.notes_file }}
-        shell: bash
+          RELEASE_SHA: ${{ steps.version.outputs.release_sha }}
+          MODULE: ${{ steps.assets.outputs.module }}
+          MODULE_SHA: ${{ steps.assets.outputs.module_sha }}
+          APP: ${{ steps.assets.outputs.app }}
+          APP_SHA: ${{ steps.assets.outputs.app_sha }}
         run: |
           set -euo pipefail
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists; immutable releases are never overwritten." >&2
-            exit 4
-          fi
           prerelease=()
           case "$VERSION" in *Alpha*|*Beta*|*RC*) prerelease=(--prerelease) ;; esac
-          gh release create "$TAG" dist/* \
-            --verify-tag \
+          gh release create "$TAG" "$MODULE" "$MODULE_SHA" "$APP" "$APP_SHA" \
+            --target "$RELEASE_SHA" \
             --title "洛书 $VERSION" \
             --notes-file "$NOTES_FILE" \
             "${prerelease[@]}"
+          git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"
+          [[ "$(git rev-list -n1 "$TAG")" == "$RELEASE_SHA" ]] || {
+            echo "Published tag $TAG does not point to the verified commit." >&2
+            exit 7
+          }
+          gh release view "$TAG" --json tagName,isDraft --jq \
+            'select(.tagName == env.TAG and .isDraft == false) | .tagName' | grep -qx "$TAG"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # 发布洛书
 
-`module.prop` 是模块、原生 App 与产物名称的唯一版本源。修改版本后，验证工作流会编译原生 App、运行模块检查并生成测试模块；它不会自动创建测试版 Release。
+`module.prop` 是模块、原生 App 与产物名称的唯一版本源。修改版本后，验证工作流会编译原生 App、运行模块检查并生成测试模块；它不会自动创建 Tag 或 Release。
 
 ## 首次配置固定 App 签名
 
@@ -9,32 +9,36 @@
 - `LUOSHU_KEYSTORE_BASE64`：JKS/PKCS12 文件的 Base64 内容；
 - `LUOSHU_KEYSTORE_PASSWORD`：密钥库密码；
 - `LUOSHU_KEY_ALIAS`：签名别名；
-- `LUOSHU_KEY_PASSWORD`：签名私钥密码。
+- `LUOSHU_KEY_PASSWORD`：签名私钥密码；
+- `LUOSHU_RELEASE_CERT_SHA256`：固定发布证书的 SHA-256 指纹，可带或不带冒号。
 
-密钥库和密码不可提交到仓库。正式 App 必须长期使用同一把密钥，否则 Android 会拒绝覆盖安装。
+密钥库和密码不可提交到仓库。正式 App 必须长期使用同一把密钥，否则 Android 会拒绝覆盖安装。发布工作流会从最终 APK 重新提取证书指纹，并与 `LUOSHU_RELEASE_CERT_SHA256` 精确比较；仅仅“存在签名”不能通过门禁。
 
 ## 候选版本门禁
 
 1. 基于最后一个干净候选基线建立独立分支，不从已废弃实验分支继续打补丁。
-2. `Validate source` 必须通过源码检查、角色覆盖门禁、App 编译与单元测试、单模块包构建和成品检查。
-3. `Build module` 必须通过复合字体烟雾测试并生成可解压的模块 ZIP。
+2. `Validate App-only source` 必须通过源码检查、角色覆盖门禁、App Lint、编译与单元测试、单模块包构建和成品检查。
+3. `Font engine smoke tests` 必须通过复合字体和 TTC 字体烟雾测试。
 4. 模块成品必须内置与独立 APK 字节一致的原生 App，不得包含 `webroot/`，`module.prop` 不得声明 `webroot=`。
 5. 按 `docs/TEST_MATRIX.md` 完成真机回归；未验证项目保持“待测”。
 6. 任一设备出现黑屏、SystemUI 重启、批量闪退或乱码，停止发布并恢复可用模块包。
 
 ## 发布步骤
 
-1. 将通过自动化和真机回归的候选版本整理到发布分支。
-2. 确认存在与版本完全匹配的发布说明，例如 `RELEASE_NOTES_v14.3.md`。
-3. 稳定版必须使用不含 Alpha、Beta、RC 的版本名，并提升 `versionCode`。
-4. 将稳定版本合并到 `main`；`Publish signed release` 会从 `module.prop` 创建唯一 Tag，例如 `v14.3`。
-5. 工作流重新运行完整源码检查、App lint/单元测试、固定签名构建、APK 证书校验与单模块成品校验，然后创建不可覆盖的 GitHub Release。
-6. 预发行版仍可手动创建唯一 Tag；已存在的 Tag 或 Release 不会被覆盖，修订内容必须提升版本号。
+1. 将通过自动化和真机回归的候选版本合并到 `main`。
+2. 确认 `module.prop` 已提升到新版本和新 `versionCode`，并存在与版本完全匹配的发布说明，例如 `RELEASE_NOTES_v14.3.4.md`。
+3. 在 GitHub Actions 中选择 `Publish signed release`，必须从 `main` 分支手动运行。
+4. 在 `confirm_tag` 中输入 `module.prop` 对应的完整 Tag，例如 `v14.3.4`。输入不一致、Tag 已存在、Release 已存在或运行提交不是最新 `main` 时，流程立即停止。
+5. 工作流先完成源码检查、App Lint、单元测试、固定签名构建、证书指纹校验、模块构建、嵌入 APK 一致性和四个发布文件的 SHA-256 校验。
+6. 已验证候选文件会先保存为 Actions Artifact；构建期间若 `main`、Tag 或 Release 状态发生变化，发布停止。
+7. 只有所有门禁通过后，最后一步才通过一次 `gh release create --target <verified commit>` 操作创建 Tag 和 GitHub Release。工作流不再提前执行 `git tag` 或 `git push refs/tags/...`。
+8. 已存在的 Tag 或 Release永不覆盖、移动或删除；修订内容必须提升版本号后重新发布。
 
-正式 Release 只包含两类可安装产物：
+正式 Release 只能包含四个文件：
 
 - `LuoShu-<版本>.zip`：唯一模块包，内置正式原生 App；
+- `LuoShu-<版本>.zip.sha256`；
 - `LuoShu-App-<版本>.apk`：相同签名的独立正式 APK；
-- 两个产物各自对应的 SHA-256 文件。
+- `LuoShu-App-<版本>.apk.sha256`。
 
 Lite 变体已取消，不再构建、上传或维护不内置 App 的模块包。模块会在刷写阶段优先自动覆盖更新 App；刷写环境无法调用 Android 包管理器时，会在首次完整开机后自动补装一次。若自动安装失败，可通过 Root 管理器中的模块“操作”按钮重试。

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -33,6 +33,7 @@ for file in \
   scripts/stability_test.sh scripts/native_zip_import_test.sh scripts/native_preview_source_test.sh \
   scripts/font_library_cache_test.sh scripts/app_installer_test.sh scripts/rc3_audit.sh \
   docs/RELEASING.md docs/TEST_MATRIX.md \
+  .github/workflows/release.yml \
   android-app/app/build.gradle.kts \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/MainActivity.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuHost.kt \
@@ -60,6 +61,24 @@ grep -q 'LUOSHU_ALLOW_DEBUG_APP' "$ROOT/scripts/build.sh"
 grep -q 'io.github.xgl34222220.luoshu.debug' "$ROOT/scripts/build.sh"
 grep -q 'LuoShu-${VERSION}.zip' "$ROOT/scripts/build.sh"
 ! grep -RIn 'LUOSHU_VARIANT' "$ROOT/scripts" "$ROOT/.github/workflows" >/dev/null 2>&1
+
+# 正式发布只能手动运行；先验证全部候选，再由一次 Release 操作创建 Tag。
+release_workflow="$ROOT/.github/workflows/release.yml"
+grep -q '^  workflow_dispatch:' "$release_workflow"
+! grep -q '^  push:' "$release_workflow"
+grep -q 'LUOSHU_RELEASE_CERT_SHA256' "$release_workflow"
+grep -q 'Build and verify the four release assets' "$release_workflow"
+grep -q 'Recheck immutable publication target' "$release_workflow"
+grep -q 'gh release create' "$release_workflow"
+grep -q -- '--target "$RELEASE_SHA"' "$release_workflow"
+! grep -qE 'git tag |git push origin.*refs/tags' "$release_workflow"
+! grep -q 'gh release create.*dist/\*' "$release_workflow"
+build_line=$(grep -n 'Build and verify the four release assets' "$release_workflow" | head -n1 | cut -d: -f1)
+publish_line=$(grep -n 'gh release create' "$release_workflow" | head -n1 | cut -d: -f1)
+case "$build_line:$publish_line" in *[!0-9:]*|:*|*:) exit 1 ;; esac
+[ "$publish_line" -gt "$build_line" ]
+grep -q '工作流不再提前执行 `git tag`' "$ROOT/docs/RELEASING.md"
+grep -q 'LUOSHU_RELEASE_CERT_SHA256' "$ROOT/docs/RELEASING.md"
 
 # 安装与运行时只面向原生 App，不得重新创建或依赖 webroot。
 grep -q 'luoshu_cli.sh.*system/bin/洛书' "$ROOT/customize.sh"


### PR DESCRIPTION
## 目标

修复正式发布流程提前创建并推送 Tag 的事务顺序。此 PR 暂时叠加在 App-only PR #40 上；#40 合并并完成真机回归后，再将本 PR 重新指向 `main`。

## 改动

- `Publish signed release` 改为仅允许从 `main` 手动触发，并要求输入与 `module.prop` 完全一致的 `confirm_tag`。
- 发布开始与最终发布前各检查一次：当前提交必须是最新 `origin/main`，目标 Tag 和 Release 必须都不存在。
- 删除提前执行的 `git tag` 与 `git push refs/tags/...`。
- 先完成 App-only 源码检查、Release Lint、单元测试、固定签名 APK 构建、模块构建和四个成品校验。
- 新增 `LUOSHU_RELEASE_CERT_SHA256`，最终 APK 的签名证书必须与固定指纹精确一致。
- Release 只允许上传模块 ZIP、模块 SHA-256、APK、APK SHA-256 四个明确文件，不再使用 `dist/*` 通配符。
- 已验证候选文件会先保存为 Actions Artifact。
- 最后通过一次 `gh release create --target <verified commit>` 操作创建 Tag 和 GitHub Release。
- `scripts/check.sh` 增加发布流程不变量门禁，防止以后重新引入自动 Push 发布、提前 Tag 或通配符上传。
- `docs/RELEASING.md` 已同步新流程与新增 Secret。

## 边界

- 不修改 `module.prop`、版本号或 `versionCode`。
- 不创建真实 Tag 或 Release。
- 不合并 PR #40；真机结果未确认前保持两个 PR 均为 Draft。
