### PR TITLE
fix: restore native font module imports

### DIFF
--- a/common/native_import.sh
+++ b/common/native_import.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 # 洛书 v14.3 Alpha1.1：原生 App 文件选择器导入桥。
-# 只接受 App 私有缓存中的 TTF/OTF/TTC/ZIP；ZIP 继续交由安全字体包导入器处理。
+# 只接受 App 私有缓存中的 TTF/OTF/TTC/ZIP；ZIP 由安全字体包导入器处理。
 set +e
 
 MODDIR="${MODDIR:-}"
@@ -14,7 +14,6 @@ fi
 MODULE_DIR="$MODDIR"
 USER_FONTS_DIR="${LUOSHU_PUBLIC_DIR:-/sdcard/LuoShu}/fonts"
 USER_IMPORT_DIR="${LUOSHU_PUBLIC_DIR:-/sdcard/LuoShu}/import"
-FONT_MANAGER="$MODDIR/common/font_manager.sh"
 PYROOT="$MODDIR/common/python"
 PYBIN="$PYROOT/bin/luoshu-python"
 FACE_EXTRACTOR="$MODDIR/common/font_extract_faces.py"
@@ -22,6 +21,7 @@ MAX_BYTES=268435456
 
 [ -f "$MODDIR/common/util_functions.sh" ] && . "$MODDIR/common/util_functions.sh"
 [ -f "$MODDIR/common/font_check.sh" ] && . "$MODDIR/common/font_check.sh"
+[ -f "$MODDIR/common/font_import.sh" ] && . "$MODDIR/common/font_import.sh"
 
 json_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '
@@ -165,6 +165,10 @@ import_zip_file() {
         fail_json "系统缺少 unzip，无法导入字体模块 ZIP"
         return
     }
+    type import_zip_package >/dev/null 2>&1 || {
+        fail_json "安全字体模块导入器不可用"
+        return
+    }
     mkdir -p "$USER_IMPORT_DIR" 2>/dev/null || { fail_json "无法创建导入目录"; return; }
     _hash=$(file_hash "$_src")
     [ -n "$_hash" ] || { fail_json "无法计算 ZIP SHA-256"; return; }
@@ -176,7 +180,7 @@ import_zip_file() {
 
     _error_file="$MODDIR/cache/native-import-zip-error.$$"
     mkdir -p "${_error_file%/*}" 2>/dev/null || true
-    _result=$(MODDIR="$MODDIR" sh "$FONT_MANAGER" action import_zip "$(basename "$_target")" 2>"$_error_file")
+    _result=$(import_zip_package "$(basename "$_target")" 2>"$_error_file")
     _rc=$?
     _stderr=$(tail -n 6 "$_error_file" 2>/dev/null | tr '\n\r' '  ')
     rm -f "$_error_file" "$_target" 2>/dev/null || true
@@ -187,7 +191,7 @@ import_zip_file() {
         printf '%s\n' "$_json"
     else
         _detail=$(printf '%s' "${_stderr:-$_result}" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' | cut -c1-180)
-        [ -n "$_detail" ] || _detail="底层导入器没有返回结果（代码 $_rc）"
+        [ -n "$_detail" ] || _detail="安全导入器没有返回结果（代码 $_rc）"
         fail_json "字体模块 ZIP 导入失败：$_detail"
     fi
 }

--- a/scripts/.native_import_fix_marker
+++ b/scripts/.native_import_fix_marker
@@ -1,0 +1,1 @@
+native font module import bridge regression

--- a/scripts/.native_import_fix_marker
+++ b/scripts/.native_import_fix_marker
@@ -1,1 +1,0 @@
-native font module import bridge regression

--- a/scripts/native_zip_import_test.sh
+++ b/scripts/native_zip_import_test.sh
@@ -48,6 +48,11 @@ SOURCE_RESULT=$(sh -c '
 ' sh "$TMP/public/import/regression.zip" "$ROOT/common/font_check.sh")
 test "$SOURCE_RESULT" = sourced-ok
 
+# App 的原生导入桥必须直接装配安全 ZIP 导入器，不能再调用不存在的 font_manager action。
+grep -q 'common/font_import.sh' "$ROOT/common/native_import.sh"
+grep -q 'import_zip_package "$(basename "$_target")"' "$ROOT/common/native_import.sh"
+! grep -q 'action import_zip' "$ROOT/common/native_import.sh"
+
 OUTPUT=$(sh -c '
     set -eu
     MODDIR="$1"; MODULE_DIR="$1"; CONFIG_DIR="$2/config"
@@ -69,4 +74,4 @@ printf '%s\n' "$OUTPUT" | grep -q '"mode":"family"'
 printf '%s\n' "$OUTPUT" | grep -q '"importedText":2'
 find "$TMP/public/fonts" -maxdepth 1 -type f -name '*-ExtraLight.ttf' -print -quit | grep -q .
 find "$TMP/public/fonts" -maxdepth 1 -type f -name '*-ExtraBold.ttf' -print -quit | grep -q .
-echo 'Native font-module ZIP import and internal-weight regression test passed.'
+echo 'Native font-module ZIP import bridge and internal-weight regression test passed.'


### PR DESCRIPTION
## 问题

原生 App 导入字体模块 ZIP 时全部失败。

## 根因

`common/native_import.sh` 会调用 `font_manager.sh action import_zip`，但当前 `font_manager.sh` 已没有 `import_zip` 动作分支。底层 `font_import.sh` 仍然存在且测试通过，因此 CI 只验证了解包函数，没有覆盖 App 的真实调用链。

## 修复

- 原生导入桥直接加载 `common/font_import.sh`。
- ZIP 复制到安全导入目录后直接调用 `import_zip_package`，不再经过不存在的动作入口。
- 保留来源目录白名单、256 MB 限制、脚本不执行、字体真实格式校验、图标/Emoji 过滤和错误详情返回。
- 回归测试强制检查原生桥已经连接安全 ZIP 导入器，并禁止重新出现 `action import_zip` 调用。

## 验证

- 字体模块 ZIP 内部字重识别与多字重导入。
- 原生 App 导入桥静态调用链。
- 完整 App、字体引擎和模块候选包 CI。