### PR TITLE
feat(import): 增加导入任务控制

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt
@@ -15,8 +15,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Cancel
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Error
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -68,10 +70,16 @@ internal fun NativeImportOverlay(
             style = style,
             state = state,
             enabled = viewModel.snapshot.installed &&
-                !state.busy &&
                 !viewModel.operationBusy &&
-                !viewModel.mixState.busy,
-            onImport = { launcher.launch(arrayOf("*/*")) },
+                !viewModel.mixState.busy &&
+                (!state.busy || state.paused),
+            onImport = {
+                if (state.paused) {
+                    importViewModel.resumeImport()
+                } else {
+                    launcher.launch(arrayOf("*/*"))
+                }
+            },
         )
     }
 
@@ -109,22 +117,26 @@ private fun ImportActionButton(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                if (state.busy) {
-                    CircularProgressIndicator(
+                when {
+                    state.busy -> CircularProgressIndicator(
                         modifier = Modifier.size(19.dp),
                         strokeWidth = 2.dp,
                         color = MaterialTheme.colorScheme.onPrimary,
                     )
-                } else {
-                    Icon(Icons.Rounded.Add, contentDescription = null)
+                    state.paused -> Icon(Icons.Rounded.PlayArrow, contentDescription = null)
+                    else -> Icon(Icons.Rounded.Add, contentDescription = null)
                 }
                 Spacer(Modifier.width(8.dp))
                 Text(
-                    if (state.busy) "导入 ${state.processed}/${state.total}" else "导入字体",
+                    when {
+                        state.busy -> "导入 ${state.processed}/${state.total}"
+                        state.paused -> "继续 ${state.processed}/${state.total}"
+                        else -> "导入字体"
+                    },
                     fontWeight = FontWeight.Black,
                 )
             }
-            if (state.busy) {
+            if (state.busy || state.paused) {
                 LinearProgressIndicator(
                     progress = { state.progress / 100f },
                     modifier = Modifier.fillMaxWidth(),
@@ -143,15 +155,23 @@ private fun ImportResultDialog(
     onDismiss: () -> Unit,
 ) {
     val failed = state.failed.isNotEmpty()
+    val cancelled = state.phase == NativeImportPhase.CANCELLED
+    val icon = when {
+        cancelled -> Icons.Rounded.Cancel
+        failed -> Icons.Rounded.Error
+        else -> Icons.Rounded.CheckCircle
+    }
+    val accent = when {
+        failed -> MaterialTheme.colorScheme.error
+        cancelled -> MaterialTheme.colorScheme.secondary
+        else -> MaterialTheme.colorScheme.primary
+    }
+
     if (style == UiStyle.MATERIAL) {
         AlertDialog(
             onDismissRequest = onDismiss,
             icon = {
-                Icon(
-                    if (failed) Icons.Rounded.Error else Icons.Rounded.CheckCircle,
-                    contentDescription = null,
-                    tint = if (failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
-                )
+                Icon(icon, contentDescription = null, tint = accent)
             },
             title = { Text(state.title, fontWeight = FontWeight.Black) },
             text = {
@@ -182,7 +202,7 @@ private fun ImportResultDialog(
                 ) {
                     Text(
                         "IMPORT RESULT",
-                        color = if (failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                        color = accent,
                         fontSize = 9.sp,
                         fontWeight = FontWeight.Bold,
                         letterSpacing = 2.sp,
@@ -196,7 +216,7 @@ private fun ImportResultDialog(
                     )
                     Text(state.summary, color = tokens.textPrimary, lineHeight = 20.sp)
                     Text(
-                        "ZIP 仅安全提取字体，不执行包内脚本。导入历史可在任务中心查看。",
+                        "ZIP 仅安全提取字体，不执行包内脚本。导入记录可在任务中心控制。",
                         color = tokens.textSecondary,
                         fontSize = 11.sp,
                     )

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt
@@ -10,8 +10,10 @@ import java.util.Base64
 import java.util.Properties
 
 internal enum class ImportQueueItemStatus {
-    PENDING, RUNNING, IMPORTED, DUPLICATE, FAILED;
-    val terminal: Boolean get() = this == IMPORTED || this == DUPLICATE || this == FAILED
+    PENDING, RUNNING, IMPORTED, DUPLICATE, FAILED, CANCELLED;
+
+    val terminal: Boolean
+        get() = this == IMPORTED || this == DUPLICATE || this == FAILED || this == CANCELLED
 }
 
 internal data class ImportQueueItem(
@@ -34,6 +36,7 @@ internal data class ImportQueueTask(
     val processed: Int get() = items.count { it.status.terminal }
     val imported: Int get() = items.count { it.status == ImportQueueItemStatus.IMPORTED }
     val duplicates: Int get() = items.count { it.status == ImportQueueItemStatus.DUPLICATE }
+    val cancelled: Int get() = items.count { it.status == ImportQueueItemStatus.CANCELLED }
     val failures: List<String> get() = items.filter { it.status == ImportQueueItemStatus.FAILED }.map {
         "${it.displayName}：${it.error.ifBlank { "导入失败" }}"
     }
@@ -44,7 +47,48 @@ internal data class ImportQueueTask(
         message = "检测到未完成导入任务，正在恢复队列",
         recovered = true,
         items = items.map {
-            if (it.status == ImportQueueItemStatus.RUNNING) it.copy(status = ImportQueueItemStatus.PENDING, error = "") else it
+            if (it.status == ImportQueueItemStatus.RUNNING) {
+                it.copy(status = ImportQueueItemStatus.PENDING, error = "")
+            } else {
+                it
+            }
+        },
+    )
+
+    fun forManualResume(): ImportQueueTask = copy(
+        phase = NativeImportPhase.QUEUED,
+        message = "继续导入剩余 ${items.count { !it.status.terminal }} 个文件",
+        items = items.map {
+            if (it.status == ImportQueueItemStatus.RUNNING) {
+                it.copy(status = ImportQueueItemStatus.PENDING, error = "")
+            } else {
+                it
+            }
+        },
+    )
+
+    fun forRetryFailures(): ImportQueueTask = copy(
+        phase = NativeImportPhase.QUEUED,
+        message = "准备重试 ${items.count { it.status == ImportQueueItemStatus.FAILED }} 个失败文件",
+        recovered = false,
+        items = items.map {
+            if (it.status == ImportQueueItemStatus.FAILED) {
+                it.copy(status = ImportQueueItemStatus.PENDING, error = "")
+            } else {
+                it
+            }
+        },
+    )
+
+    fun cancelRemaining(): ImportQueueTask = copy(
+        phase = NativeImportPhase.CANCELLED,
+        message = "字体导入已取消，剩余文件未处理",
+        items = items.map {
+            if (it.status == ImportQueueItemStatus.PENDING || it.status == ImportQueueItemStatus.RUNNING) {
+                it.copy(status = ImportQueueItemStatus.CANCELLED, error = "")
+            } else {
+                it
+            }
         },
     )
 
@@ -55,6 +99,7 @@ internal data class ImportQueueTask(
         processed = processed,
         imported = imported,
         duplicates = duplicates,
+        cancelled = cancelled,
         failed = failures,
         currentFile = items.firstOrNull { it.status == ImportQueueItemStatus.RUNNING }?.displayName.orEmpty(),
         message = message,
@@ -133,7 +178,9 @@ internal class NativeImportQueueStore(context: Context) {
 
     fun load(): ImportQueueTask? = if (stateFile.isFile) {
         decodeImportQueue(runCatching { stateFile.readText() }.getOrDefault(""))
-    } else null
+    } else {
+        null
+    }
 
     fun save(task: ImportQueueTask) {
         root.mkdirs()
@@ -149,6 +196,11 @@ internal class NativeImportQueueStore(context: Context) {
             }
             temporary.delete()
         }
+    }
+
+    fun clear() {
+        runCatching { stateFile.delete() }
+        runCatching { File(root, "task.properties.tmp").delete() }
     }
 
     fun stagedFile(taskId: String, index: Int, displayName: String): File {

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt
@@ -27,8 +27,10 @@ internal enum class NativeImportPhase(val wireName: String) {
     IDLE("idle"),
     QUEUED("queued"),
     RUNNING("running"),
+    PAUSED("paused"),
     SUCCESS("success"),
     FAILED("failed"),
+    CANCELLED("cancelled"),
 }
 
 @Immutable
@@ -39,6 +41,7 @@ internal data class NativeImportState(
     val processed: Int = 0,
     val imported: Int = 0,
     val duplicates: Int = 0,
+    val cancelled: Int = 0,
     val failed: List<String> = emptyList(),
     val currentFile: String = "",
     val message: String = "尚未开始导入",
@@ -49,6 +52,20 @@ internal data class NativeImportState(
     val busy: Boolean
         get() = phase == NativeImportPhase.QUEUED || phase == NativeImportPhase.RUNNING
 
+    val paused: Boolean
+        get() = phase == NativeImportPhase.PAUSED
+
+    val terminal: Boolean
+        get() = phase == NativeImportPhase.SUCCESS ||
+            phase == NativeImportPhase.FAILED ||
+            phase == NativeImportPhase.CANCELLED
+
+    val canPause: Boolean get() = busy
+    val canResume: Boolean get() = paused
+    val canCancel: Boolean get() = busy || paused
+    val canRetryFailed: Boolean get() = terminal && failed.isNotEmpty()
+    val canClear: Boolean get() = !busy && phase != NativeImportPhase.IDLE
+
     val progress: Int
         get() = when {
             total <= 0 -> 0
@@ -58,6 +75,8 @@ internal data class NativeImportState(
 
     val title: String
         get() = when {
+            paused -> "字体导入已暂停"
+            phase == NativeImportPhase.CANCELLED -> "字体导入已取消"
             busy && recovered -> "正在恢复字体导入"
             busy -> "正在导入字体"
             failed.isEmpty() -> "导入完成"
@@ -67,8 +86,13 @@ internal data class NativeImportState(
 
     val summary: String
         get() = buildString {
-            append("成功导入 ").append(imported).append(" 个文件")
+            if (phase == NativeImportPhase.CANCELLED) {
+                append("已处理 ").append(processed - cancelled).append('/').append(total).append(" 个文件")
+            } else {
+                append("成功导入 ").append(imported).append(" 个文件")
+            }
             if (duplicates > 0) append("，跳过 ").append(duplicates).append(" 个重复字体")
+            if (cancelled > 0) append("，取消 ").append(cancelled).append(" 个待处理文件")
             if (failed.isNotEmpty()) {
                 append("\n\n失败：\n")
                 failed.take(6).forEach { append("• ").append(it).append('\n') }
@@ -87,18 +111,25 @@ internal class NativeImportViewModel(application: Application) : AndroidViewMode
 
     private var importJob: Job? = null
 
+    @Volatile
+    private var pauseRequested = false
+
+    @Volatile
+    private var cancelRequested = false
+
     init {
         restoreSavedTask()
     }
 
     fun startImport(uris: List<Uri>) {
-        if (state.busy || importJob?.isActive == true) return
+        if (state.busy || state.paused || importJob?.isActive == true) return
         val selected = uris.take(32)
         if (selected.isEmpty()) return
 
         importJob = viewModelScope.launch {
             try {
                 val context = getApplication<Application>().applicationContext
+                withContext(Dispatchers.IO) { discardPreviousRecord(context) }
                 val items = withContext(Dispatchers.IO) {
                     selected.mapIndexed { index, uri ->
                         val name = queryDisplayName(context, uri) ?: "font-${index + 1}"
@@ -116,6 +147,8 @@ internal class NativeImportViewModel(application: Application) : AndroidViewMode
                         )
                     }
                 }
+                pauseRequested = false
+                cancelRequested = false
                 val task = ImportQueueTask(
                     taskId = "import-${System.currentTimeMillis()}",
                     phase = NativeImportPhase.QUEUED,
@@ -130,6 +163,84 @@ internal class NativeImportViewModel(application: Application) : AndroidViewMode
         }
     }
 
+    fun pauseImport() {
+        if (!state.canPause) return
+        pauseRequested = true
+        state = state.copy(
+            message = if (state.phase == NativeImportPhase.RUNNING) {
+                "当前文件完成后暂停导入队列"
+            } else {
+                "正在暂停导入队列"
+            },
+        )
+    }
+
+    fun resumeImport() {
+        if (!state.canResume || importJob?.isActive == true) return
+        importJob = viewModelScope.launch {
+            try {
+                val saved = withContext(Dispatchers.IO) { queueStore.load() } ?: return@launch
+                pauseRequested = false
+                cancelRequested = false
+                runQueue(saved.forManualResume())
+            } finally {
+                importJob = null
+            }
+        }
+    }
+
+    fun cancelImport() {
+        if (!state.canCancel) return
+        if (state.paused && importJob?.isActive != true) {
+            importJob = viewModelScope.launch {
+                try {
+                    val saved = withContext(Dispatchers.IO) { queueStore.load() } ?: return@launch
+                    finishCancelled(saved)
+                } finally {
+                    importJob = null
+                }
+            }
+            return
+        }
+        cancelRequested = true
+        pauseRequested = false
+        state = state.copy(message = "当前文件完成后取消剩余导入")
+    }
+
+    fun retryFailed() {
+        if (!state.canRetryFailed || importJob?.isActive == true) return
+        importJob = viewModelScope.launch {
+            try {
+                val saved = withContext(Dispatchers.IO) { queueStore.load() } ?: return@launch
+                if (saved.failures.isEmpty()) return@launch
+                pauseRequested = false
+                cancelRequested = false
+                runQueue(saved.forRetryFailures())
+            } finally {
+                importJob = null
+            }
+        }
+    }
+
+    fun clearRecord() {
+        if (!state.canClear || importJob?.isActive == true) return
+        importJob = viewModelScope.launch {
+            try {
+                val context = getApplication<Application>().applicationContext
+                val saved = withContext(Dispatchers.IO) { queueStore.load() }
+                withContext(Dispatchers.IO) {
+                    if (saved != null) releasePermissions(context, saved, includeFailures = true)
+                    queueStore.clear()
+                }
+                pauseRequested = false
+                cancelRequested = false
+                state = NativeImportState()
+            } finally {
+                importJob = null
+            }
+        }
+    }
+
     fun dismissResult() {
         state = state.copy(resultVisible = false)
     }
@@ -138,11 +249,13 @@ internal class NativeImportViewModel(application: Application) : AndroidViewMode
         importJob = viewModelScope.launch {
             try {
                 val saved = withContext(Dispatchers.IO) { queueStore.load() } ?: return@launch
-                val active = saved.phase == NativeImportPhase.QUEUED || saved.phase == NativeImportPhase.RUNNING
-                if (active || saved.unfinished) {
-                    runQueue(saved.forResume())
-                } else {
-                    state = saved.toUiState(resultVisible = false)
+                when {
+                    saved.phase == NativeImportPhase.PAUSED -> state = saved.toUiState(resultVisible = false)
+                    saved.phase == NativeImportPhase.SUCCESS ||
+                        saved.phase == NativeImportPhase.FAILED ||
+                        saved.phase == NativeImportPhase.CANCELLED -> state = saved.toUiState(resultVisible = false)
+                    saved.unfinished -> runQueue(saved.forResume())
+                    else -> state = saved.toUiState(resultVisible = false)
                 }
             } finally {
                 importJob = null
@@ -151,11 +264,19 @@ internal class NativeImportViewModel(application: Application) : AndroidViewMode
     }
 
     private suspend fun runQueue(initial: ImportQueueTask) {
-        val context = getApplication<Application>().applicationContext
         var task = initial
         persistAndPublish(task)
 
         task.items.indices.forEach { index ->
+            if (cancelRequested) {
+                if (task.unfinished) finishCancelled(task) else finishCompleted(task)
+                return
+            }
+            if (pauseRequested) {
+                if (task.unfinished) finishPaused(task) else finishCompleted(task)
+                return
+            }
+
             val item = task.items[index]
             if (item.status.terminal) return@forEach
 
@@ -168,6 +289,7 @@ internal class NativeImportViewModel(application: Application) : AndroidViewMode
             )
             persistAndPublish(task)
 
+            val context = getApplication<Application>().applicationContext
             val resultItem = try {
                 when (withContext(Dispatchers.IO) { importOne(context, Uri.parse(item.uri), item.displayName) }) {
                     ImportOutcome.IMPORTED -> item.copy(status = ImportQueueItemStatus.IMPORTED, error = "")
@@ -181,17 +303,55 @@ internal class NativeImportViewModel(application: Application) : AndroidViewMode
             }
             task = task.replaceItem(index, resultItem)
             persistAndPublish(task)
+
+            if (cancelRequested) {
+                if (task.unfinished) finishCancelled(task) else finishCompleted(task)
+                return
+            }
+            if (pauseRequested) {
+                if (task.unfinished) finishPaused(task) else finishCompleted(task)
+                return
+            }
         }
 
+        finishCompleted(task)
+    }
+
+    private suspend fun finishPaused(task: ImportQueueTask) {
+        pauseRequested = false
+        val paused = task.copy(
+            phase = NativeImportPhase.PAUSED,
+            message = "导入已暂停，已处理 ${task.processed}/${task.total} 个文件",
+        )
+        persistAndPublish(paused)
+    }
+
+    private suspend fun finishCancelled(task: ImportQueueTask) {
+        cancelRequested = false
+        pauseRequested = false
+        val cancelled = task.cancelRemaining()
+        persistAndPublish(
+            cancelled,
+            resultVisible = true,
+            refreshToken = if (cancelled.imported > 0) System.currentTimeMillis() else 0L,
+        )
+        val context = getApplication<Application>().applicationContext
+        withContext(Dispatchers.IO) { releasePermissions(context, cancelled, includeFailures = false) }
+    }
+
+    private suspend fun finishCompleted(task: ImportQueueTask) {
+        pauseRequested = false
+        cancelRequested = false
         val phase = if (task.failures.isEmpty()) NativeImportPhase.SUCCESS else NativeImportPhase.FAILED
         val message = when {
             task.failures.isEmpty() -> "字体导入完成，共处理 ${task.total} 个文件"
             task.imported > 0 || task.duplicates > 0 -> "字体导入部分完成，${task.failures.size} 个文件失败"
             else -> "字体导入失败，未成功处理任何文件"
         }
-        task = task.copy(phase = phase, message = message)
-        persistAndPublish(task, resultVisible = true, refreshToken = System.currentTimeMillis())
-        withContext(Dispatchers.IO) { releasePermissions(context, task) }
+        val completed = task.copy(phase = phase, message = message)
+        persistAndPublish(completed, resultVisible = true, refreshToken = System.currentTimeMillis())
+        val context = getApplication<Application>().applicationContext
+        withContext(Dispatchers.IO) { releasePermissions(context, completed, includeFailures = false) }
     }
 
     private suspend fun persistAndPublish(
@@ -206,8 +366,26 @@ internal class NativeImportViewModel(application: Application) : AndroidViewMode
     private fun ImportQueueTask.replaceItem(index: Int, replacement: ImportQueueItem): ImportQueueTask =
         copy(items = items.mapIndexed { itemIndex, item -> if (itemIndex == index) replacement else item })
 
-    private fun releasePermissions(context: android.content.Context, task: ImportQueueTask) {
-        task.items.filter { it.persistedPermission }.forEach { item ->
+    private fun discardPreviousRecord(context: android.content.Context) {
+        queueStore.load()?.let { releasePermissions(context, it, includeFailures = true) }
+        queueStore.clear()
+    }
+
+    private fun releasePermissions(
+        context: android.content.Context,
+        task: ImportQueueTask,
+        includeFailures: Boolean,
+    ) {
+        task.items.filter { item ->
+            item.persistedPermission && when (item.status) {
+                ImportQueueItemStatus.IMPORTED,
+                ImportQueueItemStatus.DUPLICATE,
+                ImportQueueItemStatus.CANCELLED -> true
+                ImportQueueItemStatus.FAILED -> includeFailures
+                ImportQueueItemStatus.PENDING,
+                ImportQueueItemStatus.RUNNING -> false
+            }
+        }.forEach { item ->
             runCatching {
                 context.contentResolver.releasePersistableUriPermission(
                     Uri.parse(item.uri),

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/ImportTaskControls.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/ImportTaskControls.kt
@@ -1,0 +1,124 @@
+package io.github.xgl34222220.luoshu.ui.logs
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Cancel
+import androidx.compose.material.icons.rounded.DeleteSweep
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Replay
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.luoshu.NativeImportPhase
+import io.github.xgl34222220.luoshu.NativeImportState
+import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
+import io.github.xgl34222220.luoshu.ui.theme.LocalMiuixTokens
+
+@Composable
+internal fun ImportTaskControls(
+    style: UiStyle,
+    state: NativeImportState,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onCancel: () -> Unit,
+    onRetry: () -> Unit,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (state.taskId.isBlank() || state.phase == NativeImportPhase.IDLE) return
+
+    val tokens = LocalMiuixTokens.current
+    val shape = RoundedCornerShape(if (style == UiStyle.MIUIX) 30.dp else 24.dp)
+    val container = if (style == UiStyle.MIUIX) {
+        tokens.elevatedCardBackground
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerHigh
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = shape,
+        color = container.copy(alpha = .98f),
+        shadowElevation = 18.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = .5f)),
+    ) {
+        Column(Modifier.padding(horizontal = 15.dp, vertical = 13.dp)) {
+            Text(
+                state.title,
+                color = if (style == UiStyle.MIUIX) tokens.textPrimary else MaterialTheme.colorScheme.onSurface,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Black,
+            )
+            Text(
+                state.message,
+                color = if (style == UiStyle.MIUIX) tokens.textSecondary else MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 10.sp,
+                maxLines = 2,
+            )
+            if (state.busy || state.paused) {
+                Spacer(Modifier.height(9.dp))
+                LinearProgressIndicator(
+                    progress = { state.progress.coerceIn(0, 100) / 100f },
+                    modifier = Modifier.fillMaxWidth().height(6.dp),
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (state.canPause) {
+                    FilledTonalButton(onClick = onPause) {
+                        Icon(Icons.Rounded.Pause, contentDescription = null)
+                        Text("暂停", modifier = Modifier.padding(start = 6.dp))
+                    }
+                }
+                if (state.canResume) {
+                    Button(onClick = onResume) {
+                        Icon(Icons.Rounded.PlayArrow, contentDescription = null)
+                        Text("继续", modifier = Modifier.padding(start = 6.dp))
+                    }
+                }
+                if (state.canCancel) {
+                    OutlinedButton(onClick = onCancel) {
+                        Icon(Icons.Rounded.Cancel, contentDescription = null)
+                        Text("取消", modifier = Modifier.padding(start = 6.dp))
+                    }
+                }
+                if (state.canRetryFailed) {
+                    FilledTonalButton(onClick = onRetry) {
+                        Icon(Icons.Rounded.Replay, contentDescription = null)
+                        Text("重试失败项", modifier = Modifier.padding(start = 6.dp))
+                    }
+                }
+                if (state.canClear) {
+                    OutlinedButton(onClick = onClear) {
+                        Icon(Icons.Rounded.DeleteSweep, contentDescription = null)
+                        Text("清除记录", modifier = Modifier.padding(start = 6.dp))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsContract.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsContract.kt
@@ -160,18 +160,29 @@ internal fun LogsUiState.withNativeImport(state: NativeImportState): LogsUiState
         NativeImportPhase.IDLE -> TaskPhase.INFO
         NativeImportPhase.QUEUED -> TaskPhase.QUEUED
         NativeImportPhase.RUNNING -> TaskPhase.RUNNING
+        NativeImportPhase.PAUSED -> TaskPhase.INFO
         NativeImportPhase.SUCCESS -> TaskPhase.SUCCESS
         NativeImportPhase.FAILED -> TaskPhase.FAILED
+        NativeImportPhase.CANCELLED -> TaskPhase.INFO
+    }
+    val title = when (state.phase) {
+        NativeImportPhase.PAUSED -> "字体导入已暂停"
+        NativeImportPhase.CANCELLED -> "字体导入已取消"
+        else -> taskTitle(TaskKind.IMPORT, phase)
     }
     val item = TaskCenterItem(
         id = state.taskId.ifBlank { "native-import" },
         kind = TaskKind.IMPORT,
         phase = phase,
-        title = taskTitle(TaskKind.IMPORT, phase),
+        title = title,
         message = state.message,
         progress = state.progress,
-        timeLabel = if (state.busy) "当前" else "最近",
-        current = state.busy,
+        timeLabel = when {
+            state.paused -> "已暂停"
+            state.busy -> "当前"
+            else -> "最近"
+        },
+        current = state.busy || state.paused,
     )
     val merged = mergeTaskItems(listOf(item), tasks)
     return copy(

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsRoute.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsRoute.kt
@@ -1,6 +1,12 @@
 package io.github.xgl34222220.luoshu.ui.logs
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import io.github.xgl34222220.luoshu.NativeImportViewModel
 import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
 
@@ -11,9 +17,25 @@ internal fun LogsRoute(
     actions: LogsActions,
 ) {
     val importViewModel: NativeImportViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
-    val displayState = state.withNativeImport(importViewModel.state)
-    when (style) {
-        UiStyle.MATERIAL -> LogsScreenMaterial(displayState, actions)
-        UiStyle.MIUIX -> LogsScreenMiuix(displayState, actions)
+    val importState = importViewModel.state
+    val displayState = state.withNativeImport(importState)
+
+    Box(Modifier.fillMaxSize()) {
+        when (style) {
+            UiStyle.MATERIAL -> LogsScreenMaterial(displayState, actions)
+            UiStyle.MIUIX -> LogsScreenMiuix(displayState, actions)
+        }
+        ImportTaskControls(
+            style = style,
+            state = importState,
+            onPause = importViewModel::pauseImport,
+            onResume = importViewModel::resumeImport,
+            onCancel = importViewModel::cancelImport,
+            onRetry = importViewModel::retryFailed,
+            onClear = importViewModel::clearRecord,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 14.dp, vertical = 94.dp),
+        )
     }
 }

--- a/android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportControlsTest.kt
+++ b/android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportControlsTest.kt
@@ -1,0 +1,106 @@
+package io.github.xgl34222220.luoshu
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeImportControlsTest {
+    @Test
+    fun pausedStateExposesResumeCancelAndClear() {
+        val state = NativeImportState(
+            taskId = "import-paused",
+            phase = NativeImportPhase.PAUSED,
+            total = 4,
+            processed = 2,
+            imported = 1,
+            duplicates = 1,
+            message = "导入已暂停",
+        )
+
+        assertFalse(state.busy)
+        assertTrue(state.paused)
+        assertFalse(state.canPause)
+        assertTrue(state.canResume)
+        assertTrue(state.canCancel)
+        assertTrue(state.canClear)
+        assertEquals(50, state.progress)
+        assertEquals("字体导入已暂停", state.title)
+    }
+
+    @Test
+    fun cancelRemainingKeepsFinishedItemsAndStopsOnlyPendingWork() {
+        val task = ImportQueueTask(
+            taskId = "import-cancel",
+            phase = NativeImportPhase.RUNNING,
+            createdAt = 1L,
+            message = "处理中",
+            items = listOf(
+                ImportQueueItem("content://one", "one.ttf", ImportQueueItemStatus.IMPORTED),
+                ImportQueueItem("content://two", "two.ttf", ImportQueueItemStatus.DUPLICATE),
+                ImportQueueItem("content://three", "three.ttf", ImportQueueItemStatus.FAILED, "字体损坏"),
+                ImportQueueItem("content://four", "four.ttf", ImportQueueItemStatus.RUNNING),
+                ImportQueueItem("content://five", "five.ttf", ImportQueueItemStatus.PENDING),
+            ),
+        )
+
+        val cancelled = task.cancelRemaining()
+
+        assertEquals(NativeImportPhase.CANCELLED, cancelled.phase)
+        assertEquals(ImportQueueItemStatus.IMPORTED, cancelled.items[0].status)
+        assertEquals(ImportQueueItemStatus.DUPLICATE, cancelled.items[1].status)
+        assertEquals(ImportQueueItemStatus.FAILED, cancelled.items[2].status)
+        assertEquals(ImportQueueItemStatus.CANCELLED, cancelled.items[3].status)
+        assertEquals(ImportQueueItemStatus.CANCELLED, cancelled.items[4].status)
+        assertEquals(2, cancelled.cancelled)
+        assertEquals(5, cancelled.processed)
+        assertTrue(cancelled.failures.single().contains("字体损坏"))
+    }
+
+    @Test
+    fun retryFailuresResetsOnlyFailedItems() {
+        val task = ImportQueueTask(
+            taskId = "import-retry",
+            phase = NativeImportPhase.FAILED,
+            createdAt = 1L,
+            message = "部分失败",
+            items = listOf(
+                ImportQueueItem("content://one", "one.ttf", ImportQueueItemStatus.IMPORTED),
+                ImportQueueItem("content://two", "two.ttf", ImportQueueItemStatus.DUPLICATE),
+                ImportQueueItem("content://three", "three.ttf", ImportQueueItemStatus.FAILED, "无法读取"),
+                ImportQueueItem("content://four", "four.ttf", ImportQueueItemStatus.CANCELLED),
+            ),
+        )
+
+        val retried = task.forRetryFailures()
+
+        assertEquals(NativeImportPhase.QUEUED, retried.phase)
+        assertEquals(ImportQueueItemStatus.IMPORTED, retried.items[0].status)
+        assertEquals(ImportQueueItemStatus.DUPLICATE, retried.items[1].status)
+        assertEquals(ImportQueueItemStatus.PENDING, retried.items[2].status)
+        assertEquals("", retried.items[2].error)
+        assertEquals(ImportQueueItemStatus.CANCELLED, retried.items[3].status)
+        assertEquals(3, retried.processed)
+    }
+
+    @Test
+    fun cancelledStateReportsCancelledCountWithoutBecomingBusy() {
+        val state = NativeImportState(
+            taskId = "import-cancelled",
+            phase = NativeImportPhase.CANCELLED,
+            total = 5,
+            processed = 5,
+            imported = 2,
+            duplicates = 1,
+            cancelled = 2,
+            message = "字体导入已取消",
+        )
+
+        assertFalse(state.busy)
+        assertTrue(state.terminal)
+        assertTrue(state.canClear)
+        assertEquals("字体导入已取消", state.title)
+        assertTrue(state.summary.contains("已处理 3/5 个文件"))
+        assertTrue(state.summary.contains("取消 2 个待处理文件"))
+    }
+}

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -47,9 +47,11 @@ for file in \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModel.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsContract.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsRoute.kt \
+  android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/ImportTaskControls.kt \
   android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportStateTest.kt \
   android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportQueueStoreTest.kt \
   android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportTaskCenterTest.kt \
+  android-app/app/src/test/java/io/github/xgl34222220/luoshu/NativeImportControlsTest.kt \
   android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModelTest.kt \
   android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/appearance/AppearanceSettingsTest.kt; do
   test -f "$ROOT/$file"
@@ -106,7 +108,13 @@ grep -q 'worker "$_request"' "$ROOT/common/v142_weighted_mix.sh"
 grep -q 'axes_task.conf' "$ROOT/common/v142_weighted_mix.sh"
 grep -q 'OpenMultipleDocuments' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt"
 grep -q 'takePersistableUriPermission' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt"
+grep -q 'fun pauseImport' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt"
+grep -q 'fun cancelImport' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt"
+grep -q 'fun retryFailed' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt"
+grep -q 'fun clearRecord' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportViewModel.kt"
 grep -q 'forResume' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt"
+grep -q 'forRetryFailures' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt"
+grep -q 'cancelRemaining' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt"
 grep -q 'encodeImportQueue' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportQueueStore.kt"
 grep -q 'viewModel<NativeImportViewModel>()' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuHost.kt"
 grep -q 'setFontVariationSettings' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeFontPreview.kt"


### PR DESCRIPTION
## 目标

让原生字体导入不再只能等待完成，用户可以在任务中心安全控制队列。

## 已完成

- 当前文件安全结束后暂停队列。
- 暂停后可从任务中心或字体库悬浮按钮继续。
- 取消时保留已完成结果，只取消剩余项目。
- 失败项目可单独重试，不重复处理已成功和重复字体。
- 清除记录时释放仍保留的失败文件读取权限。
- 暂停、取消和终态状态写入持久队列。
- Material 与 Miuix 共用任务控制面板。
- 增加暂停、取消、失败重试和结果统计单元测试。

## 边界

暂停与取消不会强制杀死正在执行的单个 Root 导入；控制会在当前文件安全结束后生效。

当前分支基于 PR #46。保持 Draft，不修改版本号，不创建 Tag 或 Release。