### PR TITLE
fix(hyperos): v14.3.7 全局字体与度量兼容

### DIFF
--- a/common/font_library_cache.sh
+++ b/common/font_library_cache.sh
@@ -51,6 +51,11 @@ font_library_fingerprint_json() {
         "$(json_escape "$_fingerprint")" "$(json_escape "$_current")" "$_count" "$_bytes"
 }
 
+# font_manager.sh 在 rom_adapters.sh 之后加载本文件，因此这里接入 HyperOS 增强层，
+# 让直接应用字体使用真实分区映射与原厂度量外壳。
+_hyperos_helper="${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}/common/hyperos_global.sh"
+[ -f "$_hyperos_helper" ] && . "$_hyperos_helper"
+
 # 直接执行时提供给原生 App 使用；被 font_manager.sh source 时只定义函数。
 if [ "${0##*/}" = "font_library_cache.sh" ]; then
     MODDIR="${MODDIR:-$(CDPATH= cd -- "${0%/*}/.." 2>/dev/null && pwd)}"

--- a/common/hyperos_global.sh
+++ b/common/hyperos_global.sh
@@ -1,0 +1,193 @@
+#!/system/bin/sh
+# 洛书 HyperOS 全局字体覆盖增强层。
+# 必须在 rom_adapters.sh 之后 source；这里重新定义 HyperOS 映射函数。
+set +e
+
+_luoshu_hyperos_module_dir() {
+    printf '%s\n' "${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
+}
+
+_luoshu_hyperos_root_pairs() {
+    _module="$(_luoshu_hyperos_module_dir)"
+    printf '%s|%s\n' "${LUOSHU_SYSTEM_FONTS_ROOT:-/system/fonts}" "$_module/system/fonts"
+    printf '%s|%s\n' "${LUOSHU_PRODUCT_FONTS_ROOT:-/product/fonts}" "$_module/product/fonts"
+    printf '%s|%s\n' "${LUOSHU_SYSTEM_EXT_FONTS_ROOT:-/system_ext/fonts}" "$_module/system_ext/fonts"
+}
+
+_hyperos_core_files() {
+    printf '%s\n' 'MiSansVF.ttf MiSansVF_Overlay.ttf MiSansLatinVF.ttf MiSansTCVF.ttf MiSansL3.otf'
+}
+
+_hyperos_weight_files() {
+    printf '%s\n' '100.ttf 200.ttf 300.ttf 350.ttf 400.ttf 500.ttf 600.ttf 700.ttf 800.ttf 900.ttf'
+}
+
+_hyperos_metric_shell_files() {
+    printf '%s\n' 'Roboto-Thin.ttf Roboto-ThinItalic.ttf Roboto-ExtraLight.ttf Roboto-ExtraLightItalic.ttf Roboto-Light.ttf Roboto-LightItalic.ttf Roboto-Regular.ttf Roboto-Italic.ttf Roboto-Medium.ttf Roboto-MediumItalic.ttf Roboto-SemiBold.ttf Roboto-SemiBoldItalic.ttf Roboto-Bold.ttf Roboto-BoldItalic.ttf Roboto-ExtraBold.ttf Roboto-ExtraBoldItalic.ttf RobotoFlex-Regular.ttf RobotoStatic-Regular.ttf GoogleSans-Regular.ttf GoogleSans-Medium.ttf GoogleSans-Bold.ttf GoogleSansText-Regular.ttf GoogleSansText-Medium.ttf GoogleSansText-Bold.ttf GoogleSansFlex-Regular.ttf'
+}
+
+# 返回完整清理清单。Roboto/GoogleSans 仅用于清除旧版本残留，不会在新映射中重新创建。
+get_all_hyperos_files() {
+    printf '%s %s %s\n' "$(_hyperos_core_files)" "$(_hyperos_weight_files)" "$(_hyperos_metric_shell_files)"
+}
+
+_hyperos_remove_overlay_file() {
+    _file="$1"
+    _module="$(_luoshu_hyperos_module_dir)"
+    rm -f "$_module/system/fonts/$_file" "$_module/product/fonts/$_file" \
+        "$_module/system_ext/fonts/$_file" 2>/dev/null || true
+}
+
+# 把一个字体锚点写到 ROM 中该文件真实存在的分区；输出成功目标数量。
+_hyperos_alias_existing_targets() {
+    _anchor="$1"
+    _file="$2"
+    _count=0
+    while IFS='|' read -r _real _overlay; do
+        [ -n "$_real" ] && [ -n "$_overlay" ] || continue
+        [ -e "$_real/$_file" ] || continue
+        mkdir -p "$_overlay" 2>/dev/null || continue
+        if _font_alias "$_anchor" "$_overlay/$_file"; then
+            _count=$((_count + 1))
+        fi
+    done <<EOF_PAIRS
+$(_luoshu_hyperos_root_pairs)
+EOF_PAIRS
+    printf '%s\n' "$_count"
+}
+
+_hyperos_pick_regular_source() {
+    _family="$1"
+    _fallback="$2"
+    _regular=''
+    _variable=''
+    _medium=''
+    _first=''
+    for _file in "$USER_FONTS_DIR"/*.ttf "$USER_FONTS_DIR"/*.otf "$USER_FONTS_DIR"/*.ttc \
+                 "$USER_FONTS_DIR"/*.TTF "$USER_FONTS_DIR"/*.OTF "$USER_FONTS_DIR"/*.TTC; do
+        [ -f "$_file" ] || continue
+        [ "$(detect_font_family "$(basename "$_file")")" = "$_family" ] || continue
+        [ -n "$_first" ] || _first="$_file"
+        _weight=$(detect_font_weight "$(basename "$_file")")
+        case "$_weight" in
+            regular) [ -n "$_regular" ] || _regular="$_file" ;;
+            variable) [ -n "$_variable" ] || _variable="$_file" ;;
+            medium) [ -n "$_medium" ] || _medium="$_file" ;;
+        esac
+    done
+    for _candidate in "$_regular" "$_variable" "$_medium" "$_first" "$_fallback"; do
+        [ -f "$_candidate" ] && { printf '%s\n' "$_candidate"; return 0; }
+    done
+    return 1
+}
+
+_hyperos_exact_weight_source() {
+    _family="$1"
+    _role="$2"
+    for _file in "$USER_FONTS_DIR"/*.ttf "$USER_FONTS_DIR"/*.otf "$USER_FONTS_DIR"/*.ttc \
+                 "$USER_FONTS_DIR"/*.TTF "$USER_FONTS_DIR"/*.OTF "$USER_FONTS_DIR"/*.TTC; do
+        [ -f "$_file" ] || continue
+        [ "$(detect_font_family "$(basename "$_file")")" = "$_family" ] || continue
+        [ "$(detect_font_weight "$(basename "$_file")")" = "$_role" ] || continue
+        printf '%s\n' "$_file"
+        return 0
+    done
+    return 1
+}
+
+_hyperos_weight_role() {
+    case "$1" in
+        100) printf 'thin\n' ;;
+        200) printf 'extralight\n' ;;
+        300) printf 'light\n' ;;
+        500) printf 'medium\n' ;;
+        600) printf 'semibold\n' ;;
+        700) printf 'bold\n' ;;
+        800) printf 'extrabold\n' ;;
+        900) printf 'black\n' ;;
+        *) printf 'regular\n' ;;
+    esac
+}
+
+_hyperos_materialize_variable_weight() {
+    _source="$1"
+    _output="$2"
+    _weight="$3"
+    _module="$(_luoshu_hyperos_module_dir)"
+    _pyroot="$_module/common/python"
+    _python="$_pyroot/bin/luoshu-python"
+    _instancer="$_module/common/font_instance.py"
+    [ -x "$_python" ] && [ -f "$_instancer" ] || return 1
+    PYTHONHOME="$_pyroot" \
+    PYTHONPATH="$_pyroot/lib/python3.14:$_pyroot/lib/python3.14/site-packages" \
+    LD_LIBRARY_PATH="$_pyroot/lib:$_pyroot/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+        "$_python" "$_instancer" --input "$_source" --output "$_output" \
+        --role cjk --weight "$_weight" --axes "wght=$_weight" >/dev/null 2>&1
+}
+
+_hyperos_weight_anchor() {
+    _regular="$1"
+    _family="$2"
+    _weight="$3"
+    _dest_dir="$4"
+    _role="$(_hyperos_weight_role "$_weight")"
+    _source="$(_hyperos_exact_weight_source "$_family" "$_role")"
+    [ -f "$_source" ] || _source="$_regular"
+
+    if type is_variable_font >/dev/null 2>&1 && is_variable_font "$_source"; then
+        _output="$_dest_dir/.luoshu-font-store/wght-${_weight}.font"
+        rm -f "$_output" 2>/dev/null || true
+        if _hyperos_materialize_variable_weight "$_source" "$_output" "$_weight" && [ -s "$_output" ]; then
+            chmod 0644 "$_output" 2>/dev/null || true
+            printf '%s\n' "$_output"
+            return 0
+        fi
+    fi
+    _font_anchor "$_source" "$_dest_dir" "wght-${_weight}"
+}
+
+# HyperOS 的 Roboto/GoogleSans 是紧凑控件的度量外壳。新实现保留这些原厂文件，
+# 只覆盖真正承载字形的 MiSans 核心文件和数字字重文件，并写入它们真实所在分区。
+copy_as_hyperos() {
+    src="$1"
+    dest_dir="$2"
+    mode="${3:-full}"
+    font_family="${4:-}"
+    _module="$(_luoshu_hyperos_module_dir)"
+    [ -n "$font_family" ] || font_family=$(detect_font_family "$(basename "$src")")
+    regular="$(_hyperos_pick_regular_source "$font_family" "$src")" || return 1
+
+    mkdir -p "$_module/system/fonts" "$_module/product/fonts" "$_module/system_ext/fonts" 2>/dev/null || true
+    for _file in $(get_all_hyperos_files); do _hyperos_remove_overlay_file "$_file"; done
+    _font_store_reset "$_module/system/fonts"
+    regular_anchor=$(_font_anchor "$regular" "$_module/system/fonts" regular) || return 1
+
+    _log_step '  正在应用用户字体（HyperOS 全局映射）...'
+    core_count=0
+    for _file in $(_hyperos_core_files); do
+        _added=$(_hyperos_alias_existing_targets "$regular_anchor" "$_file")
+        case "$_added" in ''|*[!0-9]*) _added=0 ;; esac
+        core_count=$((core_count + _added))
+    done
+
+    # 极少数旧 MIUI 设备没有可探测的 MiSans 路径时，保留一个最小兼容目标。
+    if [ "$core_count" -eq 0 ]; then
+        if _font_alias "$regular_anchor" "$_module/system/fonts/MiSansVF.ttf"; then
+            core_count=1
+        fi
+    fi
+
+    weight_count=0
+    for _file in $(_hyperos_weight_files); do
+        _weight=${_file%.ttf}
+        _anchor=$(_hyperos_weight_anchor "$regular" "$font_family" "$_weight" "$_module/system/fonts")
+        [ -s "$_anchor" ] || _anchor="$regular_anchor"
+        _added=$(_hyperos_alias_existing_targets "$_anchor" "$_file")
+        case "$_added" in ''|*[!0-9]*) _added=0 ;; esac
+        weight_count=$((weight_count + _added))
+    done
+
+    _log_step "  已按真实分区覆盖 $core_count 个 MiSans 核心目标、$weight_count 个字重目标"
+    _log_step '  已保留原厂 Roboto/GoogleSans 度量外壳，避免小标签与紧凑控件裁字'
+    return 0
+}

--- a/common/mount_compat.sh
+++ b/common/mount_compat.sh
@@ -92,7 +92,7 @@ luoshu_copy_partition_atomic() {
 }
 
 # 将洛书的分区负载镜像到元模块真实内容目录。
-# 整目录镜像可同时清理旧字体，避免恢复默认后 ext4 镜像仍残留上一次字体。
+# 整目录镜像可同时清理旧字体，避免恢复默认后 ext4 镜仍残留上一次字体。
 luoshu_sync_mount_payload() {
     _id=$(luoshu_module_id)
     _engine=$(luoshu_detect_mount_engine)
@@ -153,3 +153,8 @@ luoshu_mount_status_json() {
     printf '{"engine":"%s","roots":"%s","lastEngine":"%s","synced":%s,"failed":%s,"time":%s}' \
         "$_engine" "$_roots" "${_last_engine:-$_engine}" "${_last_synced:-0}" "${_last_failed:-0}" "${_last_time:-0}"
 }
+
+# font_mix.sh 在 rom_adapters.sh 之后加载本文件；这里覆盖 HyperOS 的旧映射实现，
+# 保证复合字体与直接应用共用真实分区和原厂度量策略。
+_hyperos_helper="${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}/common/hyperos_global.sh"
+[ -f "$_hyperos_helper" ] && . "$_hyperos_helper"

--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v14.3.6
-summary=修复液态玻璃按钮直角伪影
-notes=洛书 v14.3.6 移除悬浮按钮的矩形透明合成层，改用明确的圆形与胶囊尺寸动画；信息按钮不再对整个组件应用透明度，避免圆角外出现透明直角边。模块 versionCode 为 14328，Debug App versionCode 为 1432801。
+version=v14.3.7
+summary=HyperOS 全局字体与标签裁切修复
+notes=洛书 v14.3.7 保留 HyperOS 原厂 Roboto/GoogleSans 度量外壳，避免小标签和紧凑控件裁字；MiSans 核心与 100-900 字重按 system、product、system_ext 真实分区覆盖。静态多字重自动匹配对应文件，可变字体保留变量核心并生成精确字重实例。模块 versionCode 为 14329，Debug App versionCode 为 1432901。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v14.3.6
-versionCode=14328
+version=v14.3.7
+versionCode=14329
 author=惜故里丶
-description=Android 全局字体管理模块：原生 App-only、液态玻璃操作组、任务中心与可恢复后台导入
+description=Android 全局字体管理模块：HyperOS 真实分区映射、原厂度量兼容与精确字重
 updateJson=

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -28,10 +28,10 @@ for file in \
   common/font_role_check.sh common/native_import.sh common/font_details.sh common/luoshu_cli.sh \
   common/luoshu_composite.sh common/font_mix.sh common/v14_mix.sh common/v142_weighted_mix.sh \
   common/app_bridge.sh common/font_manager.sh common/font_library_cache.sh common/app_installer.sh \
-  common/mount_compat.sh common/rom_adapters.sh common/util_functions.sh \
+  common/mount_compat.sh common/rom_adapters.sh common/hyperos_global.sh common/util_functions.sh \
   scripts/build.sh scripts/version.sh scripts/prepare_composite_runtime.sh scripts/mount_compat_test.sh \
   scripts/stability_test.sh scripts/native_zip_import_test.sh scripts/native_preview_source_test.sh \
-  scripts/font_library_cache_test.sh scripts/app_installer_test.sh scripts/rc3_audit.sh \
+  scripts/font_library_cache_test.sh scripts/app_installer_test.sh scripts/hyperos_global_mapping_test.sh scripts/rc3_audit.sh \
   docs/RELEASING.md docs/TEST_MATRIX.md \
   android-app/app/build.gradle.kts \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/MainActivity.kt \
@@ -121,6 +121,14 @@ grep -q 'setFontVariationSettings' "$ROOT/android-app/app/src/main/java/io/githu
 grep -q 'updateMixAxis' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuViewModel.kt"
 grep -q 'testImplementation("junit:junit:4.13.2")' "$ROOT/android-app/app/build.gradle.kts"
 
+# HyperOS 必须保留紧凑控件的原厂度量壳，并按真实分区写入 MiSans 与数字字重目标。
+grep -q '_hyperos_metric_shell_files' "$ROOT/common/hyperos_global.sh"
+grep -q 'LUOSHU_PRODUCT_FONTS_ROOT' "$ROOT/common/hyperos_global.sh"
+grep -q 'font_instance.py' "$ROOT/common/hyperos_global.sh"
+grep -q 'hyperos_global.sh' "$ROOT/common/font_library_cache.sh"
+grep -q 'hyperos_global.sh' "$ROOT/common/mount_compat.sh"
+! grep -q '_font_alias.*Roboto' "$ROOT/common/hyperos_global.sh"
+
 # 禁止重新引入高风险热刷新和系统字体 XML 覆盖。
 ! grep -q 'cmd font system --update' "$ROOT/service.sh"
 ! grep -q 'oplus-font refresh' "$ROOT/service.sh"
@@ -147,6 +155,7 @@ sh "$ROOT/scripts/native_preview_source_test.sh"
 sh "$ROOT/scripts/native_zip_import_test.sh"
 sh "$ROOT/scripts/rc3_audit.sh"
 sh "$ROOT/scripts/mount_compat_test.sh"
+sh "$ROOT/scripts/hyperos_global_mapping_test.sh"
 sh "$ROOT/scripts/stability_test.sh"
 sh "$ROOT/scripts/font_library_cache_test.sh"
 sh "$ROOT/scripts/app_installer_test.sh"

--- a/scripts/hyperos_global_mapping_test.sh
+++ b/scripts/hyperos_global_mapping_test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -eu
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT HUP INT TERM
 
@@ -46,7 +47,7 @@ detect_font_weight() {
 is_variable_font() { return 1; }
 _log_step() { :; }
 
-. "$PWD/common/hyperos_global.sh"
+. "$REPO_ROOT/common/hyperos_global.sh"
 copy_as_hyperos "$USER_FONTS_DIR/Demo-Bold.ttf" "$MODULE_DIR/system/fonts" quick Demo
 
 test "$(cat "$MODULE_DIR/product/fonts/MiSansVF.ttf")" = 'regular-source'

--- a/scripts/hyperos_global_mapping_test.sh
+++ b/scripts/hyperos_global_mapping_test.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eu
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT HUP INT TERM
+
+MODULE_DIR="$ROOT/module"
+MODDIR="$MODULE_DIR"
+USER_FONTS_DIR="$ROOT/user-fonts"
+LUOSHU_SYSTEM_FONTS_ROOT="$ROOT/real/system/fonts"
+LUOSHU_PRODUCT_FONTS_ROOT="$ROOT/real/product/fonts"
+LUOSHU_SYSTEM_EXT_FONTS_ROOT="$ROOT/real/system_ext/fonts"
+export MODULE_DIR MODDIR USER_FONTS_DIR LUOSHU_SYSTEM_FONTS_ROOT LUOSHU_PRODUCT_FONTS_ROOT LUOSHU_SYSTEM_EXT_FONTS_ROOT
+
+mkdir -p "$MODULE_DIR/system/fonts" "$MODULE_DIR/product/fonts" "$MODULE_DIR/system_ext/fonts" \
+    "$USER_FONTS_DIR" "$LUOSHU_SYSTEM_FONTS_ROOT" "$LUOSHU_PRODUCT_FONTS_ROOT" "$LUOSHU_SYSTEM_EXT_FONTS_ROOT"
+printf 'regular-source\n' > "$USER_FONTS_DIR/Demo-Regular.ttf"
+printf 'bold-source\n' > "$USER_FONTS_DIR/Demo-Bold.ttf"
+printf 'stock-core\n' > "$LUOSHU_PRODUCT_FONTS_ROOT/MiSansVF.ttf"
+printf 'stock-overlay\n' > "$LUOSHU_SYSTEM_EXT_FONTS_ROOT/MiSansVF_Overlay.ttf"
+printf 'stock-400\n' > "$LUOSHU_SYSTEM_FONTS_ROOT/400.ttf"
+printf 'stock-700\n' > "$LUOSHU_PRODUCT_FONTS_ROOT/700.ttf"
+printf 'stock-metrics\n' > "$LUOSHU_SYSTEM_FONTS_ROOT/Roboto-Regular.ttf"
+printf 'stale-overlay\n' > "$MODULE_DIR/system/fonts/Roboto-Regular.ttf"
+
+_font_store_reset() {
+    rm -rf "$1/.luoshu-font-store"
+    mkdir -p "$1/.luoshu-font-store"
+}
+_font_anchor() {
+    cp -f "$1" "$2/.luoshu-font-store/$3.font"
+    printf '%s\n' "$2/.luoshu-font-store/$3.font"
+}
+_font_alias() {
+    mkdir -p "${2%/*}"
+    cp -f "$1" "$2"
+}
+detect_font_family() {
+    _name=${1%.*}
+    _name=${_name%-Regular}
+    _name=${_name%-Bold}
+    printf '%s\n' "$_name"
+}
+detect_font_weight() {
+    case "$1" in *-Bold.*) printf 'bold\n' ;; *) printf 'regular\n' ;; esac
+}
+is_variable_font() { return 1; }
+_log_step() { :; }
+
+. "$PWD/common/hyperos_global.sh"
+copy_as_hyperos "$USER_FONTS_DIR/Demo-Bold.ttf" "$MODULE_DIR/system/fonts" quick Demo
+
+test "$(cat "$MODULE_DIR/product/fonts/MiSansVF.ttf")" = 'regular-source'
+test "$(cat "$MODULE_DIR/system_ext/fonts/MiSansVF_Overlay.ttf")" = 'regular-source'
+test "$(cat "$MODULE_DIR/system/fonts/400.ttf")" = 'regular-source'
+test "$(cat "$MODULE_DIR/product/fonts/700.ttf")" = 'bold-source'
+test ! -e "$MODULE_DIR/system/fonts/MiSansVF.ttf"
+test ! -e "$MODULE_DIR/system/fonts/Roboto-Regular.ttf"
+test ! -e "$MODULE_DIR/product/fonts/Roboto-Regular.ttf"
+test ! -e "$MODULE_DIR/system_ext/fonts/Roboto-Regular.ttf"
+printf 'HyperOS global mapping tests passed.\n'


### PR DESCRIPTION
基于 PR #51 的 HyperOS 字体映射修复草稿。保留原厂 Roboto/GoogleSans 度量外壳，按 system、product、system_ext 真实分区覆盖 MiSans 核心与数字字重；静态多字重精确匹配，可变字体生成 wght 实例。版本升级为 v14.3.7 / 14329。保持 Draft，不发布。