### PR TITLE
feat(import): 支持导入队列断点恢复

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuHost.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuHost.kt
@@ -31,6 +31,7 @@ internal fun LuoShuHost() {
     val model: LuoShuViewModel = viewModel()
     val features: Alpha15FeatureViewModel = viewModel()
     val appearanceViewModel: AppearanceViewModel = viewModel()
+    viewModel<NativeImportViewModel>()
     val appearance by appearanceViewModel.settings.collectAsStateWithLifecycle()
 
     LuoShuTheme(appearance) {

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt
@@ -1,0 +1,162 @@
+package io.github.xgl34222220.luoshu
+
+import android.content.Context
+import java.io.File
+import java.io.FileOutputStream
+import java.io.StringReader
+import java.io.StringWriter
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import java.util.Properties
+
+internal enum class ImportQueueItemStatus {
+    PENDING, RUNNING, IMPORTED, DUPLICATE, FAILED;
+    val terminal: Boolean get() = this == IMPORTED || this == DUPLICATE || this == FAILED
+}
+
+internal data class ImportQueueItem(
+    val uri: String,
+    val displayName: String,
+    val status: ImportQueueItemStatus = ImportQueueItemStatus.PENDING,
+    val error: String = "",
+    val persistedPermission: Boolean = false,
+)
+
+internal data class ImportQueueTask(
+    val taskId: String,
+    val phase: NativeImportPhase,
+    val createdAt: Long,
+    val message: String,
+    val recovered: Boolean = false,
+    val items: List<ImportQueueItem>,
+) {
+    val total: Int get() = items.size
+    val processed: Int get() = items.count { it.status.terminal }
+    val imported: Int get() = items.count { it.status == ImportQueueItemStatus.IMPORTED }
+    val duplicates: Int get() = items.count { it.status == ImportQueueItemStatus.DUPLICATE }
+    val failures: List<String> get() = items.filter { it.status == ImportQueueItemStatus.FAILED }.map {
+        "${it.displayName}：${it.error.ifBlank { "导入失败" }}"
+    }
+    val unfinished: Boolean get() = items.any { !it.status.terminal }
+
+    fun forResume(): ImportQueueTask = copy(
+        phase = NativeImportPhase.QUEUED,
+        message = "检测到未完成导入任务，正在恢复队列",
+        recovered = true,
+        items = items.map {
+            if (it.status == ImportQueueItemStatus.RUNNING) it.copy(status = ImportQueueItemStatus.PENDING, error = "") else it
+        },
+    )
+
+    fun toUiState(resultVisible: Boolean = false, refreshToken: Long = 0L): NativeImportState = NativeImportState(
+        taskId = taskId,
+        phase = phase,
+        total = total,
+        processed = processed,
+        imported = imported,
+        duplicates = duplicates,
+        failed = failures,
+        currentFile = items.firstOrNull { it.status == ImportQueueItemStatus.RUNNING }?.displayName.orEmpty(),
+        message = message,
+        resultVisible = resultVisible,
+        refreshToken = refreshToken,
+        recovered = recovered,
+    )
+}
+
+internal fun encodeImportQueue(task: ImportQueueTask): String {
+    val properties = Properties()
+    properties.setProperty("schema", "1")
+    properties.setProperty("taskId", task.taskId)
+    properties.setProperty("phase", task.phase.wireName)
+    properties.setProperty("createdAt", task.createdAt.toString())
+    properties.setProperty("message", encodeField(task.message))
+    properties.setProperty("recovered", task.recovered.toString())
+    properties.setProperty("count", task.items.size.toString())
+    task.items.forEachIndexed { index, item ->
+        properties.setProperty("$index.uri", encodeField(item.uri))
+        properties.setProperty("$index.name", encodeField(item.displayName))
+        properties.setProperty("$index.status", item.status.name)
+        properties.setProperty("$index.error", encodeField(item.error))
+        properties.setProperty("$index.persisted", item.persistedPermission.toString())
+    }
+    return StringWriter().also { properties.store(it, null) }.toString()
+}
+
+internal fun decodeImportQueue(raw: String): ImportQueueTask? = runCatching {
+    val properties = Properties().apply { load(StringReader(raw)) }
+    require(properties.getProperty("schema") == "1")
+    val taskId = properties.getProperty("taskId").orEmpty()
+    require(taskId.matches(Regex("[A-Za-z0-9._-]{1,96}")))
+    val phase = NativeImportPhase.entries.firstOrNull { it.wireName == properties.getProperty("phase") }
+        ?: NativeImportPhase.IDLE
+    val count = properties.getProperty("count")?.toIntOrNull()?.coerceIn(1, 32) ?: 1
+    val items = buildList {
+        repeat(count) { index ->
+            val uri = decodeField(properties.getProperty("$index.uri").orEmpty())
+            val name = decodeField(properties.getProperty("$index.name").orEmpty())
+            if (uri.isBlank() || name.isBlank()) return@repeat
+            add(
+                ImportQueueItem(
+                    uri = uri,
+                    displayName = name,
+                    status = runCatching {
+                        ImportQueueItemStatus.valueOf(properties.getProperty("$index.status").orEmpty())
+                    }.getOrDefault(ImportQueueItemStatus.PENDING),
+                    error = decodeField(properties.getProperty("$index.error").orEmpty()),
+                    persistedPermission = properties.getProperty("$index.persisted").toBoolean(),
+                ),
+            )
+        }
+    }
+    require(items.isNotEmpty())
+    ImportQueueTask(
+        taskId = taskId,
+        phase = phase,
+        createdAt = properties.getProperty("createdAt")?.toLongOrNull() ?: 0L,
+        message = decodeField(properties.getProperty("message").orEmpty()).ifBlank { "字体导入任务" },
+        recovered = properties.getProperty("recovered").toBoolean(),
+        items = items,
+    )
+}.getOrNull()
+
+private fun encodeField(value: String): String = Base64.getUrlEncoder().withoutPadding()
+    .encodeToString(value.toByteArray(StandardCharsets.UTF_8))
+
+private fun decodeField(value: String): String = if (value.isBlank()) "" else runCatching {
+    String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8)
+}.getOrDefault("")
+
+internal class NativeImportQueueStore(context: Context) {
+    private val root = File(context.filesDir, "native_import_queue")
+    private val stateFile = File(root, "task.properties")
+
+    fun load(): ImportQueueTask? = if (stateFile.isFile) {
+        decodeImportQueue(runCatching { stateFile.readText() }.getOrDefault(""))
+    } else null
+
+    fun save(task: ImportQueueTask) {
+        root.mkdirs()
+        val temporary = File(root, "task.properties.tmp")
+        FileOutputStream(temporary).use {
+            it.write(encodeImportQueue(task).toByteArray(StandardCharsets.UTF_8))
+            it.fd.sync()
+        }
+        if (!temporary.renameTo(stateFile)) {
+            FileOutputStream(stateFile).use {
+                it.write(temporary.readBytes())
+                it.fd.sync()
+            }
+            temporary.delete()
+        }
+    }
+
+    fun stagedFile(taskId: String, index: Int, displayName: String): File {
+        val extension = displayName.substringAfterLast('.', "bin").lowercase().take(8)
+        val directory = File(root, taskId).apply { mkdirs() }
+        return File(directory, "$index.$extension")
+    }
+
+    fun partialFile(taskId: String, index: Int, displayName: String): File =
+        File(stagedFile(taskId, index, displayName).absolutePath + ".part")
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt
@@ -1,6 +1,7 @@
 package io.github.xgl34222220.luoshu
 
 import android.app.Application
+import android.content.Intent
 import android.net.Uri
 import android.provider.OpenableColumns
 import androidx.compose.runtime.Immutable
@@ -43,6 +44,7 @@ internal data class NativeImportState(
     val message: String = "尚未开始导入",
     val resultVisible: Boolean = false,
     val refreshToken: Long = 0L,
+    val recovered: Boolean = false,
 ) {
     val busy: Boolean
         get() = phase == NativeImportPhase.QUEUED || phase == NativeImportPhase.RUNNING
@@ -56,6 +58,7 @@ internal data class NativeImportState(
 
     val title: String
         get() = when {
+            busy && recovered -> "正在恢复字体导入"
             busy -> "正在导入字体"
             failed.isEmpty() -> "导入完成"
             imported > 0 || duplicates > 0 -> "导入部分完成"
@@ -77,79 +80,141 @@ internal data class NativeImportState(
 private enum class ImportOutcome { IMPORTED, DUPLICATE }
 
 internal class NativeImportViewModel(application: Application) : AndroidViewModel(application) {
+    private val queueStore = NativeImportQueueStore(application.applicationContext)
+
     var state by mutableStateOf(NativeImportState())
         private set
 
     private var importJob: Job? = null
+
+    init {
+        restoreSavedTask()
+    }
 
     fun startImport(uris: List<Uri>) {
         if (state.busy || importJob?.isActive == true) return
         val selected = uris.take(32)
         if (selected.isEmpty()) return
 
-        val taskId = "import-${System.currentTimeMillis()}"
-        state = NativeImportState(
-            taskId = taskId,
-            phase = NativeImportPhase.QUEUED,
-            total = selected.size,
-            message = "已选择 ${selected.size} 个文件，准备开始导入",
-        )
         importJob = viewModelScope.launch {
-            val context = getApplication<Application>().applicationContext
-            var imported = 0
-            var duplicates = 0
-            val failed = mutableListOf<String>()
-
-            selected.forEachIndexed { index, uri ->
-                val displayName = queryDisplayName(context, uri) ?: "font-${index + 1}"
-                state = state.copy(
-                    phase = NativeImportPhase.RUNNING,
-                    processed = index,
-                    imported = imported,
-                    duplicates = duplicates,
-                    failed = failed.toList(),
-                    currentFile = displayName,
-                    message = "正在导入 ${index + 1}/${selected.size}：$displayName",
-                )
-                try {
-                    when (withContext(Dispatchers.IO) { importOne(context, uri, displayName) }) {
-                        ImportOutcome.IMPORTED -> imported += 1
-                        ImportOutcome.DUPLICATE -> duplicates += 1
+            try {
+                val context = getApplication<Application>().applicationContext
+                val items = withContext(Dispatchers.IO) {
+                    selected.mapIndexed { index, uri ->
+                        val name = queryDisplayName(context, uri) ?: "font-${index + 1}"
+                        val persisted = runCatching {
+                            context.contentResolver.takePersistableUriPermission(
+                                uri,
+                                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                            )
+                            true
+                        }.getOrDefault(false)
+                        ImportQueueItem(
+                            uri = uri.toString(),
+                            displayName = name,
+                            persistedPermission = persisted,
+                        )
                     }
-                } catch (error: Throwable) {
-                    failed += "$displayName：${error.message ?: "导入失败"}"
                 }
-                state = state.copy(
-                    processed = index + 1,
-                    imported = imported,
-                    duplicates = duplicates,
-                    failed = failed.toList(),
+                val task = ImportQueueTask(
+                    taskId = "import-${System.currentTimeMillis()}",
+                    phase = NativeImportPhase.QUEUED,
+                    createdAt = System.currentTimeMillis(),
+                    message = "已保存 ${items.size} 个文件的导入队列",
+                    items = items,
                 )
+                runQueue(task)
+            } finally {
+                importJob = null
             }
-
-            val phase = if (failed.isEmpty()) NativeImportPhase.SUCCESS else NativeImportPhase.FAILED
-            val message = when {
-                failed.isEmpty() -> "字体导入完成，共处理 ${selected.size} 个文件"
-                imported > 0 || duplicates > 0 -> "字体导入部分完成，${failed.size} 个文件失败"
-                else -> "字体导入失败，未成功处理任何文件"
-            }
-            state = state.copy(
-                phase = phase,
-                processed = selected.size,
-                imported = imported,
-                duplicates = duplicates,
-                failed = failed.toList(),
-                currentFile = "",
-                message = message,
-                resultVisible = true,
-                refreshToken = System.currentTimeMillis(),
-            )
-            importJob = null
         }
     }
 
     fun dismissResult() {
         state = state.copy(resultVisible = false)
+    }
+
+    private fun restoreSavedTask() {
+        importJob = viewModelScope.launch {
+            try {
+                val saved = withContext(Dispatchers.IO) { queueStore.load() } ?: return@launch
+                val active = saved.phase == NativeImportPhase.QUEUED || saved.phase == NativeImportPhase.RUNNING
+                if (active || saved.unfinished) {
+                    runQueue(saved.forResume())
+                } else {
+                    state = saved.toUiState(resultVisible = false)
+                }
+            } finally {
+                importJob = null
+            }
+        }
+    }
+
+    private suspend fun runQueue(initial: ImportQueueTask) {
+        val context = getApplication<Application>().applicationContext
+        var task = initial
+        persistAndPublish(task)
+
+        task.items.indices.forEach { index ->
+            val item = task.items[index]
+            if (item.status.terminal) return@forEach
+
+            task = task.replaceItem(
+                index,
+                item.copy(status = ImportQueueItemStatus.RUNNING, error = ""),
+            ).copy(
+                phase = NativeImportPhase.RUNNING,
+                message = "正在导入 ${task.processed + 1}/${task.total}：${item.displayName}",
+            )
+            persistAndPublish(task)
+
+            val resultItem = try {
+                when (withContext(Dispatchers.IO) { importOne(context, Uri.parse(item.uri), item.displayName) }) {
+                    ImportOutcome.IMPORTED -> item.copy(status = ImportQueueItemStatus.IMPORTED, error = "")
+                    ImportOutcome.DUPLICATE -> item.copy(status = ImportQueueItemStatus.DUPLICATE, error = "")
+                }
+            } catch (error: Throwable) {
+                item.copy(
+                    status = ImportQueueItemStatus.FAILED,
+                    error = error.message ?: "导入失败",
+                )
+            }
+            task = task.replaceItem(index, resultItem)
+            persistAndPublish(task)
+        }
+
+        val phase = if (task.failures.isEmpty()) NativeImportPhase.SUCCESS else NativeImportPhase.FAILED
+        val message = when {
+            task.failures.isEmpty() -> "字体导入完成，共处理 ${task.total} 个文件"
+            task.imported > 0 || task.duplicates > 0 -> "字体导入部分完成，${task.failures.size} 个文件失败"
+            else -> "字体导入失败，未成功处理任何文件"
+        }
+        task = task.copy(phase = phase, message = message)
+        persistAndPublish(task, resultVisible = true, refreshToken = System.currentTimeMillis())
+        withContext(Dispatchers.IO) { releasePermissions(context, task) }
+    }
+
+    private suspend fun persistAndPublish(
+        task: ImportQueueTask,
+        resultVisible: Boolean = false,
+        refreshToken: Long = 0L,
+    ) {
+        withContext(Dispatchers.IO) { queueStore.save(task) }
+        state = task.toUiState(resultVisible = resultVisible, refreshToken = refreshToken)
+    }
+
+    private fun ImportQueueTask.replaceItem(index: Int, replacement: ImportQueueItem): ImportQueueTask =
+        copy(items = items.mapIndexed { itemIndex, item -> if (itemIndex == index) replacement else item })
+
+    private fun releasePermissions(context: android.content.Context, task: ImportQueueTask) {
+        task.items.filter { it.persistedPermission }.forEach { item ->
+            runCatching {
+                context.contentResolver.releasePersistableUriPermission(
+                    Uri.parse(item.uri),
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
+        }
     }
 }
 

--- a/android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportQueueStoreTest.kt
+++ b/android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportQueueStoreTest.kt
@@ -1,0 +1,91 @@
+package io.github.xgl34222220.luoshu
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeImportQueueStoreTest {
+    @Test
+    fun queueRoundTripPreservesNamesUrisAndResults() {
+        val task = ImportQueueTask(
+            taskId = "import-12345",
+            phase = NativeImportPhase.RUNNING,
+            createdAt = 12345L,
+            message = "正在导入 中文字体.ttf",
+            items = listOf(
+                ImportQueueItem(
+                    uri = "content://documents/中文字体.ttf",
+                    displayName = "中文字体.ttf",
+                    status = ImportQueueItemStatus.IMPORTED,
+                    persistedPermission = true,
+                ),
+                ImportQueueItem(
+                    uri = "content://documents/latin.zip",
+                    displayName = "latin.zip",
+                    status = ImportQueueItemStatus.RUNNING,
+                    persistedPermission = true,
+                ),
+            ),
+        )
+
+        val decoded = decodeImportQueue(encodeImportQueue(task))
+
+        assertNotNull(decoded)
+        assertEquals(task.taskId, decoded?.taskId)
+        assertEquals(task.message, decoded?.message)
+        assertEquals("中文字体.ttf", decoded?.items?.first()?.displayName)
+        assertEquals("content://documents/中文字体.ttf", decoded?.items?.first()?.uri)
+        assertEquals(ImportQueueItemStatus.RUNNING, decoded?.items?.last()?.status)
+        assertTrue(decoded?.items?.all { it.persistedPermission } == true)
+    }
+
+    @Test
+    fun resumeOnlyResetsInterruptedItem() {
+        val task = ImportQueueTask(
+            taskId = "import-67890",
+            phase = NativeImportPhase.RUNNING,
+            createdAt = 67890L,
+            message = "处理中",
+            items = listOf(
+                ImportQueueItem("content://one", "one.ttf", ImportQueueItemStatus.IMPORTED),
+                ImportQueueItem("content://two", "two.ttf", ImportQueueItemStatus.DUPLICATE),
+                ImportQueueItem("content://three", "three.ttf", ImportQueueItemStatus.RUNNING),
+                ImportQueueItem("content://four", "four.ttf", ImportQueueItemStatus.PENDING),
+            ),
+        )
+
+        val resumed = task.forResume()
+
+        assertEquals(NativeImportPhase.QUEUED, resumed.phase)
+        assertTrue(resumed.recovered)
+        assertEquals(ImportQueueItemStatus.IMPORTED, resumed.items[0].status)
+        assertEquals(ImportQueueItemStatus.DUPLICATE, resumed.items[1].status)
+        assertEquals(ImportQueueItemStatus.PENDING, resumed.items[2].status)
+        assertEquals(ImportQueueItemStatus.PENDING, resumed.items[3].status)
+        assertEquals(2, resumed.processed)
+        assertEquals(1, resumed.imported)
+        assertEquals(1, resumed.duplicates)
+    }
+
+    @Test
+    fun terminalQueueRestoresAsNonBusyUiState() {
+        val task = ImportQueueTask(
+            taskId = "import-complete",
+            phase = NativeImportPhase.SUCCESS,
+            createdAt = 1L,
+            message = "字体导入完成，共处理 1 个文件",
+            items = listOf(
+                ImportQueueItem("content://one", "one.ttf", ImportQueueItemStatus.IMPORTED),
+            ),
+        )
+
+        val state = task.toUiState()
+
+        assertFalse(state.busy)
+        assertEquals(100, state.progress)
+        assertEquals(1, state.imported)
+        assertEquals("导入完成", state.title)
+    }
+}

--- a/android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportTaskCenterTest.kt
+++ b/android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportTaskCenterTest.kt
@@ -1,0 +1,32 @@
+package io.github.xgl34222220.luoshu
+
+import io.github.xgl34222220.luoshu.ui.logs.LogsUiState
+import io.github.xgl34222220.luoshu.ui.logs.TaskKind
+import io.github.xgl34222220.luoshu.ui.logs.TaskPhase
+import io.github.xgl34222220.luoshu.ui.logs.withNativeImport
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeImportTaskCenterTest {
+    @Test
+    fun recoveredImportAppearsBeforeHistoryAsActiveTask() {
+        val display = LogsUiState().withNativeImport(
+            NativeImportState(
+                taskId = "import-resume",
+                phase = NativeImportPhase.RUNNING,
+                total = 4,
+                processed = 2,
+                currentFile = "third.ttf",
+                message = "正在恢复 3/4：third.ttf",
+                recovered = true,
+            ),
+        )
+
+        assertEquals(1, display.activeTaskCount)
+        assertTrue(display.tasks.isNotEmpty())
+        assertEquals(TaskKind.IMPORT, display.tasks.first().kind)
+        assertEquals(TaskPhase.RUNNING, display.tasks.first().phase)
+        assertTrue(display.tasks.first().message.contains("恢复"))
+    }
+}

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -38,9 +38,19 @@ for file in \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuHost.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuAppShell.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt \
+  android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt \
+  android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt \
+  android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontMetadataInspector.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeFontPreview.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuViewModel.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/appearance/AppearanceSettings.kt \
+  android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModel.kt \
+  android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsContract.kt \
+  android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsRoute.kt \
+  android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportStateTest.kt \
+  android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportQueueStoreTest.kt \
+  android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportTaskCenterTest.kt \
+  android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModelTest.kt \
   android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/appearance/AppearanceSettingsTest.kt; do
   test -f "$ROOT/$file"
 done
@@ -95,6 +105,10 @@ grep -q -- '--axes' "$ROOT/common/font_instance.py"
 grep -q 'worker "$_request"' "$ROOT/common/v142_weighted_mix.sh"
 grep -q 'axes_task.conf' "$ROOT/common/v142_weighted_mix.sh"
 grep -q 'OpenMultipleDocuments' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt"
+grep -q 'takePersistableUriPermission' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt"
+grep -q 'forResume' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt"
+grep -q 'encodeImportQueue' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt"
+grep -q 'viewModel<NativeImportViewModel>()' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuHost.kt"
 grep -q 'setFontVariationSettings' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeFontPreview.kt"
 grep -q 'updateMixAxis' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuViewModel.kt"
 grep -q 'testImplementation("junit:junit:4.13.2")' "$ROOT/android-app/app/build.gradle.kts"


### PR DESCRIPTION
## 目标

让原生批量导入在 App 被划掉、系统回收或进程异常退出后，重新打开时继续未完成队列。

## 已完成

- 使用系统文档 URI 持久读取权限保存导入来源。
- 每个文件开始前与完成后持久化队列状态。
- 恢复时只把被中断的当前项重置为待处理，已导入与重复项保持完成。
- App 根层启动即创建导入 ViewModel，无需先进入字体库。
- 终态结果重新打开后仍可进入任务中心展示。
- 增加队列编解码、中文文件名、URI、恢复状态与任务中心集成测试。
- 源码门禁明确检查恢复能力。

## 验证

- Font engine smoke tests 通过。
- App-only source、Lint、单元测试、Debug 编译、单包构建与成品检查通过。
- 模块内无 WebUI，且只内置一个与独立产物字节一致的 Debug App。

## 边界

当前分支基于 PR #45。保持 Draft，不修改版本号，不创建 Tag 或 Release。

断点恢复依赖系统文档提供方授予持久读取权限；若第三方文件提供方拒绝该权限，当前会话仍可继续导入，但进程被结束后该文件可能在恢复时报告无法读取。