### PR TITLE
fix: compact previews and preserve fonts across updates

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontUiSupport.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontUiSupport.kt
@@ -39,17 +39,17 @@ internal fun fontCapabilityLabel(font: FontItem): String {
     val capability = when {
         font.variable -> "可变字体"
         fontStaticWeights(font).size >= 2 ->
-  "多字重 · ${fontStaticWeights(font).joinToString(" / ")}"
+            "多字重 · ${fontStaticWeights(font).joinToString(" / ")}"
         else -> "固定 ${fontWeightName(fontFixedWeight(font))}"
     }
     return if (font.supportsCjk) capability else "仅拉丁 · $capability"
 }
 
 internal fun fontPreviewText(font: FontItem, detailed: Boolean = false): String = when {
-    font.supportsCjk && detailed -> "洛书字体详情预览\nHello 0123456789"
-    font.supportsCjk -> "洛书字体预览  Hello 0123456789"
-    detailed -> "Hello 0123456789\nLatin font · 中文将回退系统字体"
-    else -> "Hello 0123456789  Latin font"
+    font.supportsCjk && detailed -> "洛书字体 · Aa 0123456789\n天地玄黄 · Hello"
+    font.supportsCjk -> "洛书 Aa 0123456789"
+    detailed -> "Aa Hello 0123456789\n仅拉丁 · 中文回退系统字体"
+    else -> "Aa Hello 0123456789"
 }
 
 internal fun fontRoleWeight(role: String): Int = when (role.lowercase()) {

--- a/android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/font/FontUiSupportTest.kt
+++ b/android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/font/FontUiSupportTest.kt
@@ -17,12 +17,21 @@ class FontUiSupportTest {
     }
 
     @Test
+    fun compactCardPreviewNeverWraps() {
+        val font = font(weights = listOf("regular"))
+
+        assertEquals("洛书 Aa 0123456789", fontPreviewText(font))
+        assertFalse(fontPreviewText(font).contains('\n'))
+        assertTrue(fontPreviewText(font, detailed = true).contains('\n'))
+    }
+
+    @Test
     fun latinOnlyFontExplainsWhyChineseLooksLikeSystemDefault() {
         val font = font(weights = listOf("regular"), supportsCjk = false)
 
         assertTrue(fontCapabilityLabel(font).startsWith("仅拉丁"))
-        assertTrue(fontPreviewText(font).startsWith("Hello"))
-        assertTrue(fontPreviewText(font, detailed = true).contains("中文将回退系统字体"))
+        assertEquals("Aa Hello 0123456789", fontPreviewText(font))
+        assertTrue(fontPreviewText(font, detailed = true).contains("中文回退系统字体"))
     }
 
     @Test

--- a/common/module_update_state.sh
+++ b/common/module_update_state.sh
@@ -1,0 +1,111 @@
+#!/system/bin/sh
+# 模块更新状态迁移：继承当前字体负载，只清理一次性任务与待重启状态。
+
+luoshu_copy_update_tree() {
+    _source="$1"
+    _destination="$2"
+    [ -d "$_source" ] || return 0
+    mkdir -p "$_destination" 2>/dev/null || return 1
+    cp -af "$_source/." "$_destination/" 2>/dev/null || \
+        cp -rfp "$_source/." "$_destination/" 2>/dev/null
+}
+
+luoshu_update_config_is_volatile() {
+    case "$1" in
+        version_notes.conf|switch_task.conf|mix_task.conf|axes_task.conf|emoji_task.conf|\
+        text_reboot_required.conf|font_weight_reboot_required.conf|emoji_reboot_required.conf|\
+        webui_font_list.json|webui_font_list.key|native_font_index.json|native_font_index.key|\
+        composite_progress.json|mix_last_error.txt|app_install_pending|app_install_state.conf|\
+        app_install_manual|*.pid|*.pid.task|*.tmp|*.tmp.*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+luoshu_update_has_font_payload() {
+    _module="$1"
+    for _directory in \
+        "$_module/system/fonts" \
+        "$_module/system_ext" \
+        "$_module/product" \
+        "$_module/vendor" \
+        "$_module/odm" \
+        "$_module/oem" \
+        "$_module/my_product"; do
+        [ -d "$_directory" ] || continue
+        find "$_directory" -type f \( -iname '*.ttf' -o -iname '*.otf' -o -iname '*.ttc' \) \
+            -print -quit 2>/dev/null | grep -q . && return 0
+    done
+    return 1
+}
+
+luoshu_clear_update_volatile() {
+    _module="$1"
+    rm -f \
+        "$_module/config/switch_task.conf" \
+        "$_module/config/mix_task.conf" \
+        "$_module/config/axes_task.conf" \
+        "$_module/config/emoji_task.conf" \
+        "$_module/config/text_reboot_required.conf" \
+        "$_module/config/font_weight_reboot_required.conf" \
+        "$_module/config/emoji_reboot_required.conf" \
+        "$_module/config/webui_font_list.json" \
+        "$_module/config/webui_font_list.key" \
+        "$_module/config/native_font_index.json" \
+        "$_module/config/native_font_index.key" \
+        "$_module/config/composite_progress.json" \
+        "$_module/config/mix_last_error.txt" \
+        "$_module/config/app_install_pending" \
+        "$_module/config/app_install_state.conf" \
+        "$_module/config/app_install_manual" \
+        "$_module/.font_switch.lock" \
+        "$_module/.font-payload-commit.ok" 2>/dev/null || true
+    rm -f "$_module/config"/*.pid "$_module/config"/*.pid.task \
+        "$_module/config"/*.tmp "$_module/config"/*.tmp.* 2>/dev/null || true
+    rm -rf "$_module"/.font-payload-stage.* "$_module"/.font-payload-backup.* 2>/dev/null || true
+}
+
+luoshu_migrate_update_config() {
+    _old="$1"
+    _new="$2"
+    [ -d "$_old/config" ] || return 0
+    mkdir -p "$_new/config" 2>/dev/null || return 1
+    for _source in "$_old/config"/*; do
+        [ -f "$_source" ] || continue
+        _name=${_source##*/}
+        luoshu_update_config_is_volatile "$_name" && continue
+        cp -af "$_source" "$_new/config/$_name" 2>/dev/null || \
+            cp -fp "$_source" "$_new/config/$_name" 2>/dev/null || return 1
+    done
+    return 0
+}
+
+luoshu_migrate_active_install() {
+    _old="$1"
+    _new="$2"
+    [ -f "$_old/module.prop" ] || return 2
+    [ "$_old" != "$_new" ] || return 2
+
+    _active=$(head -n1 "$_old/config/active_font.conf" 2>/dev/null | tr -d '\r\n')
+    [ -n "$_active" ] || _active=default
+    if [ "$_active" != default ] && ! luoshu_update_has_font_payload "$_old"; then
+        return 1
+    fi
+
+    mkdir -p "$_new/config" "$_new/system/fonts" 2>/dev/null || return 1
+    luoshu_migrate_update_config "$_old" "$_new" || return 1
+
+    for _relative in system/fonts system/etc system_ext product vendor odm oem my_product; do
+        [ -d "$_old/$_relative" ] || continue
+        rm -rf "$_new/$_relative" 2>/dev/null || return 1
+        mkdir -p "${_new}/${_relative%/*}" 2>/dev/null || return 1
+        luoshu_copy_update_tree "$_old/$_relative" "$_new/$_relative" || return 1
+    done
+
+    [ -s "$_new/config/active_font.conf" ] || printf '%s\n' "$_active" >"$_new/config/active_font.conf"
+    luoshu_clear_update_volatile "$_new"
+    chmod 0644 "$_new/config"/* 2>/dev/null || true
+    find "$_new/system/fonts" -type f -exec chmod 0644 {} \; 2>/dev/null || true
+    return 0
+}

--- a/customize.sh
+++ b/customize.sh
@@ -8,6 +8,7 @@ MODULE_VERSION=$(sed -n 's/^version=//p' "$MODPATH/module.prop" 2>/dev/null | he
 MODULE_DIR="$MODPATH"
 [ -f "$MODPATH/common/util_functions.sh" ] && . "$MODPATH/common/util_functions.sh"
 [ -f "$MODPATH/common/rom_adapters.sh" ] && . "$MODPATH/common/rom_adapters.sh"
+[ -f "$MODPATH/common/module_update_state.sh" ] && . "$MODPATH/common/module_update_state.sh"
 
 if type ensure_public_storage >/dev/null 2>&1; then
     ensure_public_storage
@@ -53,20 +54,30 @@ fi
 
 mkdir -p "$MODPATH/system/fonts" "$MODPATH/system/bin" "$MODPATH/config" "$MODPATH/logs" 2>/dev/null || true
 OLD_MOD="/data/adb/modules/LuoShu"
+UPDATE_PRESERVED=false
 
-# 仅迁移用户偏好；历史任务和待重启状态不进入新安装。
-for _config in font_weight.conf font_weight_original.conf axes_mix.conf font_mix.conf; do
-    [ -f "$OLD_MOD/config/$_config" ] && cp -f "$OLD_MOD/config/$_config" "$MODPATH/config/$_config" 2>/dev/null || true
-done
-for _state in previous_font.conf switch_task.conf mix_task.conf axes_task.conf text_reboot_required.conf \
-              font_weight_reboot_required.conf active_emoji.conf emoji_task.conf emoji_reboot_required.conf \
-              webui_font_list.json webui_font_list.key native_font_index.json native_font_index.key \
-              app_install_pending app_install_state.conf app_install_manual; do
-    rm -f "$MODPATH/config/$_state" 2>/dev/null || true
-done
-rm -f "$MODPATH/system/etc/fonts.xml" "$MODPATH/system/etc/font_fallback.xml" \
-      "$MODPATH/system/fonts/NotoColorEmoji.ttf" "$MODPATH/system/fonts/NotoColorEmojiLegacy.ttf" 2>/dev/null || true
-printf 'default\n' > "$MODPATH/config/active_font.conf"
+# 更新安装继承当前活动字体与各分区负载；只清理任务、缓存、PID 和旧待重启标记。
+if type luoshu_migrate_active_install >/dev/null 2>&1; then
+    if luoshu_migrate_active_install "$OLD_MOD" "$MODPATH"; then
+        UPDATE_PRESERVED=true
+    fi
+fi
+
+if [ "$UPDATE_PRESERVED" != true ]; then
+    # 全新安装或旧负载无效时，仅迁移可安全复用的用户偏好。
+    for _config in font_weight.conf font_weight_original.conf axes_mix.conf font_mix.conf; do
+        [ -f "$OLD_MOD/config/$_config" ] && cp -f "$OLD_MOD/config/$_config" "$MODPATH/config/$_config" 2>/dev/null || true
+    done
+    for _state in previous_font.conf switch_task.conf mix_task.conf axes_task.conf text_reboot_required.conf \
+                  font_weight_reboot_required.conf active_emoji.conf emoji_task.conf emoji_reboot_required.conf \
+                  webui_font_list.json webui_font_list.key native_font_index.json native_font_index.key \
+                  app_install_pending app_install_state.conf app_install_manual; do
+        rm -f "$MODPATH/config/$_state" 2>/dev/null || true
+    done
+    rm -f "$MODPATH/system/etc/fonts.xml" "$MODPATH/system/etc/font_fallback.xml" \
+          "$MODPATH/system/fonts/NotoColorEmoji.ttf" "$MODPATH/system/fonts/NotoColorEmojiLegacy.ttf" 2>/dev/null || true
+    printf 'default\n' > "$MODPATH/config/active_font.conf"
+fi
 
 # 安装安全 CLI，不暴露上一字体回滚、热刷新或重启 SystemUI 命令。
 cp -f "$MODPATH/common/luoshu_cli.sh" "$MODPATH/system/bin/洛书" 2>/dev/null || true
@@ -80,7 +91,14 @@ chmod 0755 "$MODPATH/system/fonts" "$MODPATH/system/bin" "$MODPATH/config" "$MOD
 touch "$MODPATH/magic" 2>/dev/null || true
 
 ui_print "✓ 模块文件已部署"
-ui_print "✓ 当前保持系统默认字体"
+if [ "$UPDATE_PRESERVED" = true ]; then
+    _preserved_font=$(head -n1 "$MODPATH/config/active_font.conf" 2>/dev/null | tr -d '\r\n')
+    [ -n "$_preserved_font" ] || _preserved_font=default
+    ui_print "✓ 已继承当前字体：$_preserved_font"
+    ui_print "✓ 更新后只需重启一次，无需重新应用字体"
+else
+    ui_print "✓ 当前保持系统默认字体"
+fi
 
 if [ -s "$MODPATH/bundled/LuoShu-App.apk" ] && [ -f "$MODPATH/common/app_installer.sh" ]; then
     _app_result=$(MODDIR="$MODPATH" APP_INSTALL_LOG="$MODPATH/logs/app-install.log" sh "$MODPATH/common/app_installer.sh" flash 2>/dev/null)
@@ -97,7 +115,11 @@ if [ -s "$MODPATH/bundled/LuoShu-App.apk" ] && [ -f "$MODPATH/common/app_install
 else
     ui_print "✗ 模块内置 App 或安装器缺失，请重新下载洛书模块包"
 fi
-ui_print "请完整重启后进入洛书 App 配置字体。"
+if [ "$UPDATE_PRESERVED" = true ]; then
+    ui_print "请完整重启一次，新版本会继续使用当前字体。"
+else
+    ui_print "请完整重启后进入洛书 App 配置字体。"
+fi
 ui_print ""
-[ -f "$MODPATH/common/module_status.sh" ] && MODDIR="$MODPATH" sh "$MODPATH/common/module_status.sh" default >/dev/null 2>&1 || true
+[ -f "$MODPATH/common/module_status.sh" ] && MODDIR="$MODPATH" sh "$MODPATH/common/module_status.sh" "$(head -n1 "$MODPATH/config/active_font.conf" 2>/dev/null)" >/dev/null 2>&1 || true
 exit 0

--- a/scripts/module_update_state_test.sh
+++ b/scripts/module_update_state_test.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t luoshu-update-state)
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+OLD="$TMP/old"
+NEW="$TMP/new"
+mkdir -p \
+    "$OLD/config" "$OLD/system/fonts/.luoshu-font-store" "$OLD/system/etc" "$OLD/product/fonts" \
+    "$NEW/config" "$NEW/system/bin"
+
+printf 'id=LuoShu\nversion=old\n' >"$OLD/module.prop"
+printf 'Qsal\n' >"$OLD/config/active_font.conf"
+printf 'Twemoji\n' >"$OLD/config/active_emoji.conf"
+printf 'cjk=Qsal\nlatin=Qsal\ndigit=Qsal\n' >"$OLD/config/font_mix.conf"
+printf 'old notes\n' >"$OLD/config/version_notes.conf"
+printf 'state=running\n' >"$OLD/config/switch_task.conf"
+printf 'font=Qsal\n' >"$OLD/config/text_reboot_required.conf"
+printf '123\n' >"$OLD/config/axes_worker.pid"
+printf 'Qsal payload\n' >"$OLD/system/fonts/Qsal-Regular.ttf"
+printf 'anchor\n' >"$OLD/system/fonts/.luoshu-font-store/qsal.font"
+printf '<familyset/>\n' >"$OLD/system/etc/fonts.xml"
+printf 'OEM payload\n' >"$OLD/product/fonts/OEM-Regular.ttf"
+
+printf 'new notes\n' >"$NEW/config/version_notes.conf"
+printf '#!/bin/sh\n' >"$NEW/system/bin/洛书"
+
+. "$ROOT/common/module_update_state.sh"
+luoshu_migrate_active_install "$OLD" "$NEW"
+
+test "$(cat "$NEW/config/active_font.conf")" = Qsal
+test "$(cat "$NEW/config/active_emoji.conf")" = Twemoji
+grep -q '^cjk=Qsal$' "$NEW/config/font_mix.conf"
+test "$(cat "$NEW/config/version_notes.conf")" = 'new notes'
+test -f "$NEW/system/fonts/Qsal-Regular.ttf"
+test -f "$NEW/system/fonts/.luoshu-font-store/qsal.font"
+test -f "$NEW/system/etc/fonts.xml"
+test -f "$NEW/product/fonts/OEM-Regular.ttf"
+test -f "$NEW/system/bin/洛书"
+test ! -e "$NEW/config/switch_task.conf"
+test ! -e "$NEW/config/text_reboot_required.conf"
+test ! -e "$NEW/config/axes_worker.pid"
+
+INVALID="$TMP/invalid"
+TARGET="$TMP/invalid-target"
+mkdir -p "$INVALID/config" "$TARGET/config"
+printf 'id=LuoShu\n' >"$INVALID/module.prop"
+printf 'MissingFont\n' >"$INVALID/config/active_font.conf"
+if luoshu_migrate_active_install "$INVALID" "$TARGET"; then
+    echo 'invalid active payload was migrated' >&2
+    exit 1
+fi
+test ! -e "$TARGET/config/active_font.conf"
+
+FRESH="$TMP/fresh"
+mkdir -p "$FRESH"
+set +e
+luoshu_migrate_active_install "$TMP/not-installed" "$FRESH"
+FRESH_CODE=$?
+set -e
+test "$FRESH_CODE" -eq 2
+
+echo 'Module updates preserve active font payload and require one reboot.'

--- a/scripts/stability_test.sh
+++ b/scripts/stability_test.sh
@@ -14,7 +14,7 @@ cp "$ROOT/common/font_mix.sh" "$MODULE/common/font_mix.sh"
 cp "$ROOT/module.prop" "$MODULE/module.prop"
 
 # 状态查询不得触发真正的字体切换。
-printf '#!/bin/sh\ntouch "%s/manager-called"\nprintf '\''{"status":"ok"}\\n'\''\n' "$TMP" > "$MODULE/common/font_manager.sh"
+printf '#!/bin/sh\ntouch "%s/manager-called"\nprintf '\''{"status":"ok"}\n'\''\n' "$TMP" > "$MODULE/common/font_manager.sh"
 chmod 0755 "$MODULE/common"/*
 cat > "$MODULE/config/switch_task.conf" <<'EOT'
 task=test-task
@@ -92,6 +92,14 @@ sh "$ROOT/scripts/app_installer_test.sh"
 
 # 原生 App 字体索引只在文件集合实际变化时失效。
 sh "$ROOT/scripts/font_library_cache_test.sh"
+
+# 模块更新必须继承当前字体负载，避免“更新重启一次、应用字体再重启一次”。
+grep -q 'module_update_state.sh' "$ROOT/customize.sh"
+grep -q '更新后只需重启一次' "$ROOT/customize.sh"
+sh "$ROOT/scripts/module_update_state_test.sh"
+
+# 字体卡片必须使用紧凑单行样张，完整两行样张只出现在详情页。
+grep -q '"洛书 Aa 0123456789"' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/font/FontUiSupport.kt"
 
 # 字体导入必须淘汰模块端原生索引；三级缓存版本不得回退。
 grep -q 'native_font_index.json' "$ROOT/common/native_import.sh"


### PR DESCRIPTION
## 用户反馈

- 字体库卡片预览文案过长，在 MIUIx 卡片中换行后被裁切，数字只露出半行，留白也不协调；
- 每次更新模块都会先重启激活更新，再应用字体并再次重启，实际需要两次完整重启。

## 根因

- 卡片使用“洛书字体预览  Hello 0123456789”作为单行样张，原生 TextView 在有限宽度内产生第二行，而卡片又将其限制为一行，造成硬裁切。
- `customize.sh` 在每次安装时删除活动状态和字体 XML/Emoji 负载，并强制把 `active_font.conf` 写成 `default`，因此更新后必然丢失当前字体。

## 修复

- 字体卡片改用紧凑单行样张 `洛书 Aa 0123456789`；仅详情页保留两行完整中英数字样张。
- 新增 `common/module_update_state.sh`，更新安装时继承旧模块的活动字体、复合配置、Emoji 状态和真实分区字体负载。
- 迁移覆盖 `system/fonts`、`system/etc`、`system_ext`、`product`、`vendor`、`odm`、`oem` 与 `my_product`。
- 只清理任务文件、Worker PID、索引缓存、临时事务和旧待重启标记；新版本自己的 CLI、版本说明和程序文件不会被旧版本覆盖。
- 活动字体声明与负载不一致时拒绝迁移，回退到系统默认字体，避免更新后带着损坏负载启动。
- 全新安装保持原逻辑；正常更新只需一次完整重启，新版本启动后继续使用更新前的字体。

## 回归

- 新增真实模块更新迁移测试，验证活动字体、Emoji、复合配置、XML 与 OEM 分区负载被保留；
- 验证版本说明和新 CLI 不被覆盖；
- 验证任务、PID 与待重启标记不被迁移；
- 验证无负载的活动字体配置会被拒绝；
- Kotlin 单元测试锁定卡片样张必须是单行，详情样张才允许换行。

等待完整 CI。