### PR TITLE
perf: speed up font import refresh

### DIFF
--- a/common/font_check.sh
+++ b/common/font_check.sh
@@ -2,8 +2,58 @@
 # LuoShu v13.4 Beta2 Hotfix6 - 字体文件真实格式与基础兼容性检测
 # 只读取文件，不修改字体。
 
+# 同一个字体在一次 shell 进程中通常会连续经过格式、完整性、可变字体和彩色字体检查。
+# 缓存前 128 KiB 中出现的 SFNT 表标签，避免每个标签都重新 dd 一遍大字体文件。
+FONT_TABLE_CACHE_FILE=""
+FONT_TABLE_CACHE_TAGS=""
+FONT_TABLE_CACHE_READY="false"
+
 font_magic_hex() {
     dd if="$1" bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n\r'
+}
+
+font_table_token() {
+    case "$1" in
+        'SVG ') printf '%s\n' 'SVG_' ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+font_table_cache_load() {
+    _ftc_file="$1"
+    FONT_TABLE_CACHE_FILE="$_ftc_file"
+    # SFNT 表目录位于文件头部。一次读取后提取洛书关心的全部标签；命令替换只保存
+    # 匹配到的 ASCII 标签，不会把字体二进制内容放进 shell 变量。
+    FONT_TABLE_CACHE_TAGS=$(
+        dd if="$_ftc_file" bs=65536 count=2 2>/dev/null | \
+            grep -a -o -E 'cmap|head|maxp|fvar|COLR|CBDT|sbix|SVG ' 2>/dev/null | \
+            sed 's/^SVG $/SVG_/' | \
+            sort -u 2>/dev/null | \
+            tr '\n' '|'
+    )
+    if [ -n "$FONT_TABLE_CACHE_TAGS" ]; then
+        FONT_TABLE_CACHE_READY="true"
+    else
+        FONT_TABLE_CACHE_READY="false"
+    fi
+}
+
+font_has_table() {
+    _fht_file="$1"
+    _fht_tag="$2"
+    case "$_fht_tag" in
+        cmap|head|maxp|fvar|COLR|CBDT|sbix|'SVG ')
+            if [ "$FONT_TABLE_CACHE_READY" = "true" ] && [ "$FONT_TABLE_CACHE_FILE" = "$_fht_file" ]; then
+                _fht_token=$(font_table_token "$_fht_tag")
+                case "|$FONT_TABLE_CACHE_TAGS" in
+                    *"|${_fht_token}|"*) return 0 ;;
+                    *) return 1 ;;
+                esac
+            fi
+            ;;
+    esac
+    # 兼容未知标签或极少数 grep 不支持 -o/-E 的环境。
+    dd if="$_fht_file" bs=65536 count=2 2>/dev/null | grep -a -q "$_fht_tag"
 }
 
 font_detect_format() {
@@ -16,11 +66,6 @@ font_detect_format() {
         504b0304) echo "ZIP" ;;
         *) echo "UNKNOWN" ;;
     esac
-}
-
-font_has_table() {
-    # SFNT 表目录位于文件头部。只读取前 128 KiB，避免对几十个 10–30 MB 字体反复全文件 grep。
-    dd if="$1" bs=65536 count=2 2>/dev/null | grep -a -q "$2"
 }
 
 font_validate() {
@@ -61,6 +106,8 @@ font_validate() {
             return 1
             ;;
     esac
+
+    font_table_cache_load "$_file"
 
     if ! font_has_table "$_file" "cmap"; then
         FONT_CHECK_ERROR="字体缺少 cmap 字符映射表"

--- a/scripts/stability_test.sh
+++ b/scripts/stability_test.sh
@@ -58,6 +58,35 @@ grep -q 'native_font_index.key' "$ROOT/common/font_manager.sh"
 test ! -d "$ROOT/webroot"
 test ! -e "$ROOT/scripts/prepare_webui.sh"
 
+# 字体完整性校验必须一次读取表目录，并让后续标签查询复用结果。
+# 旧实现会为 cmap/head/maxp/fvar/COLR/CBDT/sbix/SVG 分别 dd，字体库刷新时非常慢。
+FONT=$(find /usr/share/fonts -type f \( -iname 'DejaVuSans.ttf' -o -iname 'LiberationSans-Regular.ttf' \) -print -quit 2>/dev/null || true)
+if [ -s "$FONT" ]; then
+    mkdir -p "$TMP/bin"
+    REAL_DD=$(command -v dd)
+    cat > "$TMP/bin/dd" <<'EOS'
+#!/bin/sh
+_count=$(cat "$LUOSHU_DD_COUNT" 2>/dev/null || printf '0')
+case "$_count" in ''|*[!0-9]*) _count=0 ;; esac
+printf '%s\n' "$((_count + 1))" > "$LUOSHU_DD_COUNT"
+exec "$LUOSHU_REAL_DD" "$@"
+EOS
+    chmod 0755 "$TMP/bin/dd"
+    printf '0\n' > "$TMP/dd-count"
+    PATH="$TMP/bin:$PATH" LUOSHU_REAL_DD="$REAL_DD" LUOSHU_DD_COUNT="$TMP/dd-count" \
+        sh -c '
+            . "$1/common/font_check.sh"
+            font_validate "$2" text
+            test "$FONT_CHECK_FORMAT" = TTF
+            font_has_table "$2" cmap
+            font_has_table "$2" head
+            font_has_table "$2" maxp
+            font_has_table "$2" fvar || true
+        ' sh "$ROOT" "$FONT"
+    DD_CALLS=$(cat "$TMP/dd-count")
+    test "$DD_CALLS" -le 2
+fi
+
 # 单包内置 App 安装器必须正确处理当前版本、覆盖更新、延迟安装和签名失败。
 sh "$ROOT/scripts/app_installer_test.sh"
 


### PR DESCRIPTION
## 问题

导入字体后刷新字体列表很慢，字体越多、CJK 字体越大越明显。

## 根因

字体索引重建会校验每个字体族的代表文件。旧的 `font_validate` 为 `cmap/head/maxp/fvar/COLR/CBDT/sbix/SVG` 分别执行一次 `dd`，同一个字体最多重复读取前 128 KiB 8 次，再加一次格式头读取。全库刷新时外部进程和存储读取被成倍放大。

## 优化

- 每个字体只读取一次 128 KiB 表目录。
- 一次提取全部受关注的 SFNT 表标签。
- 后续完整性、可变字体和彩色字体判断复用同一份缓存。
- 对未知标签或不支持 `grep -o/-E` 的环境保留旧的逐标签回退逻辑。
- 不降低真实格式、cmap/head/maxp、可变字体和彩色字体校验标准。

## 回归测试

通过 PATH 包装 `dd` 统计调用次数，强制验证一个普通 TTF 完成格式、完整性和后续表查询时最多只读取 2 次（4 字节格式头 + 128 KiB 表目录）。