### PR TITLE
fix: recover nested font mix tasks from persistent state

### DIFF
--- a/.ci-nested-trigger
+++ b/.ci-nested-trigger
@@ -1,0 +1,1 @@
+diagnose nested mix handoff

--- a/.ci-nested-trigger
+++ b/.ci-nested-trigger
@@ -1,1 +1,0 @@
-diagnose nested mix handoff

--- a/common/mix_task_handoff.sh
+++ b/common/mix_task_handoff.sh
@@ -1,0 +1,62 @@
+#!/system/bin/sh
+# 嵌套复合任务交接：标准输出可能因 Android 后台 Shell 行为丢失，持久化任务文件是最终依据。
+
+luoshu_mix_task_value() {
+    _file="$1"
+    _key="$2"
+    sed -n "s/^${_key}=//p" "$_file" 2>/dev/null | head -n1 | tr -d '\r\n'
+}
+
+luoshu_mix_task_from_response() {
+    _response="$1"
+    [ -s "$_response" ] || return 1
+    sed -n 's/^.*"task":"\([^"]*\)".*$/\1/p' "$_response" 2>/dev/null | tail -n1
+}
+
+luoshu_mix_task_message_from_response() {
+    _response="$1"
+    [ -s "$_response" ] || return 1
+    sed -n 's/^.*"message":"\([^"]*\)".*$/\1/p' "$_response" 2>/dev/null | tail -n1
+}
+
+luoshu_mix_task_matches_request() {
+    _task_file="$1"
+    _candidate="$2"
+    _previous="$3"
+    _cjk="$4"
+    _latin="$5"
+    _digit="$6"
+
+    [ -n "$_candidate" ] || return 1
+    [ "$_candidate" != "$_previous" ] || return 1
+    [ "$(luoshu_mix_task_value "$_task_file" task)" = "$_candidate" ] || return 1
+    [ "$(luoshu_mix_task_value "$_task_file" cjk)" = "$_cjk" ] || return 1
+    [ "$(luoshu_mix_task_value "$_task_file" latin)" = "$_latin" ] || return 1
+    [ "$(luoshu_mix_task_value "$_task_file" digit)" = "$_digit" ] || return 1
+    case "$(luoshu_mix_task_value "$_task_file" state)" in
+        queued|running|success|failed) return 0 ;;
+    esac
+    return 1
+}
+
+luoshu_resolve_nested_mix_task() {
+    _response="$1"
+    _task_file="$2"
+    _previous="$3"
+    _cjk="$4"
+    _latin="$5"
+    _digit="$6"
+
+    _child=$(luoshu_mix_task_from_response "$_response" 2>/dev/null)
+    if [ -n "$_child" ]; then
+        printf '%s\n' "$_child"
+        return 0
+    fi
+
+    _candidate=$(luoshu_mix_task_value "$_task_file" task)
+    if luoshu_mix_task_matches_request "$_task_file" "$_candidate" "$_previous" "$_cjk" "$_latin" "$_digit"; then
+        printf '%s\n' "$_candidate"
+        return 0
+    fi
+    return 1
+}

