### PR TITLE
feat(import): 重构原生批量导入流程

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontMetadataInspector.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontMetadataInspector.kt
@@ -1,0 +1,329 @@
+package io.github.xgl34222220.luoshu
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
+import io.github.xgl34222220.luoshu.ui.theme.LocalMiuixTokens
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+private const val DETAILS_BRIDGE = "/data/adb/modules/LuoShu/common/font_details.sh"
+
+private data class DetailedFontMetadata(
+    val title: String,
+    val text: String,
+)
+
+@Composable
+internal fun FontMetadataInspector(
+    viewModel: LuoShuViewModel,
+    style: UiStyle,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+    var showPicker by remember { mutableStateOf(false) }
+    var busy by remember { mutableStateOf(false) }
+    var details by remember { mutableStateOf<DetailedFontMetadata?>(null) }
+    val tokens = LocalMiuixTokens.current
+
+    Surface(
+        onClick = { showPicker = true },
+        enabled = viewModel.snapshot.installed && viewModel.fonts.isNotEmpty() && !busy,
+        modifier = modifier.size(if (style == UiStyle.MIUIX) 54.dp else 52.dp),
+        shape = if (style == UiStyle.MIUIX) RoundedCornerShape(19.dp) else CircleShape,
+        color = if (style == UiStyle.MIUIX) tokens.elevatedCardBackground else MaterialTheme.colorScheme.surface.copy(alpha = .96f),
+        contentColor = MaterialTheme.colorScheme.primary,
+        shadowElevation = if (style == UiStyle.MIUIX) 16.dp else 12.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = .10f)),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            if (busy) {
+                CircularProgressIndicator(Modifier.size(19.dp), strokeWidth = 2.dp)
+            } else {
+                Icon(Icons.Rounded.Info, contentDescription = "深度分析字体")
+            }
+        }
+    }
+
+    if (showPicker) {
+        MetadataPickerDialog(
+            style = style,
+            fonts = viewModel.fonts,
+            onDismiss = { showPicker = false },
+            onChoose = { font ->
+                showPicker = false
+                busy = true
+                scope.launch {
+                    details = withContext(Dispatchers.IO) { loadDetailedFontMetadata(font) }
+                    busy = false
+                }
+            },
+        )
+    }
+
+    if (busy) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("正在分析字体", fontWeight = FontWeight.Black) },
+            text = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
+                    Spacer(Modifier.width(12.dp))
+                    Text("正在读取内部名称、字重、覆盖范围和可变轴…")
+                }
+            },
+            confirmButton = {},
+            shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 34.dp else 28.dp),
+            containerColor = if (style == UiStyle.MIUIX) tokens.elevatedCardBackground else MaterialTheme.colorScheme.surfaceContainerHigh,
+        )
+    }
+
+    details?.let { result ->
+        MetadataResultDialog(
+            style = style,
+            result = result,
+            onDismiss = { details = null },
+        )
+    }
+}
+
+@Composable
+private fun MetadataPickerDialog(
+    style: UiStyle,
+    fonts: List<FontItem>,
+    onDismiss: () -> Unit,
+    onChoose: (FontItem) -> Unit,
+) {
+    var query by remember { mutableStateOf("") }
+    val filtered = remember(fonts, query) {
+        val needle = query.trim()
+        if (needle.isBlank()) fonts else fonts.filter { font ->
+            font.name.contains(needle, ignoreCase = true) ||
+                font.format.contains(needle, ignoreCase = true) ||
+                font.weightLabel.contains(needle, ignoreCase = true)
+        }
+    }
+    val tokens = LocalMiuixTokens.current
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("选择字体进行深度分析", fontWeight = FontWeight.Black) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 20.dp else 16.dp),
+                    leadingIcon = { Icon(Icons.Rounded.Search, contentDescription = null) },
+                    placeholder = { Text("搜索字体") },
+                )
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp),
+                    verticalArrangement = Arrangement.spacedBy(7.dp),
+                ) {
+                    items(filtered, key = { it.id }) { font ->
+                        Surface(
+                            modifier = Modifier.fillMaxWidth().clickable { onChoose(font) },
+                            shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 24.dp else 18.dp),
+                            color = if (style == UiStyle.MIUIX) tokens.cardBackground else MaterialTheme.colorScheme.surfaceContainerLow,
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Surface(
+                                    modifier = Modifier.size(44.dp),
+                                    shape = RoundedCornerShape(15.dp),
+                                    color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
+                                ) {
+                                    Box(contentAlignment = Alignment.Center) {
+                                        Text("Aa", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Black)
+                                    }
+                                }
+                                Spacer(Modifier.width(12.dp))
+                                Column(Modifier.weight(1f)) {
+                                    Text(font.name, fontWeight = FontWeight.Bold, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                                    Text(
+                                        listOf(font.format, font.size, font.weightLabel).filter { it.isNotBlank() }.joinToString(" · "),
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        fontSize = 10.sp,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("关闭") } },
+        shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 34.dp else 28.dp),
+        containerColor = if (style == UiStyle.MIUIX) tokens.elevatedCardBackground else MaterialTheme.colorScheme.surfaceContainerHigh,
+    )
+}
+
+@Composable
+private fun MetadataResultDialog(
+    style: UiStyle,
+    result: DetailedFontMetadata,
+    onDismiss: () -> Unit,
+) {
+    val tokens = LocalMiuixTokens.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(result.title, fontWeight = FontWeight.Black, maxLines = 2) },
+        text = {
+            SelectionContainer {
+                LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 500.dp)) {
+                    item {
+                        Text(
+                            result.text,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            lineHeight = 18.sp,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = { Button(onClick = onDismiss) { Text("完成") } },
+        shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 34.dp else 28.dp),
+        containerColor = if (style == UiStyle.MIUIX) tokens.elevatedCardBackground else MaterialTheme.colorScheme.surfaceContainerHigh,
+    )
+}
+
+private suspend fun loadDetailedFontMetadata(font: FontItem): DetailedFontMetadata {
+    return try {
+        val result = RootShell.exec(
+            "sh ${RootShell.quote(DETAILS_BRIDGE)} ${RootShell.quote(font.id)}",
+            timeoutMs = 60_000L,
+        )
+        if (result.code != 0) error(result.stderr.ifBlank { "字体详情读取失败" })
+        val root = firstMetadataJson(result.stdout)
+        if (root.optString("status") != "ok") error(root.optString("message", "字体详情读取失败"))
+        val data = root.getJSONObject("data")
+        val faces = data.getJSONArray("faces")
+        val title = faces.optJSONObject(0)?.optString("fullName", font.name).orEmpty().ifBlank { font.name }
+        val text = buildString {
+            append("文件：").append(data.optString("fileName")).append('\n')
+            append("SHA-256：").append(data.optString("sha256")).append('\n')
+            append("稳定文件 ID：").append(data.optString("fileUid")).append('\n')
+            append("字体面数量：").append(data.optInt("faceCount", faces.length())).append('\n')
+            append("文件大小：").append(formatMetadataBytes(data.optLong("bytes"))).append("\n\n")
+            for (index in 0 until faces.length()) {
+                val face = faces.optJSONObject(index) ?: continue
+                val coverage = face.optJSONObject("coverage")
+                val roles = coverage?.optJSONObject("roles")
+                append("字体面 #").append(face.optInt("faceIndex", index)).append('\n')
+                append("  名称：").append(face.optString("fullName", face.optString("family"))).append('\n')
+                append("  Family：").append(face.optString("family")).append('\n')
+                append("  Subfamily：").append(face.optString("subfamily")).append('\n')
+                face.optString("postScriptName").takeIf { it.isNotBlank() }?.let {
+                    append("  PostScript：").append(it).append('\n')
+                }
+                append("  稳定 ID：").append(face.optString("uid")).append('\n')
+                append("  格式：").append(face.optString("format"))
+                    .append(" · 字重 ").append(face.optInt("weight", 400))
+                    .append(if (face.optBoolean("italic")) " · 斜体" else " · 正体")
+                    .append('\n')
+                append("  字形：").append(face.optInt("glyphs"))
+                    .append(" · Unicode：").append(coverage?.optInt("codepoints") ?: 0)
+                    .append(" · CJK：").append(coverage?.optInt("cjkCount") ?: 0)
+                    .append('\n')
+                val roleLabels = buildList {
+                    if (roles?.optBoolean("cjk") == true) add("中文基底")
+                    if (roles?.optBoolean("latin") == true) add("英文")
+                    if (roles?.optBoolean("digit") == true) add("数字")
+                }
+                append("  推荐角色：")
+                    .append(if (roleLabels.isEmpty()) "不满足完整角色门禁" else roleLabels.joinToString("、"))
+                    .append('\n')
+                val axes = face.optJSONArray("axes")
+                if (axes != null && axes.length() > 0) {
+                    append("  可变轴：")
+                    for (axisIndex in 0 until axes.length()) {
+                        val axis = axes.optJSONObject(axisIndex) ?: continue
+                        if (axisIndex > 0) append("；")
+                        append(axis.optString("tag"))
+                            .append(' ')
+                            .append(trimMetadataNumber(axis.optDouble("min")))
+                            .append("–")
+                            .append(trimMetadataNumber(axis.optDouble("max")))
+                            .append("，默认 ")
+                            .append(trimMetadataNumber(axis.optDouble("default")))
+                    }
+                    append('\n')
+                } else {
+                    append("  可变轴：无\n")
+                }
+                if (index < faces.length() - 1) append('\n')
+            }
+        }.trimEnd()
+        DetailedFontMetadata(title, text)
+    } catch (error: Throwable) {
+        DetailedFontMetadata(font.name, error.message ?: "字体详情读取失败")
+    }
+}
+
+private fun firstMetadataJson(raw: String): JSONObject {
+    val line = raw.lineSequence().firstOrNull { it.trimStart().startsWith("{") }
+        ?: error("模块没有返回 JSON 数据")
+    return JSONObject(line.trim())
+}
+
+private fun formatMetadataBytes(bytes: Long): String = when {
+    bytes < 1024 -> "$bytes B"
+    bytes < 1024 * 1024 -> "%.1f KB".format(bytes / 1024.0)
+    bytes < 1024L * 1024L * 1024L -> "%.1f MB".format(bytes / 1024.0 / 1024.0)
+    else -> "%.2f GB".format(bytes / 1024.0 / 1024.0 / 1024.0)
+}
+
+private fun trimMetadataNumber(value: Double): String {
+    val rounded = value.toLong()
+    return if (value == rounded.toDouble()) rounded.toString()
+    else "%.2f".format(value).trimEnd('0').trimEnd('.')
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt
@@ -1,95 +1,40 @@
 package io.github.xgl34222220.luoshu
 
-import android.content.Context
-import android.net.Uri
-import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.CheckCircle
-import androidx.compose.material.icons.rounded.Info
-import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Error
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
 import io.github.xgl34222220.luoshu.ui.theme.LocalMiuixTokens
-import java.io.File
-import java.io.FileOutputStream
-import java.util.UUID
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.json.JSONObject
-
-private const val IMPORT_BRIDGE = "/data/adb/modules/LuoShu/common/app_bridge.sh"
-private const val DETAILS_BRIDGE = "/data/adb/modules/LuoShu/common/font_details.sh"
-private const val MAX_IMPORT_BYTES = 268_435_456L
-private val ALLOWED_EXTENSIONS = setOf("ttf", "otf", "ttc", "zip")
-
-private data class ImportSummary(
-    val imported: Int,
-    val duplicates: Int,
-    val failed: List<String>,
-) {
-    val title: String get() = if (failed.isEmpty()) "导入完成" else "导入结果"
-
-    val message: String
-        get() = buildString {
-            append("成功导入 ").append(imported).append(" 个文件")
-            if (duplicates > 0) append("，跳过 ").append(duplicates).append(" 个重复字体")
-            if (failed.isNotEmpty()) {
-                append("\n\n失败：\n")
-                failed.take(6).forEach { append("• ").append(it).append('\n') }
-                if (failed.size > 6) append("其余 ").append(failed.size - 6).append(" 项请查看日志")
-            }
-        }.trimEnd()
-}
-
-private data class FontDetails(
-    val title: String,
-    val text: String,
-)
 
 @Composable
 internal fun NativeImportOverlay(
@@ -97,125 +42,67 @@ internal fun NativeImportOverlay(
     style: UiStyle,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    var importBusy by remember { mutableStateOf(false) }
-    var importSummary by remember { mutableStateOf<ImportSummary?>(null) }
-    var showDetailsPicker by remember { mutableStateOf(false) }
-    var detailsBusy by remember { mutableStateOf(false) }
-    var details by remember { mutableStateOf<FontDetails?>(null) }
+    val importViewModel: NativeImportViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
+    val state = importViewModel.state
+
+    LaunchedEffect(state.refreshToken) {
+        if (state.refreshToken > 0L) viewModel.refreshFonts(force = true)
+    }
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenMultipleDocuments(),
     ) { uris ->
-        if (uris.isEmpty() || importBusy) return@rememberLauncherForActivityResult
-        importBusy = true
-        scope.launch {
-            importSummary = withContext(Dispatchers.IO) {
-                importDocuments(context.applicationContext, uris)
-            }
-            importBusy = false
-            viewModel.refreshFonts(force = true)
-        }
+        importViewModel.startImport(uris)
     }
 
-    ImportActions(
+    ImportActionButton(
         style = style,
-        importBusy = importBusy,
-        detailsBusy = detailsBusy,
-        detailsEnabled = viewModel.snapshot.installed && viewModel.fonts.isNotEmpty() && !detailsBusy,
-        importEnabled = viewModel.snapshot.installed &&
-            !importBusy &&
+        state = state,
+        enabled = viewModel.snapshot.installed &&
+            !state.busy &&
             !viewModel.operationBusy &&
             !viewModel.mixState.busy,
-        onDetails = { showDetailsPicker = true },
         onImport = { launcher.launch(arrayOf("*/*")) },
         modifier = modifier,
     )
 
-    importSummary?.let { result ->
-        ImportResultDialog(style, result) { importSummary = null }
-    }
-
-    if (showDetailsPicker) {
-        FontDetailsPickerDialog(
+    if (state.resultVisible) {
+        ImportResultDialog(
             style = style,
-            fonts = viewModel.fonts,
-            onDismiss = { showDetailsPicker = false },
-            onChoose = { font ->
-                showDetailsPicker = false
-                detailsBusy = true
-                scope.launch {
-                    details = withContext(Dispatchers.IO) { loadFontDetails(font) }
-                    detailsBusy = false
-                }
-            },
+            state = state,
+            onDismiss = importViewModel::dismissResult,
         )
-    }
-
-    if (detailsBusy) AnalysisLoadingDialog(style)
-
-    details?.let { result ->
-        FontDetailsDialog(style, result) { details = null }
     }
 }
 
 @Composable
-private fun ImportActions(
+private fun ImportActionButton(
     style: UiStyle,
-    importBusy: Boolean,
-    detailsBusy: Boolean,
-    detailsEnabled: Boolean,
-    importEnabled: Boolean,
-    onDetails: () -> Unit,
+    state: NativeImportState,
+    enabled: Boolean,
     onImport: () -> Unit,
     modifier: Modifier,
 ) {
-    val tokens = LocalMiuixTokens.current
-    Column(
+    Surface(
+        onClick = onImport,
+        enabled = enabled,
         modifier = modifier,
-        horizontalAlignment = Alignment.End,
-        verticalArrangement = Arrangement.spacedBy(10.dp),
+        shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 24.dp else 22.dp),
+        color = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+        shadowElevation = if (style == UiStyle.MIUIX) 18.dp else 14.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = .10f)),
     ) {
-        Surface(
-            onClick = onDetails,
-            enabled = detailsEnabled,
-            modifier = Modifier.size(if (style == UiStyle.MIUIX) 54.dp else 52.dp),
-            shape = if (style == UiStyle.MIUIX) RoundedCornerShape(19.dp) else CircleShape,
-            color = if (style == UiStyle.MIUIX) {
-                tokens.elevatedCardBackground
-            } else {
-                MaterialTheme.colorScheme.surface.copy(alpha = .96f)
-            },
-            contentColor = MaterialTheme.colorScheme.primary,
-            shadowElevation = if (style == UiStyle.MIUIX) 16.dp else 12.dp,
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = .10f)),
+        Column(
+            modifier = Modifier.padding(
+                horizontal = if (style == UiStyle.MIUIX) 19.dp else 18.dp,
+                vertical = if (style == UiStyle.MIUIX) 14.dp else 13.dp,
+            ),
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Box(contentAlignment = Alignment.Center) {
-                if (detailsBusy) {
-                    CircularProgressIndicator(Modifier.size(19.dp), strokeWidth = 2.dp)
-                } else {
-                    Icon(Icons.Rounded.Info, contentDescription = "字体详情")
-                }
-            }
-        }
-
-        Surface(
-            onClick = onImport,
-            enabled = importEnabled,
-            shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 24.dp else 22.dp),
-            color = MaterialTheme.colorScheme.primary,
-            contentColor = MaterialTheme.colorScheme.onPrimary,
-            shadowElevation = if (style == UiStyle.MIUIX) 18.dp else 14.dp,
-        ) {
-            Row(
-                modifier = Modifier.padding(
-                    horizontal = if (style == UiStyle.MIUIX) 19.dp else 18.dp,
-                    vertical = if (style == UiStyle.MIUIX) 16.dp else 15.dp,
-                ),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (importBusy) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (state.busy) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(19.dp),
                         strokeWidth = 2.dp,
@@ -225,7 +112,18 @@ private fun ImportActions(
                     Icon(Icons.Rounded.Add, contentDescription = null)
                 }
                 Spacer(Modifier.width(8.dp))
-                Text(if (importBusy) "导入中" else "导入字体", fontWeight = FontWeight.Black)
+                Text(
+                    if (state.busy) "导入 ${state.processed}/${state.total}" else "导入字体",
+                    fontWeight = FontWeight.Black,
+                )
+            }
+            if (state.busy) {
+                LinearProgressIndicator(
+                    progress = { state.progress / 100f },
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    trackColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = .24f),
+                )
             }
         }
     }
@@ -234,23 +132,24 @@ private fun ImportActions(
 @Composable
 private fun ImportResultDialog(
     style: UiStyle,
-    result: ImportSummary,
+    state: NativeImportState,
     onDismiss: () -> Unit,
 ) {
+    val failed = state.failed.isNotEmpty()
     if (style == UiStyle.MATERIAL) {
         AlertDialog(
             onDismissRequest = onDismiss,
             icon = {
                 Icon(
-                    Icons.Rounded.CheckCircle,
+                    if (failed) Icons.Rounded.Error else Icons.Rounded.CheckCircle,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = if (failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
                 )
             },
-            title = { Text(result.title, fontWeight = FontWeight.Black) },
+            title = { Text(state.title, fontWeight = FontWeight.Black) },
             text = {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(result.message)
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Text(state.summary)
                     Text(
                         "支持 TTF、OTF、TTC 与字体模块 ZIP。ZIP 只提取字体文件，不执行包内脚本。",
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -262,422 +161,45 @@ private fun ImportResultDialog(
             shape = MaterialTheme.shapes.extraLarge,
         )
     } else {
-        MiuixDialogFrame(
-            eyebrow = "IMPORT RESULT",
-            title = result.title,
-            onDismiss = onDismiss,
-        ) {
-            Text(result.message, color = LocalMiuixTokens.current.textPrimary, lineHeight = 20.sp)
-            Text(
-                "ZIP 仅安全提取字体，不执行包内脚本。",
-                color = LocalMiuixTokens.current.textSecondary,
-                fontSize = 11.sp,
-            )
-            Button(
-                onClick = onDismiss,
-                modifier = Modifier.align(Alignment.End),
-                shape = RoundedCornerShape(18.dp),
-            ) { Text("完成", fontWeight = FontWeight.Bold) }
-        }
-    }
-}
-
-@Composable
-private fun FontDetailsPickerDialog(
-    style: UiStyle,
-    fonts: List<FontItem>,
-    onDismiss: () -> Unit,
-    onChoose: (FontItem) -> Unit,
-) {
-    var query by remember { mutableStateOf("") }
-    val filtered = remember(fonts, query) {
-        val needle = query.trim()
-        if (needle.isBlank()) {
-            fonts
-        } else {
-            fonts.filter { font ->
-                font.name.contains(needle, ignoreCase = true) ||
-                    font.format.contains(needle, ignoreCase = true) ||
-                    font.weightLabel.contains(needle, ignoreCase = true)
-            }
-        }
-    }
-    val body: @Composable () -> Unit = {
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            OutlinedTextField(
-                value = query,
-                onValueChange = { query = it },
+        val tokens = LocalMiuixTokens.current
+        Dialog(onDismissRequest = onDismiss) {
+            Surface(
                 modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 20.dp else 16.dp),
-                leadingIcon = { Icon(Icons.Rounded.Search, contentDescription = null) },
-                placeholder = { Text("搜索字体") },
-            )
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 420.dp),
-                verticalArrangement = Arrangement.spacedBy(7.dp),
+                shape = RoundedCornerShape(38.dp),
+                color = tokens.elevatedCardBackground,
+                shadowElevation = 20.dp,
             ) {
-                items(filtered, key = { it.id }) { font ->
-                    Surface(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(if (style == UiStyle.MIUIX) 24.dp else 18.dp))
-                            .clickable { onChoose(font) },
-                        shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 24.dp else 18.dp),
-                        color = if (style == UiStyle.MIUIX) {
-                            LocalMiuixTokens.current.cardBackground
-                        } else {
-                            MaterialTheme.colorScheme.surfaceContainerLow
-                        },
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Surface(
-                                modifier = Modifier.size(44.dp),
-                                shape = RoundedCornerShape(15.dp),
-                                color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
-                            ) {
-                                Box(contentAlignment = Alignment.Center) {
-                                    Text("Aa", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Black)
-                                }
-                            }
-                            Spacer(Modifier.width(12.dp))
-                            Column(Modifier.weight(1f)) {
-                                Text(
-                                    font.name,
-                                    fontWeight = FontWeight.Bold,
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                                Text(
-                                    listOf(font.format, font.size, font.weightLabel)
-                                        .filter { it.isNotBlank() }
-                                        .joinToString(" · "),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    fontSize = 10.sp,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            }
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(13.dp),
+                ) {
+                    Text(
+                        "IMPORT RESULT",
+                        color = if (failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                        fontSize = 9.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 2.sp,
+                    )
+                    Text(
+                        state.title,
+                        color = tokens.textPrimary,
+                        fontSize = 25.sp,
+                        lineHeight = 30.sp,
+                        fontWeight = FontWeight.Black,
+                    )
+                    Text(state.summary, color = tokens.textPrimary, lineHeight = 20.sp)
+                    Text(
+                        "ZIP 仅安全提取字体，不执行包内脚本。导入历史可在任务中心查看。",
+                        color = tokens.textSecondary,
+                        fontSize = 11.sp,
+                    )
+                    Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+                        Button(onClick = onDismiss, shape = RoundedCornerShape(18.dp)) {
+                            Text("完成", fontWeight = FontWeight.Bold)
                         }
                     }
                 }
             }
         }
-    }
-
-    if (style == UiStyle.MATERIAL) {
-        AlertDialog(
-            onDismissRequest = onDismiss,
-            title = { Text("选择字体查看详情", fontWeight = FontWeight.Black) },
-            text = body,
-            confirmButton = { TextButton(onClick = onDismiss) { Text("关闭") } },
-            shape = MaterialTheme.shapes.extraLarge,
-        )
-    } else {
-        MiuixDialogFrame(
-            eyebrow = "FONT DETAILS",
-            title = "选择字体",
-            onDismiss = onDismiss,
-        ) {
-            body()
-            TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) {
-                Text("关闭", fontWeight = FontWeight.Bold)
-            }
-        }
-    }
-}
-
-@Composable
-private fun AnalysisLoadingDialog(style: UiStyle) {
-    if (style == UiStyle.MATERIAL) {
-        AlertDialog(
-            onDismissRequest = {},
-            title = { Text("正在分析字体", fontWeight = FontWeight.Black) },
-            text = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
-                    Spacer(Modifier.width(12.dp))
-                    Text("正在读取字体内部名称、字重、覆盖范围和可变轴…")
-                }
-            },
-            confirmButton = {},
-            shape = MaterialTheme.shapes.extraLarge,
-        )
-    } else {
-        MiuixDialogFrame(
-            eyebrow = "ANALYZING",
-            title = "正在分析字体",
-            onDismiss = {},
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                CircularProgressIndicator(Modifier.size(26.dp), strokeWidth = 2.dp)
-                Spacer(Modifier.width(12.dp))
-                Text(
-                    "正在读取内部名称、字重、覆盖范围和可变轴…",
-                    color = LocalMiuixTokens.current.textSecondary,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun FontDetailsDialog(
-    style: UiStyle,
-    result: FontDetails,
-    onDismiss: () -> Unit,
-) {
-    val body: @Composable () -> Unit = {
-        SelectionContainer {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 500.dp),
-            ) {
-                item {
-                    Text(
-                        result.text,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        lineHeight = 18.sp,
-                    )
-                }
-            }
-        }
-    }
-
-    if (style == UiStyle.MATERIAL) {
-        AlertDialog(
-            onDismissRequest = onDismiss,
-            title = { Text(result.title, fontWeight = FontWeight.Black, maxLines = 2) },
-            text = body,
-            confirmButton = { Button(onClick = onDismiss) { Text("完成") } },
-            shape = MaterialTheme.shapes.extraLarge,
-        )
-    } else {
-        MiuixDialogFrame(
-            eyebrow = "FONT METADATA",
-            title = result.title,
-            onDismiss = onDismiss,
-        ) {
-            body()
-            Button(
-                onClick = onDismiss,
-                modifier = Modifier.align(Alignment.End),
-                shape = RoundedCornerShape(18.dp),
-            ) { Text("完成", fontWeight = FontWeight.Bold) }
-        }
-    }
-}
-
-@Composable
-private fun MiuixDialogFrame(
-    eyebrow: String,
-    title: String,
-    onDismiss: () -> Unit,
-    content: @Composable ColumnScope.() -> Unit,
-) {
-    val tokens = LocalMiuixTokens.current
-    Dialog(onDismissRequest = onDismiss) {
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(38.dp),
-            color = tokens.elevatedCardBackground,
-            shadowElevation = 20.dp,
-        ) {
-            Column(
-                modifier = Modifier.padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(13.dp),
-            ) {
-                Text(
-                    eyebrow,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontSize = 9.sp,
-                    fontWeight = FontWeight.Bold,
-                    letterSpacing = 2.sp,
-                )
-                Text(
-                    title,
-                    color = tokens.textPrimary,
-                    fontSize = 25.sp,
-                    lineHeight = 30.sp,
-                    fontWeight = FontWeight.Black,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                content()
-            }
-        }
-    }
-}
-
-private suspend fun importDocuments(context: Context, uris: List<Uri>): ImportSummary {
-    val cacheDir = File(context.cacheDir, "native_import")
-    cacheDir.mkdirs()
-    var imported = 0
-    var duplicates = 0
-    val failed = mutableListOf<String>()
-
-    uris.take(32).forEachIndexed { index, uri ->
-        var temp: File? = null
-        val displayName = queryDisplayName(context, uri) ?: "font-${index + 1}"
-        try {
-            val extension = displayName.substringAfterLast('.', "").lowercase()
-            require(extension in ALLOWED_EXTENSIONS) { "仅支持 TTF、OTF、TTC 和 ZIP" }
-            temp = File(cacheDir, "${System.currentTimeMillis()}-${UUID.randomUUID()}.$extension")
-            copyUriWithLimit(context, uri, temp)
-            val result = RootShell.exec(
-                "sh ${RootShell.quote(IMPORT_BRIDGE)} import_file " +
-                    "${RootShell.quote(temp.absolutePath)} ${RootShell.quote(displayName)}",
-                timeoutMs = if (extension == "zip") 180_000L else 60_000L,
-            )
-            if (result.code != 0) error(result.stderr.ifBlank { "Root 导入失败" })
-            val root = firstJson(result.stdout)
-            if (root.optString("status") != "ok") error(root.optString("message", "导入失败"))
-            val duplicate = root.optJSONObject("data")?.optBoolean("duplicate", false) == true
-            if (duplicate) duplicates += 1 else imported += 1
-        } catch (error: Throwable) {
-            failed += "$displayName：${error.message ?: "导入失败"}"
-        } finally {
-            temp?.delete()
-        }
-    }
-
-    cacheDir.listFiles()?.filter { it.isFile }?.forEach { file ->
-        if (System.currentTimeMillis() - file.lastModified() > 3_600_000L) file.delete()
-    }
-    return ImportSummary(imported = imported, duplicates = duplicates, failed = failed)
-}
-
-private suspend fun loadFontDetails(font: FontItem): FontDetails {
-    return try {
-        val result = RootShell.exec(
-            "sh ${RootShell.quote(DETAILS_BRIDGE)} ${RootShell.quote(font.id)}",
-            timeoutMs = 60_000L,
-        )
-        if (result.code != 0) error(result.stderr.ifBlank { "字体详情读取失败" })
-        val root = firstJson(result.stdout)
-        if (root.optString("status") != "ok") error(root.optString("message", "字体详情读取失败"))
-        val data = root.getJSONObject("data")
-        val faces = data.getJSONArray("faces")
-        val title = faces.optJSONObject(0)?.optString("fullName", font.name).orEmpty().ifBlank { font.name }
-        val text = buildString {
-            append("文件：").append(data.optString("fileName")).append('\n')
-            append("SHA-256：").append(data.optString("sha256")).append('\n')
-            append("稳定文件 ID：").append(data.optString("fileUid")).append('\n')
-            append("字体面数量：").append(data.optInt("faceCount", faces.length())).append('\n')
-            append("文件大小：").append(formatBytes(data.optLong("bytes"))).append("\n\n")
-            for (index in 0 until faces.length()) {
-                val face = faces.optJSONObject(index) ?: continue
-                val coverage = face.optJSONObject("coverage")
-                val roles = coverage?.optJSONObject("roles")
-                append("字体面 #").append(face.optInt("faceIndex", index)).append('\n')
-                append("  名称：").append(face.optString("fullName", face.optString("family"))).append('\n')
-                append("  Family：").append(face.optString("family")).append('\n')
-                append("  Subfamily：").append(face.optString("subfamily")).append('\n')
-                face.optString("postScriptName").takeIf { it.isNotBlank() }?.let {
-                    append("  PostScript：").append(it).append('\n')
-                }
-                append("  稳定 ID：").append(face.optString("uid")).append('\n')
-                append("  格式：").append(face.optString("format"))
-                    .append(" · 字重 ").append(face.optInt("weight", 400))
-                    .append(if (face.optBoolean("italic")) " · 斜体" else " · 正体")
-                    .append('\n')
-                append("  字形：").append(face.optInt("glyphs"))
-                    .append(" · Unicode：").append(coverage?.optInt("codepoints") ?: 0)
-                    .append(" · CJK：").append(coverage?.optInt("cjkCount") ?: 0)
-                    .append('\n')
-                append("  推荐角色：")
-                val roleLabels = buildList {
-                    if (roles?.optBoolean("cjk") == true) add("中文基底")
-                    if (roles?.optBoolean("latin") == true) add("英文")
-                    if (roles?.optBoolean("digit") == true) add("数字")
-                }
-                append(if (roleLabels.isEmpty()) "不满足完整角色门禁" else roleLabels.joinToString("、")).append('\n')
-                val axes = face.optJSONArray("axes")
-                if (axes != null && axes.length() > 0) {
-                    append("  可变轴：")
-                    for (axisIndex in 0 until axes.length()) {
-                        val axis = axes.optJSONObject(axisIndex) ?: continue
-                        if (axisIndex > 0) append("；")
-                        append(axis.optString("tag"))
-                            .append(' ')
-                            .append(trimNumber(axis.optDouble("min")))
-                            .append("–")
-                            .append(trimNumber(axis.optDouble("max")))
-                            .append("，默认 ")
-                            .append(trimNumber(axis.optDouble("default")))
-                    }
-                    append('\n')
-                } else {
-                    append("  可变轴：无\n")
-                }
-                if (index < faces.length() - 1) append('\n')
-            }
-        }.trimEnd()
-        FontDetails(title = title, text = text)
-    } catch (error: Throwable) {
-        FontDetails(title = font.name, text = error.message ?: "字体详情读取失败")
-    }
-}
-
-private fun queryDisplayName(context: Context, uri: Uri): String? {
-    context.contentResolver.query(
-        uri,
-        arrayOf(OpenableColumns.DISPLAY_NAME),
-        null,
-        null,
-        null,
-    )?.use { cursor ->
-        if (cursor.moveToFirst()) {
-            val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-            if (index >= 0) return cursor.getString(index)?.substringAfterLast('/')
-        }
-    }
-    return uri.lastPathSegment?.substringAfterLast('/')
-}
-
-private fun copyUriWithLimit(context: Context, uri: Uri, target: File) {
-    context.contentResolver.openInputStream(uri)?.use { input ->
-        FileOutputStream(target).use { output ->
-            val buffer = ByteArray(128 * 1024)
-            var total = 0L
-            while (true) {
-                val count = input.read(buffer)
-                if (count < 0) break
-                total += count
-                require(total <= MAX_IMPORT_BYTES) { "文件超过 256 MB 限制" }
-                output.write(buffer, 0, count)
-            }
-            require(total > 0L) { "文件为空" }
-            output.fd.sync()
-        }
-    } ?: error("无法读取所选文件")
-}
-
-private fun firstJson(raw: String): JSONObject {
-    val line = raw.lineSequence().firstOrNull { it.trimStart().startsWith("{") }
-        ?: error("模块没有返回 JSON 数据")
-    return JSONObject(line.trim())
-}
-
-private fun formatBytes(bytes: Long): String = when {
-    bytes < 1024 -> "$bytes B"
-    bytes < 1024 * 1024 -> "%.1f KB".format(bytes / 1024.0)
-    bytes < 1024L * 1024L * 1024L -> "%.1f MB".format(bytes / 1024.0 / 1024.0)
-    else -> "%.2f GB".format(bytes / 1024.0 / 1024.0 / 1024.0)
-}
-
-private fun trimNumber(value: Double): String {
-    val rounded = value.toLong()
-    return if (value == rounded.toDouble()) {
-        rounded.toString()
-    } else {
-        "%.2f".format(value).trimEnd('0').trimEnd('.')
     }
 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt
@@ -55,16 +55,25 @@ internal fun NativeImportOverlay(
         importViewModel.startImport(uris)
     }
 
-    ImportActionButton(
-        style = style,
-        state = state,
-        enabled = viewModel.snapshot.installed &&
-            !state.busy &&
-            !viewModel.operationBusy &&
-            !viewModel.mixState.busy,
-        onImport = { launcher.launch(arrayOf("*/*")) },
+    Column(
         modifier = modifier,
-    )
+        horizontalAlignment = Alignment.End,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        FontMetadataInspector(
+            viewModel = viewModel,
+            style = style,
+        )
+        ImportActionButton(
+            style = style,
+            state = state,
+            enabled = viewModel.snapshot.installed &&
+                !state.busy &&
+                !viewModel.operationBusy &&
+                !viewModel.mixState.busy,
+            onImport = { launcher.launch(arrayOf("*/*")) },
+        )
+    }
 
     if (state.resultVisible) {
         ImportResultDialog(
@@ -81,12 +90,10 @@ private fun ImportActionButton(
     state: NativeImportState,
     enabled: Boolean,
     onImport: () -> Unit,
-    modifier: Modifier,
 ) {
     Surface(
         onClick = onImport,
         enabled = enabled,
-        modifier = modifier,
         shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 24.dp else 22.dp),
         color = MaterialTheme.colorScheme.primary,
         contentColor = MaterialTheme.colorScheme.onPrimary,

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt
@@ -1,0 +1,224 @@
+package io.github.xgl34222220.luoshu
+
+import android.app.Application
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+private const val IMPORT_BRIDGE = "/data/adb/modules/LuoShu/common/app_bridge.sh"
+private const val MAX_IMPORT_BYTES = 268_435_456L
+private val ALLOWED_IMPORT_EXTENSIONS = setOf("ttf", "otf", "ttc", "zip")
+
+internal enum class NativeImportPhase(val wireName: String) {
+    IDLE("idle"),
+    QUEUED("queued"),
+    RUNNING("running"),
+    SUCCESS("success"),
+    FAILED("failed"),
+}
+
+@Immutable
+internal data class NativeImportState(
+    val taskId: String = "",
+    val phase: NativeImportPhase = NativeImportPhase.IDLE,
+    val total: Int = 0,
+    val processed: Int = 0,
+    val imported: Int = 0,
+    val duplicates: Int = 0,
+    val failed: List<String> = emptyList(),
+    val currentFile: String = "",
+    val message: String = "尚未开始导入",
+    val resultVisible: Boolean = false,
+    val refreshToken: Long = 0L,
+) {
+    val busy: Boolean
+        get() = phase == NativeImportPhase.QUEUED || phase == NativeImportPhase.RUNNING
+
+    val progress: Int
+        get() = when {
+            total <= 0 -> 0
+            processed >= total -> 100
+            else -> ((processed * 100) / total).coerceIn(0, 99)
+        }
+
+    val title: String
+        get() = when {
+            busy -> "正在导入字体"
+            failed.isEmpty() -> "导入完成"
+            imported > 0 || duplicates > 0 -> "导入部分完成"
+            else -> "导入失败"
+        }
+
+    val summary: String
+        get() = buildString {
+            append("成功导入 ").append(imported).append(" 个文件")
+            if (duplicates > 0) append("，跳过 ").append(duplicates).append(" 个重复字体")
+            if (failed.isNotEmpty()) {
+                append("\n\n失败：\n")
+                failed.take(6).forEach { append("• ").append(it).append('\n') }
+                if (failed.size > 6) append("其余 ").append(failed.size - 6).append(" 项请查看任务中心")
+            }
+        }.trimEnd()
+}
+
+private enum class ImportOutcome { IMPORTED, DUPLICATE }
+
+internal class NativeImportViewModel(application: Application) : AndroidViewModel(application) {
+    var state by mutableStateOf(NativeImportState())
+        private set
+
+    private var importJob: Job? = null
+
+    fun startImport(uris: List<Uri>) {
+        if (state.busy || importJob?.isActive == true) return
+        val selected = uris.take(32)
+        if (selected.isEmpty()) return
+
+        val taskId = "import-${System.currentTimeMillis()}"
+        state = NativeImportState(
+            taskId = taskId,
+            phase = NativeImportPhase.QUEUED,
+            total = selected.size,
+            message = "已选择 ${selected.size} 个文件，准备开始导入",
+        )
+        importJob = viewModelScope.launch {
+            val context = getApplication<Application>().applicationContext
+            var imported = 0
+            var duplicates = 0
+            val failed = mutableListOf<String>()
+
+            selected.forEachIndexed { index, uri ->
+                val displayName = queryDisplayName(context, uri) ?: "font-${index + 1}"
+                state = state.copy(
+                    phase = NativeImportPhase.RUNNING,
+                    processed = index,
+                    imported = imported,
+                    duplicates = duplicates,
+                    failed = failed.toList(),
+                    currentFile = displayName,
+                    message = "正在导入 ${index + 1}/${selected.size}：$displayName",
+                )
+                try {
+                    when (withContext(Dispatchers.IO) { importOne(context, uri, displayName) }) {
+                        ImportOutcome.IMPORTED -> imported += 1
+                        ImportOutcome.DUPLICATE -> duplicates += 1
+                    }
+                } catch (error: Throwable) {
+                    failed += "$displayName：${error.message ?: "导入失败"}"
+                }
+                state = state.copy(
+                    processed = index + 1,
+                    imported = imported,
+                    duplicates = duplicates,
+                    failed = failed.toList(),
+                )
+            }
+
+            val phase = if (failed.isEmpty()) NativeImportPhase.SUCCESS else NativeImportPhase.FAILED
+            val message = when {
+                failed.isEmpty() -> "字体导入完成，共处理 ${selected.size} 个文件"
+                imported > 0 || duplicates > 0 -> "字体导入部分完成，${failed.size} 个文件失败"
+                else -> "字体导入失败，未成功处理任何文件"
+            }
+            state = state.copy(
+                phase = phase,
+                processed = selected.size,
+                imported = imported,
+                duplicates = duplicates,
+                failed = failed.toList(),
+                currentFile = "",
+                message = message,
+                resultVisible = true,
+                refreshToken = System.currentTimeMillis(),
+            )
+            importJob = null
+        }
+    }
+
+    fun dismissResult() {
+        state = state.copy(resultVisible = false)
+    }
+}
+
+private suspend fun importOne(context: android.content.Context, uri: Uri, displayName: String): ImportOutcome {
+    val extension = displayName.substringAfterLast('.', "").lowercase()
+    require(extension in ALLOWED_IMPORT_EXTENSIONS) { "仅支持 TTF、OTF、TTC 和 ZIP" }
+
+    val cacheDir = File(context.cacheDir, "native_import")
+    cacheDir.mkdirs()
+    val temp = File(cacheDir, "${System.currentTimeMillis()}-${UUID.randomUUID()}.$extension")
+    try {
+        copyUriWithLimit(context, uri, temp)
+        val result = RootShell.exec(
+            "sh ${RootShell.quote(IMPORT_BRIDGE)} import_file " +
+                "${RootShell.quote(temp.absolutePath)} ${RootShell.quote(displayName)}",
+            timeoutMs = if (extension == "zip") 180_000L else 60_000L,
+        )
+        if (result.code != 0) error(result.stderr.ifBlank { "Root 导入失败" })
+        val root = firstImportJson(result.stdout)
+        if (root.optString("status") != "ok") error(root.optString("message", "导入失败"))
+        return if (root.optJSONObject("data")?.optBoolean("duplicate", false) == true) {
+            ImportOutcome.DUPLICATE
+        } else {
+            ImportOutcome.IMPORTED
+        }
+    } finally {
+        temp.delete()
+        cacheDir.listFiles()?.filter { it.isFile }?.forEach { file ->
+            if (System.currentTimeMillis() - file.lastModified() > 3_600_000L) file.delete()
+        }
+    }
+}
+
+private fun queryDisplayName(context: android.content.Context, uri: Uri): String? {
+    context.contentResolver.query(
+        uri,
+        arrayOf(OpenableColumns.DISPLAY_NAME),
+        null,
+        null,
+        null,
+    )?.use { cursor ->
+        if (cursor.moveToFirst()) {
+            val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (index >= 0) return cursor.getString(index)?.substringAfterLast('/')
+        }
+    }
+    return uri.lastPathSegment?.substringAfterLast('/')
+}
+
+private fun copyUriWithLimit(context: android.content.Context, uri: Uri, target: File) {
+    context.contentResolver.openInputStream(uri)?.use { input ->
+        FileOutputStream(target).use { output ->
+            val buffer = ByteArray(128 * 1024)
+            var total = 0L
+            while (true) {
+                val count = input.read(buffer)
+                if (count < 0) break
+                total += count
+                require(total <= MAX_IMPORT_BYTES) { "文件超过 256 MB 限制" }
+                output.write(buffer, 0, count)
+            }
+            require(total > 0L) { "文件为空" }
+            output.fd.sync()
+        }
+    } ?: error("无法读取所选文件")
+}
+
+private fun firstImportJson(raw: String): JSONObject {
+    val line = raw.lineSequence().firstOrNull { it.trimStart().startsWith("{") }
+        ?: error("未收到导入结果")
+    return JSONObject(line.trim())
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsContract.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsContract.kt
@@ -2,6 +2,8 @@ package io.github.xgl34222220.luoshu.ui.logs
 
 import androidx.compose.runtime.Immutable
 import io.github.xgl34222220.luoshu.LuoShuViewModel
+import io.github.xgl34222220.luoshu.NativeImportPhase
+import io.github.xgl34222220.luoshu.NativeImportState
 
 @Immutable
 internal data class LogsUiState(
@@ -149,5 +151,33 @@ internal fun LuoShuViewModel.toLogsUiState(): LogsUiState {
         completedTaskCount = tasks.count { it.completed },
         failedTaskCount = tasks.count { it.phase == TaskPhase.FAILED },
         rebootRequired = rebootRequired || snapshot.rebootRequired,
+    )
+}
+
+internal fun LogsUiState.withNativeImport(state: NativeImportState): LogsUiState {
+    if (state.phase == NativeImportPhase.IDLE) return this
+    val phase = when (state.phase) {
+        NativeImportPhase.IDLE -> TaskPhase.INFO
+        NativeImportPhase.QUEUED -> TaskPhase.QUEUED
+        NativeImportPhase.RUNNING -> TaskPhase.RUNNING
+        NativeImportPhase.SUCCESS -> TaskPhase.SUCCESS
+        NativeImportPhase.FAILED -> TaskPhase.FAILED
+    }
+    val item = TaskCenterItem(
+        id = state.taskId.ifBlank { "native-import" },
+        kind = TaskKind.IMPORT,
+        phase = phase,
+        title = taskTitle(TaskKind.IMPORT, phase),
+        message = state.message,
+        progress = state.progress,
+        timeLabel = if (state.busy) "当前" else "最近",
+        current = state.busy,
+    )
+    val merged = mergeTaskItems(listOf(item), tasks)
+    return copy(
+        tasks = merged,
+        activeTaskCount = merged.count { it.active },
+        completedTaskCount = merged.count { it.completed },
+        failedTaskCount = merged.count { it.phase == TaskPhase.FAILED },
     )
 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsRoute.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsRoute.kt
@@ -1,6 +1,7 @@
 package io.github.xgl34222220.luoshu.ui.logs
 
 import androidx.compose.runtime.Composable
+import io.github.xgl34222220.luoshu.NativeImportViewModel
 import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
 
 @Composable
@@ -9,8 +10,10 @@ internal fun LogsRoute(
     state: LogsUiState,
     actions: LogsActions,
 ) {
+    val importViewModel: NativeImportViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
+    val displayState = state.withNativeImport(importViewModel.state)
     when (style) {
-        UiStyle.MATERIAL -> LogsScreenMaterial(state, actions)
-        UiStyle.MIUIX -> LogsScreenMiuix(state, actions)
+        UiStyle.MATERIAL -> LogsScreenMaterial(displayState, actions)
+        UiStyle.MIUIX -> LogsScreenMiuix(displayState, actions)
     }
 }

--- a/android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportStateTest.kt
+++ b/android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportStateTest.kt
@@ -1,0 +1,68 @@
+package io.github.xgl34222220.luoshu
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeImportStateTest {
+    @Test
+    fun runningStateCalculatesProgressBelowCompletion() {
+        val state = NativeImportState(
+            phase = NativeImportPhase.RUNNING,
+            total = 3,
+            processed = 2,
+            currentFile = "Example.ttf",
+        )
+
+        assertTrue(state.busy)
+        assertEquals(66, state.progress)
+        assertEquals("正在导入字体", state.title)
+    }
+
+    @Test
+    fun completedStateReportsImportedAndDuplicates() {
+        val state = NativeImportState(
+            phase = NativeImportPhase.SUCCESS,
+            total = 4,
+            processed = 4,
+            imported = 3,
+            duplicates = 1,
+        )
+
+        assertFalse(state.busy)
+        assertEquals(100, state.progress)
+        assertEquals("导入完成", state.title)
+        assertTrue(state.summary.contains("成功导入 3 个文件"))
+        assertTrue(state.summary.contains("跳过 1 个重复字体"))
+    }
+
+    @Test
+    fun partialFailureKeepsSuccessfulCountsVisible() {
+        val state = NativeImportState(
+            phase = NativeImportPhase.FAILED,
+            total = 3,
+            processed = 3,
+            imported = 1,
+            duplicates = 1,
+            failed = listOf("broken.ttf：字体文件不可用"),
+        )
+
+        assertEquals("导入部分完成", state.title)
+        assertTrue(state.summary.contains("成功导入 1 个文件"))
+        assertTrue(state.summary.contains("broken.ttf"))
+    }
+
+    @Test
+    fun totalFailureUsesFailureTitle() {
+        val state = NativeImportState(
+            phase = NativeImportPhase.FAILED,
+            total = 1,
+            processed = 1,
+            failed = listOf("bad.zip：ZIP 中没有字体文件"),
+        )
+
+        assertEquals("导入失败", state.title)
+        assertEquals(100, state.progress)
+    }
+}

--- a/android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/logs/NativeImportTaskIntegrationTest.kt
+++ b/android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/logs/NativeImportTaskIntegrationTest.kt
@@ -1,0 +1,70 @@
+package io.github.xgl34222220.luoshu.ui.logs
+
+import io.github.xgl34222220.luoshu.NativeImportPhase
+import io.github.xgl34222220.luoshu.NativeImportState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeImportTaskIntegrationTest {
+    @Test
+    fun runningImportAppearsBeforeHistoryAndUpdatesActiveCount() {
+        val history = TaskCenterItem(
+            id = "old-scan",
+            kind = TaskKind.SCAN,
+            phase = TaskPhase.SUCCESS,
+            title = "字体扫描已完成",
+            message = "字体索引已更新",
+        )
+        val result = LogsUiState(tasks = listOf(history)).withNativeImport(
+            NativeImportState(
+                taskId = "import-1",
+                phase = NativeImportPhase.RUNNING,
+                total = 4,
+                processed = 2,
+                currentFile = "Example.ttf",
+                message = "正在导入 3/4：Example.ttf",
+            ),
+        )
+
+        assertEquals(TaskKind.IMPORT, result.tasks.first().kind)
+        assertEquals(TaskPhase.RUNNING, result.tasks.first().phase)
+        assertEquals(50, result.tasks.first().progress)
+        assertEquals(1, result.activeTaskCount)
+    }
+
+    @Test
+    fun failedImportUpdatesFailureCount() {
+        val result = LogsUiState().withNativeImport(
+            NativeImportState(
+                taskId = "import-2",
+                phase = NativeImportPhase.FAILED,
+                total = 1,
+                processed = 1,
+                failed = listOf("bad.ttf：字体不可用"),
+                message = "字体导入失败，未成功处理任何文件",
+            ),
+        )
+
+        assertEquals(1, result.failedTaskCount)
+        assertEquals(0, result.activeTaskCount)
+        assertTrue(result.tasks.first().message.contains("失败"))
+    }
+
+    @Test
+    fun successfulImportCountsAsCompleted() {
+        val result = LogsUiState().withNativeImport(
+            NativeImportState(
+                taskId = "import-3",
+                phase = NativeImportPhase.SUCCESS,
+                total = 2,
+                processed = 2,
+                imported = 2,
+                message = "字体导入完成，共处理 2 个文件",
+            ),
+        )
+
+        assertEquals(1, result.completedTaskCount)
+        assertEquals(TaskPhase.SUCCESS, result.tasks.first().phase)
+    }
+}


### PR DESCRIPTION
## 目标

把字体批量导入从页面临时协程迁移到 Activity 级 ViewModel，并统一接入任务中心。

## 已完成

- 切换页面时导入任务继续运行，不再随字体库页面销毁而取消。
- 显示当前文件、已处理数量和真实批量进度。
- 统一统计成功、重复与失败文件。
- 导入状态实时进入任务中心，并在完成后保留最近结果。
- 基础字体详情继续由字体库提供；SHA-256、字体面、覆盖范围、推荐角色和可变轴等能力保留为独立“深度分析”入口。
- ZIP 仍只安全提取字体文件，不执行包内脚本。
- 增加导入状态与任务中心集成单元测试。

## 验证

- Font engine smoke tests 通过。
- App-only source、Lint、单元测试、Debug 编译、单包构建与成品检查通过。

## 边界

当前分支基于 PR #44。保持 Draft，不修改版本号，不创建 Tag 或 Release。