### PR TITLE
feat(studio): v14.3.8 使用字体原生默认轴

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/dialogs/FontPickerDialog.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/dialogs/FontPickerDialog.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,7 +41,9 @@ import androidx.compose.ui.window.Dialog
 import io.github.xgl34222220.luoshu.FontItem
 import io.github.xgl34222220.luoshu.MixSlot
 import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
+import io.github.xgl34222220.luoshu.ui.font.resolveAndCacheFontDefaultAxes
 import io.github.xgl34222220.luoshu.ui.theme.LocalMiuixTokens
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun FontPickerDialogRoute(
@@ -51,9 +54,21 @@ internal fun FontPickerDialogRoute(
     onDismiss: () -> Unit,
     onChoose: (FontItem) -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
+    var resolvingId by remember(slot) { mutableStateOf<String?>(null) }
+    val choose: (FontItem) -> Unit = { font ->
+        if (resolvingId == null) {
+            resolvingId = font.id
+            scope.launch {
+                resolveAndCacheFontDefaultAxes(font)
+                resolvingId = null
+                onChoose(font)
+            }
+        }
+    }
     when (style) {
-        UiStyle.MATERIAL -> MaterialFontPickerDialog(slot, fonts, selected, onDismiss, onChoose)
-        UiStyle.MIUIX -> MiuixFontPickerDialog(slot, fonts, selected, onDismiss, onChoose)
+        UiStyle.MATERIAL -> MaterialFontPickerDialog(slot, fonts, selected, onDismiss, choose)
+        UiStyle.MIUIX -> MiuixFontPickerDialog(slot, fonts, selected, onDismiss, choose)
     }
 }
 

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontDefaultAxes.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontDefaultAxes.kt
@@ -1,0 +1,40 @@
+package io.github.xgl34222220.luoshu.ui.font
+
+import io.github.xgl34222220.luoshu.FontItem
+import io.github.xgl34222220.luoshu.RootShell
+import org.json.JSONObject
+
+internal suspend fun resolveFontDefaultAxes(font: FontItem): Map<String, Float> {
+    if (!font.variable) {
+        val weights = fontStaticWeights(font)
+        val weight = when {
+            400 in weights -> 400
+            weights.isNotEmpty() -> weights.first()
+            else -> 400
+        }
+        return mapOf("wght" to weight.toFloat())
+    }
+    val bridge = "/data/adb/modules/LuoShu/common/app_bridge.sh"
+    val result = RootShell.exec(
+        "sh ${RootShell.quote(bridge)} weight_axis ${RootShell.quote(font.id)}",
+        timeoutMs = 20_000L,
+    )
+    if (result.code != 0) return mapOf("wght" to 400f)
+    return runCatching {
+        val line = result.stdout.lineSequence().first { it.trimStart().startsWith("{") }
+        val root = JSONObject(line.trim())
+        if (root.optString("status") != "ok") return@runCatching mapOf("wght" to 400f)
+        val axes = linkedMapOf<String, Float>()
+        val array = root.optJSONArray("axes")
+        if (array != null) {
+            for (index in 0 until array.length()) {
+                val axis = array.optJSONObject(index) ?: continue
+                val tag = axis.optString("tag")
+                val value = axis.optDouble("default", Double.NaN).toFloat()
+                if (tag.length == 4 && value.isFinite()) axes[tag] = value
+            }
+        }
+        if ("wght" !in axes) axes["wght"] = 400f
+        axes.toMap()
+    }.getOrElse { mapOf("wght" to 400f) }
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontDefaultAxes.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontDefaultAxes.kt
@@ -3,6 +3,35 @@ package io.github.xgl34222220.luoshu.ui.font
 import io.github.xgl34222220.luoshu.FontItem
 import io.github.xgl34222220.luoshu.RootShell
 import org.json.JSONObject
+import kotlin.math.roundToInt
+
+private val defaultAxisCache = mutableMapOf<String, Map<String, Float>>()
+private val defaultAxisLock = Any()
+
+internal fun cacheFontDefaultAxes(fontId: String, axes: Map<String, Float>) {
+    if (fontId.isBlank()) return
+    val clean = axes.filter { (tag, value) -> tag.length == 4 && value.isFinite() }
+        .ifEmpty { mapOf("wght" to 400f) }
+    synchronized(defaultAxisLock) {
+        defaultAxisCache[fontId] = clean
+    }
+}
+
+internal fun cachedFontDefaultAxes(fontId: String): Map<String, Float>? = synchronized(defaultAxisLock) {
+    defaultAxisCache[fontId]
+}
+
+internal fun cachedFontDefaultWeight(fontId: String): Int? = cachedFontDefaultAxes(fontId)
+    ?.get("wght")
+    ?.takeIf { it.isFinite() }
+    ?.roundToInt()
+    ?.coerceIn(1, 1000)
+
+internal suspend fun resolveAndCacheFontDefaultAxes(font: FontItem): Map<String, Float> {
+    val cached = cachedFontDefaultAxes(font.id)
+    if (cached != null) return cached
+    return resolveFontDefaultAxes(font).also { cacheFontDefaultAxes(font.id, it) }
+}
 
 internal suspend fun resolveFontDefaultAxes(font: FontItem): Map<String, Float> {
     if (!font.variable) {

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontUiSupport.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontUiSupport.kt
@@ -14,11 +14,13 @@ internal fun fontStaticWeights(font: FontItem): List<Int> = font.weights
 
 internal fun fontFixedWeight(font: FontItem): Int = fontStaticWeights(font).firstOrNull() ?: 400
 
-internal fun fontNormalizedWeight(font: FontItem, current: Int): Int = when {
-    font.variable -> current.coerceIn(1, 1000)
-    fontStaticWeights(font).size >= 2 -> fontStaticWeights(font).minByOrNull { abs(it - current) } ?: 400
-    else -> fontFixedWeight(font)
-}
+internal fun fontNormalizedWeight(font: FontItem, current: Int): Int =
+    cachedFontDefaultWeight(font.id) ?: when {
+        font.variable -> 400
+        400 in fontStaticWeights(font) -> 400
+        fontStaticWeights(font).size >= 2 -> fontStaticWeights(font).minByOrNull { abs(it - 400) } ?: 400
+        else -> fontFixedWeight(font)
+    }
 
 internal fun fontCapabilityLabel(font: FontItem): String = when {
     font.variable -> "可变字体"

--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v14.3.7
-summary=HyperOS 全局字体与标签裁切修复
-notes=洛书 v14.3.7 保留 HyperOS 原厂 Roboto/GoogleSans 度量外壳，避免小标签和紧凑控件裁字；MiSans 核心与 100-900 字重按 system、product、system_ext 真实分区覆盖。静态多字重自动匹配对应文件，可变字体保留变量核心并生成精确字重实例。模块 versionCode 为 14329，Debug App versionCode 为 1432901。
+version=v14.3.8
+summary=组合页使用字体原生默认值
+notes=v14.3.8 选择字体时读取原生默认轴；可变字体使用 fvar 默认值，静态字体优先 Regular。模块 versionCode 14330，Debug App versionCode 1433001。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v14.3.7
-versionCode=14329
+version=v14.3.8
+versionCode=14330
 author=惜故里丶
-description=Android 全局字体管理模块：HyperOS 真实分区映射、原厂度量兼容与精确字重
+description=Android 全局字体管理模块：HyperOS 全局映射与组合页字体原生默认轴
 updateJson=

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -43,6 +43,7 @@ for file in \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontMetadataInspector.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeFontPreview.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuViewModel.kt \
+  android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontDefaultAxes.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/appearance/AppearanceSettings.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModel.kt \
   android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsContract.kt \
@@ -119,6 +120,9 @@ grep -q 'encodeImportQueue' "$ROOT/android-app/app/src/main/java/io/github/xgl34
 grep -q 'viewModel<NativeImportViewModel>()' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuHost.kt"
 grep -q 'setFontVariationSettings' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeFontPreview.kt"
 grep -q 'updateMixAxis' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuViewModel.kt"
+grep -q 'resolveAndCacheFontDefaultAxes' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/dialogs/FontPickerDialog.kt"
+grep -q 'cachedFontDefaultWeight' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontUiSupport.kt"
+grep -q 'optDouble("default"' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontDefaultAxes.kt"
 grep -q 'testImplementation("junit:junit:4.13.2")' "$ROOT/android-app/app/build.gradle.kts"
 
 # HyperOS 必须保留紧凑控件的原厂度量壳，并按真实分区写入 MiSans 与数字字重目标。


### PR DESCRIPTION
基于 PR #52 的组合页默认值修复草稿。选择字体时先读取原生轴默认值；可变字体采用 fvar 默认值，静态多字重优先 Regular，主动滑动后才覆盖默认值。版本升级为 v14.3.8 / 14330。完整 CI 已通过。保持 Draft，不发布。