### PR TITLE
chore(version): 升级到 v14.3.4

### DIFF
--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v14.3.3
-summary=正式版发布修订：兼容 Android v3 APK 签名验证
-notes=洛书 v14.3.3 保持 v14.3.2 的 Material 3 Glass / Miuix 双皮肤、Monet 配置更新、字体库本地索引秒开、轻量目录指纹、真实可变轴、静态多字重、中文/英文/数字复合、覆盖诊断与安全导入能力；正式 APK 已由固定密钥签名且 apksigner 返回验证成功，当前最低 Android 版本为 API 28，APK 使用受支持的 v3 签名方案。本修订将发布门禁由硬性匹配 v2 和旧版 Signer #1 文本，改为要求 apksigner 成功、至少一个受支持的 v2/v3 方案为 true、签名者数量大于零且存在证书 SHA-256 摘要。Full 模块继续内置并自动安装或更新固定签名 App，Lite 不内置 App。
+version=v14.3.4
+summary=原生 App-only、字体库与可恢复后台导入测试线
+notes=洛书 v14.3.4 切换为原生 App-only 单包模块，统一状态栏与安全区，增强 Miuix Monet 页面、卡片与 Dock 取色；字体库加入筛选、排序和原生详情；日志页重构为任务中心；批量导入迁移到共享状态源，支持进度追踪、断点恢复、暂停、继续、取消、失败重试与记录清理；导入任务可由 dataSync 前台服务在后台继续，并通过系统通知显示进度与控制操作。本版本将模块 versionCode 提升至 14326，原生 App versionCode 提升至 1432601，用于覆盖此前 v14.3.3 测试构建。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v14.3.3
-versionCode=14325
+version=v14.3.4
+versionCode=14326
 author=惜故里丶
-description=Android 全局字体管理模块：原生 App 支持双皮肤、字体库秒开、真实可变轴、复合字体、安全导入与任务恢复
+description=Android 全局字体管理模块：原生 App-only、字体库详情与筛选、任务中心、可恢复导入及后台通知
 updateJson=


### PR DESCRIPTION
基于 PR #48 的版本升级草稿。模块版本为 v14.3.4，versionCode 为 14326。保持 Draft，不发布。