--- a/common/mix_task_handoff.sh
+++ b/common/mix_task_handoff.sh
@@ -47,7 +47,8 @@ luoshu_resolve_nested_mix_task() {
     _latin="$5"
     _digit="$6"
 
-    _child=$(luoshu_mix_task_from_response "$_response" 2>/dev/null)
+    # “无启动输出”正是需要回退到持久化任务文件的正常场景；不得让 set -e 提前终止。
+    _child=$(luoshu_mix_task_from_response "$_response" 2>/dev/null || true)
     if [ -n "$_child" ]; then
         printf '%s\n' "$_child"
         return 0

--- a/common/v142_weighted_mix.sh
+++ b/common/v142_weighted_mix.sh
@@ -35,6 +35,7 @@ MODULE_DIR="$MODDIR"
 [ -f "$MODDIR/common/util_functions.sh" ] && . "$MODDIR/common/util_functions.sh"
 [ -f "$MODDIR/common/font_check.sh" ] && . "$MODDIR/common/font_check.sh"
 [ -f "$MODDIR/common/background_task.sh" ] && . "$MODDIR/common/background_task.sh"
+[ -f "$MODDIR/common/mix_task_handoff.sh" ] && . "$MODDIR/common/mix_task_handoff.sh"
 
 json_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '
@@ -254,14 +255,29 @@ worker() {
     }
 
     update_task "$_wanted" running '正在启动完整复合字体引擎' 34 '' ''
-    _output=$(LUOSHU_PUBLIC_DIR="$_root" MODDIR="$MODDIR" sh "$BASE_ENGINE" start LuoShuMixCJK LuoShuMixLatin LuoShuMixDigit 2>&1)
-    _child=$(printf '%s\n' "$_output" | sed -n 's/^.*"task":"\([^"]*\)".*$/\1/p' | tail -n1)
+    _previous_child=$(read_value "$BASE_TASK_FILE" task)
+    _response_file="$_root/base-engine-start.json"
+    : >"$_response_file" 2>/dev/null || true
+    LUOSHU_PUBLIC_DIR="$_root" MODDIR="$MODDIR" sh "$BASE_ENGINE" start \
+        LuoShuMixCJK LuoShuMixLatin LuoShuMixDigit >"$_response_file" 2>&1
+    _child=""
+    if type luoshu_resolve_nested_mix_task >/dev/null 2>&1; then
+        _child=$(luoshu_resolve_nested_mix_task "$_response_file" "$BASE_TASK_FILE" "$_previous_child" \
+            LuoShuMixCJK LuoShuMixLatin LuoShuMixDigit 2>/dev/null)
+    else
+        _child=$(sed -n 's/^.*"task":"\([^"]*\)".*$/\1/p' "$_response_file" 2>/dev/null | tail -n1)
+    fi
     if [ -z "$_child" ]; then
-        _message=$(printf '%s\n' "$_output" | sed -n 's/^.*"message":"\([^"]*\)".*$/\1/p' | tail -n1)
-        [ -n "$_message" ] || _message='无法启动完整复合字体引擎'
+        if type luoshu_mix_task_message_from_response >/dev/null 2>&1; then
+            _message=$(luoshu_mix_task_message_from_response "$_response_file" 2>/dev/null)
+        else
+            _message=$(sed -n 's/^.*"message":"\([^"]*\)".*$/\1/p' "$_response_file" 2>/dev/null | tail -n1)
+        fi
+        [ -n "$_message" ] || _message='完整复合字体任务未登记，启动输出为空'
         update_task "$_wanted" failed "$_message" 100 '' "$(date +%s)"
         rm -rf "$_root"; luoshu_clear_task_pid "$WORKER_PID" "$_wanted"; exit 1
     fi
+    rm -f "$_response_file" 2>/dev/null || true
 
     update_task "$_wanted" running '完整复合字体正在后台生成' 36 "$_child" ''
     _loops=0

--- a/scripts/background_mix_worker_test.sh
+++ b/scripts/background_mix_worker_test.sh
@@ -30,4 +30,6 @@ grep -q 'luoshu_start_detached.*worker' "$ROOT/common/font_mix.sh"
 _PRECHECK_COUNT=$(grep -Fc 'precheck_mix "$2" "$3" "$4"' "$ROOT/common/v14_mix.sh")
 [ "$_PRECHECK_COUNT" -eq 1 ]
 grep -q '多字重引擎会在独立 Root Worker 内完成角色检查' "$ROOT/common/v14_mix.sh"
-echo 'Detached root font workers survive their submitting shell and weighted jobs queue immediately.'
+# 嵌套完整复合引擎即使丢失启动输出，也必须从持久化任务文件接管。
+sh "$ROOT/scripts/nested_mix_task_handoff_test.sh"
+echo 'Detached root font workers survive their submitting shell, nested handoff, and weighted jobs queue immediately.'

--- a/scripts/nested_mix_task_handoff_test.sh
+++ b/scripts/nested_mix_task_handoff_test.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t luoshu-mix-handoff)
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+. "$ROOT/common/mix_task_handoff.sh"
+
+RESPONSE="$TMP/response.json"
+TASK="$TMP/mix_task.conf"
+
+printf '%s\n' '{"status":"ok","data":{"task":"from-output"}}' >"$RESPONSE"
+cat >"$TASK" <<'EOF_TASK'
+task=stale
+state=success
+cjk=LuoShuMixCJK
+latin=LuoShuMixLatin
+digit=LuoShuMixDigit
+EOF_TASK
+test "$(luoshu_resolve_nested_mix_task "$RESPONSE" "$TASK" stale LuoShuMixCJK LuoShuMixLatin LuoShuMixDigit)" = from-output
+
+: >"$RESPONSE"
+cat >"$TASK" <<'EOF_TASK'
+task=from-state
+state=running
+message=正在生成
+cjk=LuoShuMixCJK
+latin=LuoShuMixLatin
+digit=LuoShuMixDigit
+EOF_TASK
+test "$(luoshu_resolve_nested_mix_task "$RESPONSE" "$TASK" stale LuoShuMixCJK LuoShuMixLatin LuoShuMixDigit)" = from-state
+
+if luoshu_resolve_nested_mix_task "$RESPONSE" "$TASK" from-state LuoShuMixCJK LuoShuMixLatin LuoShuMixDigit >/dev/null 2>&1; then
+    echo 'stale task was accepted' >&2
+    exit 1
+fi
+
+sed 's/^latin=.*/latin=WrongLatin/' "$TASK" >"$TASK.tmp"
+mv -f "$TASK.tmp" "$TASK"
+if luoshu_resolve_nested_mix_task "$RESPONSE" "$TASK" stale LuoShuMixCJK LuoShuMixLatin LuoShuMixDigit >/dev/null 2>&1; then
+    echo 'mismatched task was accepted' >&2
+    exit 1
+fi
+
+printf '%s\n' '{"status":"error","message":"真实启动错误"}' >"$RESPONSE"
+test "$(luoshu_mix_task_message_from_response "$RESPONSE")" = 真实启动错误
+
+# 真实复现：内层引擎成功登记任务并开始运行，但标准输出完全为空。
+# 外层 Worker 必须从 mix_task.conf 接管子任务，不能误判失败并删除输入目录。
+FONT=$(find /usr/share/fonts -type f \( -iname 'DejaVuSans.ttf' -o -iname 'LiberationSans-Regular.ttf' \) -print -quit 2>/dev/null || true)
+if [ -s "$FONT" ]; then
+    MODULE="$TMP/module"
+    PUBLIC="$TMP/public"
+    mkdir -p "$MODULE/common" "$MODULE/config" "$MODULE/logs" "$PUBLIC/fonts"
+    cp "$ROOT/common/v142_weighted_mix.sh" "$MODULE/common/v142_weighted_mix.sh"
+    cp "$ROOT/common/util_functions.sh" "$MODULE/common/util_functions.sh"
+    cp "$ROOT/common/font_check.sh" "$MODULE/common/font_check.sh"
+    cp "$ROOT/common/background_task.sh" "$MODULE/common/background_task.sh"
+    cp "$ROOT/common/mix_task_handoff.sh" "$MODULE/common/mix_task_handoff.sh"
+
+    cat >"$MODULE/common/font_role_check.sh" <<'EOF_ROLE'
+#!/bin/sh
+exit 0
+EOF_ROLE
+    cat >"$MODULE/common/font_mix.sh" <<'EOF_ENGINE'
+#!/bin/sh
+MODDIR="${MODDIR:-${0%/*}/..}"
+TASK="$MODDIR/config/mix_task.conf"
+case "${1:-}" in
+    start)
+        cat >"$TASK" <<EOF_INNER
+task=base-no-output
+state=success
+message=内层任务已完成
+cjk=$2
+latin=$3
+digit=$4
+started=1
+finished=2
+EOF_INNER
+        chmod 0644 "$TASK" 2>/dev/null || true
+        # 故意不输出 JSON，模拟部分 Android Root Shell 上丢失启动输出。
+        ;;
+    recover) exit 0 ;;
+esac
+exit 0
+EOF_ENGINE
+    chmod 0755 "$MODULE/common"/*.sh
+
+    cp "$FONT" "$PUBLIC/fonts/CJK-Regular.ttf"
+    cp "$FONT" "$PUBLIC/fonts/Latin-Regular.ttf"
+    cp "$FONT" "$PUBLIC/fonts/Digit-Regular.ttf"
+
+    START=$(MODDIR="$MODULE" LUOSHU_PUBLIC_DIR="$PUBLIC" sh "$MODULE/common/v142_weighted_mix.sh" \
+        start CJK Latin Digit wght=400 wght=400 wght=400)
+    OUTER=$(printf '%s\n' "$START" | sed -n 's/^.*"task":"\([^"]*\)".*$/\1/p' | tail -n1)
+    test -n "$OUTER"
+
+    COUNT=0
+    while [ "$COUNT" -lt 100 ]; do
+        STATE=$(sed -n 's/^state=//p' "$MODULE/config/axes_task.conf" 2>/dev/null | head -n1)
+        case "$STATE" in success|failed) break ;; esac
+        sleep 0.1
+        COUNT=$((COUNT + 1))
+    done
+    test "$(sed -n 's/^state=//p' "$MODULE/config/axes_task.conf")" = success
+    test "$(sed -n 's/^childTask=//p' "$MODULE/config/axes_task.conf")" = base-no-output
+    ! grep -q '无法启动完整复合字体引擎' "$MODULE/config/axes_task.conf"
+fi
+
+grep -q 'mix_task_handoff.sh' "$ROOT/common/v142_weighted_mix.sh"
+grep -q 'luoshu_resolve_nested_mix_task' "$ROOT/common/v142_weighted_mix.sh"
+grep -q '_response_file=' "$ROOT/common/v142_weighted_mix.sh"
+! grep -q '_output=$(LUOSHU_PUBLIC_DIR=' "$ROOT/common/v142_weighted_mix.sh"
+
+echo 'Nested mix task handoff survives missing startup output.'

--- a/scripts/nested_mix_task_handoff_test.sh
+++ b/scripts/nested_mix_task_handoff_test.sh
@@ -98,13 +98,23 @@ EOF_ENGINE
     test -n "$OUTER"
 
     COUNT=0
-    while [ "$COUNT" -lt 100 ]; do
+    while [ "$COUNT" -lt 30 ]; do
         STATE=$(sed -n 's/^state=//p' "$MODULE/config/axes_task.conf" 2>/dev/null | head -n1)
         case "$STATE" in success|failed) break ;; esac
-        sleep 0.1
+        sleep 1
         COUNT=$((COUNT + 1))
     done
-    test "$(sed -n 's/^state=//p' "$MODULE/config/axes_task.conf")" = success
+    STATE=$(sed -n 's/^state=//p' "$MODULE/config/axes_task.conf" 2>/dev/null | head -n1)
+    if [ "$STATE" != success ]; then
+        echo "nested handoff integration failed: state=${STATE:-missing}" >&2
+        echo '--- axes_task.conf ---' >&2
+        cat "$MODULE/config/axes_task.conf" >&2 2>/dev/null || true
+        echo '--- mix_task.conf ---' >&2
+        cat "$MODULE/config/mix_task.conf" >&2 2>/dev/null || true
+        echo '--- fontswitch.log ---' >&2
+        tail -n 80 "$MODULE/logs/fontswitch.log" >&2 2>/dev/null || true
+        exit 1
+    fi
     test "$(sed -n 's/^childTask=//p' "$MODULE/config/axes_task.conf")" = base-no-output
     ! grep -q '无法启动完整复合字体引擎' "$MODULE/config/axes_task.conf"
 fi


### PR DESCRIPTION
## 用户反馈

同一套字体组合此前可用，更新后任务中心显示：

- `字体组合失败：无法启动完整复合字体引擎`；
- 随后恢复系统字体时又出现元模块旧负载回写失败；
- 日志时间线却已经出现内层 `mix start`，说明完整复合引擎实际上已经启动。

## 根因

固定字重组合由外层 `v142_weighted_mix.sh` Worker 准备三套字体，再启动内层 `font_mix.sh` Worker。旧逻辑只从内层启动命令的标准输出解析子任务 ID。

部分 Android Root Shell / 嵌套后台会话中，内层任务已经写入持久化 `mix_task.conf` 并开始运行，但启动 JSON 没有回到外层命令替换。外层因此误判“无法启动”，删除了内层正在使用的临时字体目录，真正运行中的内层任务随后也失败并触发回滚。

## 修复

- 新增 `common/mix_task_handoff.sh`，统一解析嵌套任务交接。
- 内层启动输出改写入普通响应文件，不再依赖命令替换管道。
- 标准输出中的任务 ID仍优先使用；输出为空时，以新写入的 `mix_task.conf` 为最终依据。
- 只有任务 ID 相比旧任务发生变化，且 `cjk/latin/digit` 与本次内部字体三槽完全一致，才接管该子任务，避免误接旧任务。
- 成功接管后继续轮询真实子任务进度，绝不删除其输入目录。
- 真正没有启动任务时才失败，并返回更明确的“任务未登记/启动输出为空”诊断。

## 回归

新增真实嵌套回归：

1. 外层 Worker 使用三个真实 TTF 准备中文、英文和数字槽；
2. 内层引擎写入一个成功任务，但故意不输出任何 JSON；
3. 外层必须从任务文件恢复 `childTask` 并最终成功；
4. 旧任务、参数不匹配的任务不得被错误接管。

等待完整 CI。