### PR TITLE
ui: synchronize Material and MIUIx font library polish

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryScreenMaterial.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryScreenMaterial.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -19,18 +21,18 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.FontDownload
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Warning
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,7 +41,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,7 +66,7 @@ internal fun FontLibraryScreenMaterial(
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(start = 18.dp, top = 8.dp, end = 18.dp, bottom = 24.dp),
+        contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 28.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
         item { MaterialLibraryHeader(state, actions.refresh) }
@@ -74,20 +75,44 @@ internal fun FontLibraryScreenMaterial(
         item { MaterialBrowsePanel(state, actions) }
 
         if (state.loading || state.operationBusy) {
-            item { LinearProgressIndicator(Modifier.fillMaxWidth().height(4.dp)) }
+            item {
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth().height(4.dp),
+                    trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                )
+            }
         }
         if (state.error.isNotBlank()) {
             item { MaterialLibraryMessage(state.error, error = true) }
         }
         if (state.operationMessage.isNotBlank()) {
-            item { MaterialLibraryMessage(state.operationMessage, error = false, busy = state.operationBusy) }
+            item {
+                MaterialLibraryMessage(
+                    message = state.operationMessage,
+                    error = false,
+                    busy = state.operationBusy,
+                )
+            }
         }
 
+        item {
+            MaterialSectionLabel(
+                title = "系统字体",
+                subtitle = if (state.activeFontId == "default") "正在使用 ROM 原始映射" else "可随时恢复系统字体",
+            )
+        }
         item {
             MaterialSystemFontCard(
                 active = state.activeFontId == "default",
                 busy = state.operationBusy,
                 onRestore = actions.restoreDefault,
+            )
+        }
+
+        item {
+            MaterialSectionLabel(
+                title = "已导入字体",
+                subtitle = "显示 ${state.visibleCount} 个 · ${state.sort.label}",
             )
         }
         if (!state.loading && state.fonts.isEmpty()) {
@@ -109,7 +134,7 @@ internal fun FontLibraryScreenMaterial(
 @Composable
 private fun MaterialLibraryHeader(state: FontLibraryUiState, onRefresh: () -> Unit) {
     Row(
-        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+        modifier = Modifier.fillMaxWidth().padding(top = 2.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(Modifier.weight(1f)) {
@@ -121,21 +146,31 @@ private fun MaterialLibraryHeader(state: FontLibraryUiState, onRefresh: () -> Un
                 letterSpacing = 2.2.sp,
             )
             Spacer(Modifier.height(4.dp))
-            Text("字体库", style = MaterialTheme.typography.headlineLarge, fontWeight = FontWeight.Black)
             Text(
-                "真实字体预览 · 共 ${state.totalCount} 个来源",
+                "字体库",
+                color = MaterialTheme.colorScheme.onBackground,
+                fontSize = 34.sp,
+                lineHeight = 39.sp,
+                fontWeight = FontWeight.Black,
+            )
+            Text(
+                "管理与应用本地字体 · ${state.validCount}/${state.totalCount} 可用",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 12.sp,
             )
         }
         Surface(
-            shape = MaterialTheme.shapes.large,
-            color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = .84f),
-            shadowElevation = 7.dp,
+            shape = RoundedCornerShape(18.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            shadowElevation = 4.dp,
         ) {
-            IconButton(onClick = onRefresh, modifier = Modifier.size(56.dp), enabled = !state.loading) {
+            IconButton(
+                onClick = onRefresh,
+                modifier = Modifier.size(52.dp),
+                enabled = !state.loading,
+            ) {
                 if (state.loading) {
-                    CircularProgressIndicator(Modifier.size(22.dp), strokeWidth = 2.dp)
+                    CircularProgressIndicator(Modifier.size(21.dp), strokeWidth = 2.dp)
                 } else {
                     Icon(Icons.Rounded.Refresh, contentDescription = "刷新字体库")
                 }
@@ -147,10 +182,12 @@ private fun MaterialLibraryHeader(state: FontLibraryUiState, onRefresh: () -> Un
 @Composable
 private fun MaterialLibraryOverview(state: FontLibraryUiState) {
     val scheme = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(28.dp)
     Card(
-        shape = MaterialTheme.shapes.extraLarge,
+        modifier = Modifier.fillMaxWidth(),
+        shape = shape,
         colors = CardDefaults.cardColors(containerColor = Color.Transparent),
-        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 5.dp),
     ) {
         Box(
             modifier = Modifier
@@ -159,28 +196,33 @@ private fun MaterialLibraryOverview(state: FontLibraryUiState) {
                 .drawBehind {
                     drawCircle(
                         brush = Brush.radialGradient(
-                            colors = listOf(Color.White.copy(alpha = .32f), Color.Transparent),
-                            center = Offset(size.width * .9f, 0f),
-                            radius = size.width * .72f,
+                            colors = listOf(Color.White.copy(alpha = .30f), Color.Transparent),
+                            center = Offset(size.width * .92f, size.height * .08f),
+                            radius = size.width * .70f,
                         ),
-                        center = Offset(size.width * .9f, 0f),
-                        radius = size.width * .72f,
+                        center = Offset(size.width * .92f, size.height * .08f),
+                        radius = size.width * .70f,
                     )
                 }
-                .padding(22.dp),
+                .padding(horizontal = 20.dp, vertical = 18.dp),
         ) {
             Column {
-                Text("字体资源概览", color = Color.White.copy(alpha = .78f), fontSize = 12.sp)
-                Spacer(Modifier.height(6.dp))
+                Text(
+                    "字体资源概览",
+                    color = Color.White.copy(alpha = .78f),
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(4.dp))
                 Text(
                     "${state.validCount} 个可用字体",
                     color = Color.White,
-                    fontSize = 28.sp,
-                    lineHeight = 33.sp,
+                    fontSize = 25.sp,
+                    lineHeight = 30.sp,
                     fontWeight = FontWeight.Black,
                 )
-                Spacer(Modifier.height(18.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(9.dp)) {
+                Spacer(Modifier.height(15.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     MaterialOverviewMetric("结果", state.visibleCount.toString(), Modifier.weight(1f))
                     MaterialOverviewMetric("可变", state.variableCount.toString(), Modifier.weight(1f))
                     MaterialOverviewMetric("多字重", state.multiWeightCount.toString(), Modifier.weight(1f))
@@ -194,12 +236,12 @@ private fun MaterialLibraryOverview(state: FontLibraryUiState) {
 private fun MaterialOverviewMetric(label: String, value: String, modifier: Modifier) {
     Surface(
         modifier = modifier,
-        shape = MaterialTheme.shapes.large,
+        shape = RoundedCornerShape(16.dp),
         color = Color.White.copy(alpha = .16f),
         contentColor = Color.White,
     ) {
-        Column(Modifier.padding(horizontal = 13.dp, vertical = 11.dp)) {
-            Text(value, fontSize = 19.sp, fontWeight = FontWeight.Black)
+        Column(Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+            Text(value, fontSize = 18.sp, fontWeight = FontWeight.Black)
             Text(label, color = Color.White.copy(alpha = .72f), fontSize = 10.sp)
         }
     }
@@ -208,23 +250,24 @@ private fun MaterialOverviewMetric(label: String, value: String, modifier: Modif
 @Composable
 private fun MaterialBrowsePanel(state: FontLibraryUiState, actions: FontLibraryActions) {
     Card(
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = RoundedCornerShape(28.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = .84f),
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
     ) {
-        Column(Modifier.padding(10.dp)) {
+        Column(Modifier.padding(12.dp)) {
             OutlinedTextField(
                 value = state.query,
                 onValueChange = actions.setQuery,
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
-                shape = MaterialTheme.shapes.large,
+                shape = RoundedCornerShape(20.dp),
                 leadingIcon = { Icon(Icons.Rounded.Search, contentDescription = null) },
                 placeholder = { Text("搜索名称、ID 或格式") },
             )
             Spacer(Modifier.height(12.dp))
-            Text("筛选", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+            MaterialPanelLabel("筛选")
             Spacer(Modifier.height(7.dp))
             Row(
                 modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
@@ -239,7 +282,7 @@ private fun MaterialBrowsePanel(state: FontLibraryUiState, actions: FontLibraryA
                 }
             }
             Spacer(Modifier.height(12.dp))
-            Text("排序", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+            MaterialPanelLabel("排序")
             Spacer(Modifier.height(7.dp))
             Row(
                 modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
@@ -258,11 +301,26 @@ private fun MaterialBrowsePanel(state: FontLibraryUiState, actions: FontLibraryA
 }
 
 @Composable
+private fun MaterialPanelLabel(text: String) {
+    Text(
+        text,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = .5.sp,
+    )
+}
+
+@Composable
 private fun MaterialChoicePill(label: String, active: Boolean, onClick: () -> Unit) {
     Surface(
         modifier = Modifier.clickable(onClick = onClick),
         shape = CircleShape,
-        color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerHigh,
+        color = if (active) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHigh
+        },
     ) {
         Text(
             text = label,
@@ -270,6 +328,31 @@ private fun MaterialChoicePill(label: String, active: Boolean, onClick: () -> Un
             color = if (active) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
             fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            softWrap = false,
+        )
+    }
+}
+
+@Composable
+private fun MaterialSectionLabel(title: String, subtitle: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.Bottom,
+    ) {
+        Text(
+            title,
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.onBackground,
+            fontSize = 21.sp,
+            fontWeight = FontWeight.Black,
+        )
+        Text(
+            subtitle,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 10.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }
@@ -277,33 +360,57 @@ private fun MaterialChoicePill(label: String, active: Boolean, onClick: () -> Un
 @Composable
 private fun MaterialSystemFontCard(active: Boolean, busy: Boolean, onRestore: () -> Unit) {
     Card(
-        shape = MaterialTheme.shapes.extraLarge,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(26.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = .84f),
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(18.dp),
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Surface(
-                modifier = Modifier.size(52.dp),
-                shape = MaterialTheme.shapes.large,
+                modifier = Modifier.size(54.dp),
+                shape = RoundedCornerShape(18.dp),
                 color = MaterialTheme.colorScheme.primaryContainer,
             ) {
                 Box(contentAlignment = Alignment.Center) {
-                    Text("系", color = MaterialTheme.colorScheme.primary, fontSize = 20.sp, fontWeight = FontWeight.Black)
+                    Text(
+                        "系",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Black,
+                    )
                 }
             }
             Spacer(Modifier.width(13.dp))
             Column(Modifier.weight(1f)) {
-                Text("系统默认字体", fontSize = 17.sp, fontWeight = FontWeight.Black)
-                Text("恢复 ROM 原始字体映射", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+                Text(
+                    "系统默认字体",
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 17.sp,
+                    fontWeight = FontWeight.Black,
+                )
+                Text(
+                    "恢复 ROM 原始字体映射",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 11.sp,
+                )
             }
+            Spacer(Modifier.width(8.dp))
             if (active) {
                 MaterialLibraryPill("使用中", Color(0xFF21966C))
             } else {
-                FilledTonalButton(onClick = onRestore, enabled = !busy) { Text("恢复") }
+                MaterialCardAction(
+                    label = "恢复",
+                    primary = false,
+                    enabled = !busy,
+                    onClick = onRestore,
+                    modifier = Modifier.width(82.dp),
+                    showArrow = false,
+                )
             }
         }
     }
@@ -318,47 +425,82 @@ private fun MaterialFontCard(
     onApply: () -> Unit,
     onDelete: () -> Unit,
 ) {
+    val scheme = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(28.dp)
     val container = if (font.valid) {
-        MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = .84f)
+        scheme.surfaceContainerLow
     } else {
-        MaterialTheme.colorScheme.errorContainer.copy(alpha = .52f)
+        scheme.errorContainer.copy(alpha = .54f)
     }
     Card(
-        shape = MaterialTheme.shapes.extraLarge,
+        modifier = Modifier.fillMaxWidth(),
+        shape = shape,
         colors = CardDefaults.cardColors(containerColor = container),
-        elevation = CardDefaults.cardElevation(defaultElevation = if (active) 7.dp else 2.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (active) 6.dp else 2.dp),
     ) {
-        Column(Modifier.padding(18.dp)) {
+        Column(Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Surface(
-                    modifier = Modifier.size(52.dp).clickable(onClick = onDetails),
-                    shape = MaterialTheme.shapes.large,
-                    color = MaterialTheme.colorScheme.primaryContainer,
+                    modifier = Modifier.size(56.dp).clickable(onClick = onDetails),
+                    shape = RoundedCornerShape(19.dp),
+                    color = scheme.primaryContainer,
                 ) {
                     Box(contentAlignment = Alignment.Center) {
-                        Text("Aa", color = MaterialTheme.colorScheme.primary, fontSize = 17.sp, fontWeight = FontWeight.Black)
+                        Text(
+                            "Aa",
+                            color = scheme.primary,
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Black,
+                        )
                     }
                 }
                 Spacer(Modifier.width(13.dp))
-                Column(Modifier.weight(1f).clickable(onClick = onDetails)) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .heightIn(min = 56.dp)
+                        .clickable(onClick = onDetails),
+                    verticalArrangement = Arrangement.Center,
+                ) {
                     Text(
                         font.name,
-                        fontSize = 17.sp,
+                        color = scheme.onSurface,
+                        fontSize = 18.sp,
+                        lineHeight = 22.sp,
                         fontWeight = FontWeight.Black,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )
+                    Spacer(Modifier.height(2.dp))
                     Text(
-                        listOf(font.format, font.size, font.date).filter { it.isNotBlank() }.joinToString(" · "),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        listOf(font.format, font.size, font.date)
+                            .filter { it.isNotBlank() }
+                            .joinToString(" · "),
+                        color = scheme.onSurfaceVariant,
                         fontSize = 10.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                if (!active) {
-                    IconButton(onClick = onDelete, enabled = !busy) {
-                        Icon(Icons.Rounded.Delete, contentDescription = "删除字体", tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                Spacer(Modifier.width(6.dp))
+                if (active) {
+                    MaterialLibraryPill("使用中", scheme.primary)
+                } else {
+                    Surface(
+                        onClick = onDelete,
+                        enabled = !busy,
+                        modifier = Modifier.size(40.dp),
+                        shape = RoundedCornerShape(14.dp),
+                        color = scheme.onSurface.copy(alpha = .055f),
+                        contentColor = scheme.onSurfaceVariant,
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                Icons.Rounded.Delete,
+                                contentDescription = "删除字体",
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
                     }
                 }
             }
@@ -366,15 +508,18 @@ private fun MaterialFontCard(
             Spacer(Modifier.height(14.dp))
             Surface(
                 modifier = Modifier.fillMaxWidth().clickable(onClick = onDetails),
-                shape = MaterialTheme.shapes.large,
-                color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = .62f),
+                shape = RoundedCornerShape(22.dp),
+                color = scheme.surfaceContainerHigh.copy(alpha = .72f),
             ) {
                 NativeFontPreview(
                     font = font,
                     text = fontPreviewText(font, detailed = true),
                     axes = if (font.variable) mapOf("wght" to 400f) else emptyMap(),
-                    modifier = Modifier.fillMaxWidth().height(98.dp).padding(horizontal = 17.dp, vertical = 13.dp),
-                    textSizeSp = 24f,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(102.dp)
+                        .padding(horizontal = 17.dp, vertical = 14.dp),
+                    textSizeSp = 23f,
                     maxLines = 2,
                 )
             }
@@ -382,29 +527,55 @@ private fun MaterialFontCard(
             if (!font.valid && font.error.isNotBlank()) {
                 Spacer(Modifier.height(10.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.Rounded.Warning, contentDescription = null, tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(17.dp))
+                    Icon(
+                        Icons.Rounded.Warning,
+                        contentDescription = null,
+                        tint = scheme.error,
+                        modifier = Modifier.size(17.dp),
+                    )
                     Spacer(Modifier.width(7.dp))
-                    Text(font.error, color = MaterialTheme.colorScheme.error, fontSize = 10.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                    Text(
+                        font.error,
+                        color = scheme.error,
+                        fontSize = 10.sp,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
             }
 
             Spacer(Modifier.height(12.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .55f))
-            Spacer(Modifier.height(8.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                MaterialLibraryPill(fontCapabilityLabel(font), MaterialTheme.colorScheme.primary)
-                Spacer(Modifier.weight(1f))
-                TextButton(onClick = onDetails) { Text("详情") }
+            HorizontalDivider(color = scheme.outlineVariant.copy(alpha = .44f))
+            Spacer(Modifier.height(11.dp))
+            MaterialCapabilityStrip(fontCapabilityLabel(font))
+            Spacer(Modifier.height(10.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                MaterialCardAction(
+                    label = "查看详情",
+                    primary = false,
+                    enabled = true,
+                    onClick = onDetails,
+                    modifier = Modifier.weight(1f),
+                    showArrow = false,
+                )
                 if (active) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Rounded.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(18.dp))
-                        Spacer(Modifier.width(5.dp))
-                        Text("当前使用", color = MaterialTheme.colorScheme.primary, fontSize = 12.sp, fontWeight = FontWeight.Black)
-                    }
+                    MaterialCurrentAction(
+                        modifier = Modifier.weight(1f),
+                        color = Color(0xFF21966C),
+                    )
                 } else {
-                    Button(onClick = onApply, enabled = font.valid && !busy) {
-                        Text("应用字体", fontWeight = FontWeight.Bold)
-                    }
+                    MaterialCardAction(
+                        label = "应用字体",
+                        primary = true,
+                        enabled = font.valid && !busy,
+                        onClick = onApply,
+                        modifier = Modifier.weight(1f),
+                        showArrow = true,
+                    )
                 }
             }
         }
@@ -412,12 +583,126 @@ private fun MaterialFontCard(
 }
 
 @Composable
+private fun MaterialCapabilityStrip(text: String) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.primary.copy(alpha = .085f),
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 9.dp),
+            color = MaterialTheme.colorScheme.primary,
+            fontSize = 10.sp,
+            lineHeight = 14.sp,
+            fontWeight = FontWeight.Black,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun MaterialCardAction(
+    label: String,
+    primary: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    showArrow: Boolean,
+) {
+    val scheme = MaterialTheme.colorScheme
+    val container = when {
+        primary && enabled -> scheme.primary
+        primary -> scheme.surfaceVariant
+        else -> scheme.surfaceContainerHigh
+    }
+    val content = when {
+        primary && enabled -> scheme.onPrimary
+        primary -> scheme.onSurfaceVariant.copy(alpha = .68f)
+        else -> scheme.onSurface
+    }
+    Surface(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier.defaultMinSize(minHeight = 46.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = container,
+        contentColor = content,
+        shadowElevation = if (primary && enabled) 2.dp else 0.dp,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                label,
+                color = content,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Black,
+                maxLines = 1,
+                softWrap = false,
+            )
+            if (showArrow) {
+                Spacer(Modifier.width(4.dp))
+                Icon(
+                    Icons.Rounded.ChevronRight,
+                    contentDescription = null,
+                    modifier = Modifier.size(17.dp),
+                    tint = content,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MaterialCurrentAction(modifier: Modifier = Modifier, color: Color) {
+    Surface(
+        modifier = modifier.defaultMinSize(minHeight = 46.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = color.copy(alpha = .12f),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Rounded.CheckCircle,
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(17.dp),
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                "正在使用",
+                color = color,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Black,
+                maxLines = 1,
+                softWrap = false,
+            )
+        }
+    }
+}
+
+@Composable
 private fun MaterialLibraryMessage(message: String, error: Boolean, busy: Boolean = false) {
     Surface(
-        shape = MaterialTheme.shapes.large,
-        color = if (error) MaterialTheme.colorScheme.errorContainer else MaterialTheme.colorScheme.secondaryContainer,
+        shape = RoundedCornerShape(22.dp),
+        color = if (error) {
+            MaterialTheme.colorScheme.errorContainer
+        } else {
+            MaterialTheme.colorScheme.secondaryContainer
+        },
     ) {
-        Row(Modifier.fillMaxWidth().padding(15.dp), verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(15.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             if (busy) {
                 CircularProgressIndicator(Modifier.size(19.dp), strokeWidth = 2.dp)
             } else {
@@ -431,7 +716,11 @@ private fun MaterialLibraryMessage(message: String, error: Boolean, busy: Boolea
             Text(
                 message,
                 modifier = Modifier.weight(1f),
-                color = if (error) MaterialTheme.colorScheme.onErrorContainer else MaterialTheme.colorScheme.onSecondaryContainer,
+                color = if (error) {
+                    MaterialTheme.colorScheme.onErrorContainer
+                } else {
+                    MaterialTheme.colorScheme.onSecondaryContainer
+                },
                 fontSize = 12.sp,
             )
         }
@@ -442,14 +731,29 @@ private fun MaterialLibraryMessage(message: String, error: Boolean, busy: Boolea
 private fun MaterialLibraryEmpty(state: FontLibraryUiState) {
     val filtered = state.filter != FontLibraryFilter.ALL
     Card(
-        shape = MaterialTheme.shapes.extraLarge,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = .84f)),
+        shape = RoundedCornerShape(30.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(34.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Icon(Icons.Rounded.FontDownload, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(42.dp))
+            Surface(
+                modifier = Modifier.size(58.dp),
+                shape = RoundedCornerShape(20.dp),
+                color = MaterialTheme.colorScheme.primaryContainer,
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        Icons.Rounded.FontDownload,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
             Spacer(Modifier.height(13.dp))
             Text(
                 when {
@@ -464,7 +768,7 @@ private fun MaterialLibraryEmpty(state: FontLibraryUiState) {
                 when {
                     state.query.isNotBlank() -> "换一个关键词，或者清空搜索条件"
                     filtered -> "切换到“全部”查看其他字体"
-                    else -> "使用右下角导入按钮选择 TTF、OTF、TTC 或模块 ZIP"
+                    else -> "使用页面上方的导入工具栏添加 TTF、OTF、TTC 或模块 ZIP"
                 },
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 11.sp,
@@ -483,6 +787,9 @@ private fun MaterialLibraryPill(text: String, color: Color) {
             color = color,
             fontSize = 10.sp,
             fontWeight = FontWeight.Black,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryScreenMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryScreenMiuix.kt
@@ -6,9 +6,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -28,7 +28,6 @@ import androidx.compose.material.icons.rounded.FontDownload
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Warning
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -40,7 +39,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,7 +63,7 @@ internal fun FontLibraryScreenMiuix(
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 24.dp),
+        contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 28.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
         item { MiuixLibraryHeader(state, actions.refresh) }
@@ -73,13 +71,24 @@ internal fun FontLibraryScreenMiuix(
         item { MiuixBrowsePanel(state, actions) }
 
         if (state.loading || state.operationBusy) {
-            item { LinearProgressIndicator(Modifier.fillMaxWidth().height(4.dp)) }
+            item {
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth().height(4.dp),
+                    trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                )
+            }
         }
         if (state.error.isNotBlank()) {
             item { MiuixLibraryNotice(state.error, error = true) }
         }
         if (state.operationMessage.isNotBlank()) {
-            item { MiuixLibraryNotice(state.operationMessage, error = false, busy = state.operationBusy) }
+            item {
+                MiuixLibraryNotice(
+                    message = state.operationMessage,
+                    error = false,
+                    busy = state.operationBusy,
+                )
+            }
         }
 
         item {
@@ -122,7 +131,7 @@ internal fun FontLibraryScreenMiuix(
 private fun MiuixLibraryHeader(state: FontLibraryUiState, onRefresh: () -> Unit) {
     val tokens = LocalMiuixTokens.current
     Row(
-        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+        modifier = Modifier.fillMaxWidth().padding(top = 2.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(Modifier.weight(1f)) {
@@ -142,7 +151,7 @@ private fun MiuixLibraryHeader(state: FontLibraryUiState, onRefresh: () -> Unit)
                 fontWeight = FontWeight.Black,
             )
             Text(
-                "${state.validCount}/${state.totalCount} 可用 · ${state.variableCount} 个可变字体",
+                "管理与应用本地字体 · ${state.validCount}/${state.totalCount} 可用",
                 color = tokens.textSecondary,
                 fontSize = 12.sp,
             )
@@ -150,11 +159,15 @@ private fun MiuixLibraryHeader(state: FontLibraryUiState, onRefresh: () -> Unit)
         Card(
             shape = RoundedCornerShape(18.dp),
             colors = CardDefaults.cardColors(containerColor = tokens.elevatedCardBackground),
-            elevation = CardDefaults.cardElevation(defaultElevation = 7.dp),
+            elevation = CardDefaults.cardElevation(defaultElevation = 5.dp),
         ) {
-            IconButton(onClick = onRefresh, enabled = !state.loading, modifier = Modifier.size(56.dp)) {
+            IconButton(
+                onClick = onRefresh,
+                enabled = !state.loading,
+                modifier = Modifier.size(52.dp),
+            ) {
                 if (state.loading) {
-                    CircularProgressIndicator(Modifier.size(22.dp), strokeWidth = 2.dp)
+                    CircularProgressIndicator(Modifier.size(21.dp), strokeWidth = 2.dp)
                 } else {
                     Icon(Icons.Rounded.Refresh, contentDescription = "刷新字体库")
                 }
@@ -182,7 +195,7 @@ private fun MiuixBrowsePanel(state: FontLibraryUiState, actions: FontLibraryActi
                 placeholder = { Text("搜索名称、ID 或格式") },
             )
             Spacer(Modifier.height(12.dp))
-            Text("筛选", color = tokens.textSecondary, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+            MiuixPanelLabel("筛选")
             Spacer(Modifier.height(7.dp))
             Row(
                 modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
@@ -197,7 +210,7 @@ private fun MiuixBrowsePanel(state: FontLibraryUiState, actions: FontLibraryActi
                 }
             }
             Spacer(Modifier.height(12.dp))
-            Text("排序", color = tokens.textSecondary, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+            MiuixPanelLabel("排序")
             Spacer(Modifier.height(7.dp))
             Row(
                 modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
@@ -222,11 +235,27 @@ private fun MiuixBrowsePanel(state: FontLibraryUiState, actions: FontLibraryActi
 }
 
 @Composable
+private fun MiuixPanelLabel(text: String) {
+    val tokens = LocalMiuixTokens.current
+    Text(
+        text,
+        color = tokens.textSecondary,
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = .5.sp,
+    )
+}
+
+@Composable
 private fun MiuixChoicePill(label: String, active: Boolean, onClick: () -> Unit) {
     Surface(
         modifier = Modifier.clickable(onClick = onClick),
         shape = RoundedCornerShape(999.dp),
-        color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerHigh,
+        color = if (active) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHigh
+        },
     ) {
         Text(
             text = label,
@@ -234,6 +263,8 @@ private fun MiuixChoicePill(label: String, active: Boolean, onClick: () -> Unit)
             color = if (active) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
             fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            softWrap = false,
         )
     }
 }
@@ -250,7 +281,12 @@ private fun MiuixMetricPill(label: String, value: Int, modifier: Modifier) {
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(value.toString(), color = MaterialTheme.colorScheme.primary, fontSize = 17.sp, fontWeight = FontWeight.Black)
+            Text(
+                value.toString(),
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Black,
+            )
             Spacer(Modifier.width(6.dp))
             Text(label, color = tokens.textSecondary, fontSize = 10.sp)
         }
@@ -264,8 +300,20 @@ private fun MiuixSectionLabel(title: String, subtitle: String) {
         modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 2.dp),
         verticalAlignment = Alignment.Bottom,
     ) {
-        Text(title, color = tokens.textPrimary, fontSize = 22.sp, fontWeight = FontWeight.Black, modifier = Modifier.weight(1f))
-        Text(subtitle, color = tokens.textSecondary, fontSize = 10.sp)
+        Text(
+            title,
+            color = tokens.textPrimary,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Black,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            subtitle,
+            color = tokens.textSecondary,
+            fontSize = 10.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 
@@ -273,34 +321,55 @@ private fun MiuixSectionLabel(title: String, subtitle: String) {
 private fun MiuixSystemFontRow(active: Boolean, busy: Boolean, onRestore: () -> Unit) {
     val tokens = LocalMiuixTokens.current
     Card(
+        modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(28.dp),
         colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
         elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(17.dp),
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Surface(
-                modifier = Modifier.size(50.dp),
-                shape = RoundedCornerShape(18.dp),
+                modifier = Modifier.size(54.dp),
+                shape = RoundedCornerShape(19.dp),
                 color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
             ) {
                 Box(contentAlignment = Alignment.Center) {
-                    Text("系", color = MaterialTheme.colorScheme.primary, fontSize = 20.sp, fontWeight = FontWeight.Black)
+                    Text(
+                        "系",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Black,
+                    )
                 }
             }
             Spacer(Modifier.width(13.dp))
             Column(Modifier.weight(1f)) {
-                Text("系统默认字体", color = tokens.textPrimary, fontSize = 17.sp, fontWeight = FontWeight.Black)
-                Text("ROM 原始字体映射", color = tokens.textSecondary, fontSize = 11.sp)
+                Text(
+                    "系统默认字体",
+                    color = tokens.textPrimary,
+                    fontSize = 17.sp,
+                    fontWeight = FontWeight.Black,
+                )
+                Text(
+                    "ROM 原始字体映射",
+                    color = tokens.textSecondary,
+                    fontSize = 11.sp,
+                )
             }
+            Spacer(Modifier.width(8.dp))
             if (active) {
                 MiuixLibraryPill("使用中", tokens.success)
             } else {
-                Button(onClick = onRestore, enabled = !busy, shape = RoundedCornerShape(17.dp)) {
-                    Text("恢复", fontWeight = FontWeight.Bold)
-                }
+                MiuixCardAction(
+                    label = "恢复",
+                    primary = false,
+                    enabled = !busy,
+                    onClick = onRestore,
+                    modifier = Modifier.width(82.dp),
+                    showArrow = false,
+                )
             }
         }
     }
@@ -316,30 +385,42 @@ private fun MiuixFontCard(
     onDelete: () -> Unit,
 ) {
     val tokens = LocalMiuixTokens.current
-    val shape = RoundedCornerShape(28.dp)
+    val scheme = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(30.dp)
     Card(
-        modifier = Modifier.fillMaxWidth().shadow(if (active) 8.dp else 3.dp, shape, clip = false),
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(if (active) 8.dp else 4.dp, shape, clip = false),
         shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = if (font.valid) tokens.cardBackground else MaterialTheme.colorScheme.errorContainer.copy(alpha = .42f),
+            containerColor = if (font.valid) {
+                tokens.cardBackground
+            } else {
+                scheme.errorContainer.copy(alpha = .42f)
+            },
         ),
     ) {
         Column(Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Surface(
-                    modifier = Modifier.size(52.dp).clickable(onClick = onDetails),
-                    shape = RoundedCornerShape(18.dp),
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = .10f),
+                    modifier = Modifier.size(56.dp).clickable(onClick = onDetails),
+                    shape = RoundedCornerShape(20.dp),
+                    color = scheme.primary.copy(alpha = .105f),
                 ) {
                     Box(contentAlignment = Alignment.Center) {
-                        Text("Aa", color = MaterialTheme.colorScheme.primary, fontSize = 17.sp, fontWeight = FontWeight.Black)
+                        Text(
+                            "Aa",
+                            color = scheme.primary,
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Black,
+                        )
                     }
                 }
-                Spacer(Modifier.width(12.dp))
+                Spacer(Modifier.width(13.dp))
                 Column(
                     modifier = Modifier
                         .weight(1f)
-                        .heightIn(min = 52.dp)
+                        .heightIn(min = 56.dp)
                         .clickable(onClick = onDetails),
                     verticalArrangement = Arrangement.Center,
                 ) {
@@ -354,15 +435,19 @@ private fun MiuixFontCard(
                     )
                     Spacer(Modifier.height(2.dp))
                     Text(
-                        listOf(font.format, font.size, font.date).filter { it.isNotBlank() }.joinToString(" · "),
+                        listOf(font.format, font.size, font.date)
+                            .filter { it.isNotBlank() }
+                            .joinToString(" · "),
                         color = tokens.textSecondary,
                         fontSize = 10.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                if (!active) {
-                    Spacer(Modifier.width(6.dp))
+                Spacer(Modifier.width(6.dp))
+                if (active) {
+                    MiuixLibraryPill("使用中", tokens.success)
+                } else {
                     Surface(
                         onClick = onDelete,
                         enabled = !busy,
@@ -382,19 +467,22 @@ private fun MiuixFontCard(
                 }
             }
 
-            Spacer(Modifier.height(13.dp))
+            Spacer(Modifier.height(14.dp))
             Surface(
                 modifier = Modifier.fillMaxWidth().clickable(onClick = onDetails),
-                shape = RoundedCornerShape(22.dp),
-                color = tokens.textPrimary.copy(alpha = .035f),
+                shape = RoundedCornerShape(23.dp),
+                color = tokens.textPrimary.copy(alpha = .038f),
             ) {
                 NativeFontPreview(
                     font = font,
-                    text = fontPreviewText(font),
+                    text = fontPreviewText(font, detailed = true),
                     axes = if (font.variable) mapOf("wght" to 400f) else emptyMap(),
-                    modifier = Modifier.fillMaxWidth().height(88.dp).padding(horizontal = 15.dp, vertical = 14.dp),
-                    textSizeSp = 22f,
-                    maxLines = 1,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(102.dp)
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    textSizeSp = 23f,
+                    maxLines = 2,
                 )
             }
 
@@ -404,13 +492,13 @@ private fun MiuixFontCard(
                     Icon(
                         Icons.Rounded.Warning,
                         contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error,
+                        tint = scheme.error,
                         modifier = Modifier.size(16.dp),
                     )
                     Spacer(Modifier.width(6.dp))
                     Text(
                         font.error,
-                        color = MaterialTheme.colorScheme.error,
+                        color = scheme.error,
                         fontSize = 10.sp,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
@@ -419,7 +507,7 @@ private fun MiuixFontCard(
             }
 
             Spacer(Modifier.height(12.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .34f))
+            HorizontalDivider(color = scheme.outlineVariant.copy(alpha = .30f))
             Spacer(Modifier.height(11.dp))
             MiuixCapabilityStrip(fontCapabilityLabel(font))
             Spacer(Modifier.height(10.dp))
@@ -434,9 +522,13 @@ private fun MiuixFontCard(
                     enabled = true,
                     onClick = onDetails,
                     modifier = Modifier.weight(1f),
+                    showArrow = false,
                 )
                 if (active) {
-                    MiuixCurrentAction(modifier = Modifier.weight(1f), color = tokens.success)
+                    MiuixCurrentAction(
+                        modifier = Modifier.weight(1f),
+                        color = tokens.success,
+                    )
                 } else {
                     MiuixCardAction(
                         label = "应用字体",
@@ -444,6 +536,7 @@ private fun MiuixFontCard(
                         enabled = font.valid && !busy,
                         onClick = onApply,
                         modifier = Modifier.weight(1f),
+                        showArrow = true,
                     )
                 }
             }
@@ -455,8 +548,8 @@ private fun MiuixFontCard(
 private fun MiuixCapabilityStrip(text: String) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.primary.copy(alpha = .075f),
+        shape = RoundedCornerShape(17.dp),
+        color = MaterialTheme.colorScheme.primary.copy(alpha = .08f),
     ) {
         Text(
             text = text,
@@ -479,6 +572,7 @@ private fun MiuixCardAction(
     enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    showArrow: Boolean,
 ) {
     val scheme = MaterialTheme.colorScheme
     val container = when {
@@ -488,16 +582,17 @@ private fun MiuixCardAction(
     }
     val content = when {
         primary && enabled -> scheme.onPrimary
-        primary -> scheme.onSurfaceVariant
+        primary -> scheme.onSurfaceVariant.copy(alpha = .68f)
         else -> scheme.onSurface
     }
     Surface(
         onClick = onClick,
         enabled = enabled,
-        modifier = modifier.defaultMinSize(minHeight = 44.dp),
-        shape = RoundedCornerShape(16.dp),
+        modifier = modifier.defaultMinSize(minHeight = 46.dp),
+        shape = RoundedCornerShape(17.dp),
         color = container,
         contentColor = content,
+        shadowElevation = if (primary && enabled) 3.dp else 0.dp,
     ) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 12.dp),
@@ -512,7 +607,7 @@ private fun MiuixCardAction(
                 maxLines = 1,
                 softWrap = false,
             )
-            if (primary) {
+            if (showArrow) {
                 Spacer(Modifier.width(4.dp))
                 Icon(
                     Icons.Rounded.ChevronRight,
@@ -528,8 +623,8 @@ private fun MiuixCardAction(
 @Composable
 private fun MiuixCurrentAction(modifier: Modifier = Modifier, color: Color) {
     Surface(
-        modifier = modifier.defaultMinSize(minHeight = 44.dp),
-        shape = RoundedCornerShape(16.dp),
+        modifier = modifier.defaultMinSize(minHeight = 46.dp),
+        shape = RoundedCornerShape(17.dp),
         color = color.copy(alpha = .11f),
     ) {
         Row(
@@ -537,7 +632,12 @@ private fun MiuixCurrentAction(modifier: Modifier = Modifier, color: Color) {
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Icon(Icons.Rounded.CheckCircle, contentDescription = null, tint = color, modifier = Modifier.size(17.dp))
+            Icon(
+                Icons.Rounded.CheckCircle,
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(17.dp),
+            )
             Spacer(Modifier.width(6.dp))
             Text(
                 "正在使用",
@@ -559,7 +659,10 @@ private fun MiuixLibraryNotice(message: String, error: Boolean, busy: Boolean = 
         color = if (error) MaterialTheme.colorScheme.errorContainer else tokens.cardBackground,
         shadowElevation = if (error) 0.dp else 4.dp,
     ) {
-        Row(Modifier.fillMaxWidth().padding(15.dp), verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(15.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             if (busy) {
                 CircularProgressIndicator(Modifier.size(19.dp), strokeWidth = 2.dp)
             } else {
@@ -587,7 +690,7 @@ private fun MiuixLibraryEmpty(state: FontLibraryUiState) {
     Card(
         shape = RoundedCornerShape(34.dp),
         colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 5.dp),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(34.dp),
@@ -599,7 +702,11 @@ private fun MiuixLibraryEmpty(state: FontLibraryUiState) {
                 color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
             ) {
                 Box(contentAlignment = Alignment.Center) {
-                    Icon(Icons.Rounded.FontDownload, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                    Icon(
+                        Icons.Rounded.FontDownload,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
                 }
             }
             Spacer(Modifier.height(13.dp))
@@ -617,7 +724,7 @@ private fun MiuixLibraryEmpty(state: FontLibraryUiState) {
                 when {
                     state.query.isNotBlank() -> "清空搜索或尝试其他关键词"
                     filtered -> "切换到“全部”查看其他字体"
-                    else -> "点击右下角导入按钮添加字体文件"
+                    else -> "使用页面上方的导入工具栏添加字体文件"
                 },
                 color = tokens.textSecondary,
                 fontSize = 11.sp,

--- a/scripts/font_library_ui_layout_test.sh
+++ b/scripts/font_library_ui_layout_test.sh
@@ -8,8 +8,11 @@ OVERLAY="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/Native
 SHELL="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuAppShell.kt"
 
 grep -q 'private fun MiuixCapabilityStrip' "$MIUIX"
+grep -q 'private fun MaterialCapabilityStrip' "$MATERIAL"
 grep -q 'label = "查看详情"' "$MIUIX"
 grep -q 'label = "应用字体"' "$MIUIX"
+grep -q 'label = "查看详情"' "$MATERIAL"
+grep -q 'label = "应用字体"' "$MATERIAL"
 grep -q 'topActions()' "$MIUIX"
 grep -q 'topActions()' "$MATERIAL"
 grep -q 'topActions: @Composable' "$ROUTE"
@@ -19,12 +22,23 @@ grep -q 'libraryDockClearance' "$SHELL"
 grep -q 'if (page == AppPage.Studio)' "$SHELL"
 ! grep -q 'page == AppPage.Library || page == AppPage.Studio' "$SHELL"
 
-CARD=$(sed -n '/private fun MiuixFontCard/,/private fun MiuixLibraryNotice/p' "$MIUIX")
-printf '%s\n' "$CARD" | grep -q 'Arrangement.spacedBy(10.dp)'
-printf '%s\n' "$CARD" | grep -q 'Modifier.weight(1f)'
-printf '%s\n' "$CARD" | grep -q 'softWrap = false'
-printf '%s\n' "$CARD" | grep -q 'MiuixCapabilityStrip(fontCapabilityLabel(font))'
-! printf '%s\n' "$CARD" | grep -q 'Spacer(Modifier.weight(1f))'
+MIUIX_CARD=$(sed -n '/private fun MiuixFontCard/,/private fun MiuixLibraryNotice/p' "$MIUIX")
+printf '%s\n' "$MIUIX_CARD" | grep -q 'Arrangement.spacedBy(10.dp)'
+printf '%s\n' "$MIUIX_CARD" | grep -q 'Modifier.weight(1f)'
+printf '%s\n' "$MIUIX_CARD" | grep -q 'softWrap = false'
+printf '%s\n' "$MIUIX_CARD" | grep -q 'MiuixCapabilityStrip(fontCapabilityLabel(font))'
+printf '%s\n' "$MIUIX_CARD" | grep -q 'fontPreviewText(font, detailed = true)'
+printf '%s\n' "$MIUIX_CARD" | grep -q 'maxLines = 2'
+! printf '%s\n' "$MIUIX_CARD" | grep -q 'Spacer(Modifier.weight(1f))'
+
+MATERIAL_CARD=$(sed -n '/private fun MaterialFontCard/,/private fun MaterialLibraryMessage/p' "$MATERIAL")
+printf '%s\n' "$MATERIAL_CARD" | grep -q 'Arrangement.spacedBy(10.dp)'
+printf '%s\n' "$MATERIAL_CARD" | grep -q 'Modifier.weight(1f)'
+printf '%s\n' "$MATERIAL_CARD" | grep -q 'softWrap = false'
+printf '%s\n' "$MATERIAL_CARD" | grep -q 'MaterialCapabilityStrip(fontCapabilityLabel(font))'
+printf '%s\n' "$MATERIAL_CARD" | grep -q 'fontPreviewText(font, detailed = true)'
+printf '%s\n' "$MATERIAL_CARD" | grep -q 'maxLines = 2'
+! printf '%s\n' "$MATERIAL_CARD" | grep -q 'Spacer(Modifier.weight(1f))'
 
 DOCK=$(sed -n '/private fun MiuixAppDock/,$p' "$SHELL")
 printf '%s\n' "$DOCK" | grep -q 'height(54.dp)'


### PR DESCRIPTION
## 用户反馈

Material 字体库仍沿用旧的单行底部操作布局，长能力标签会挤压“详情”和“应用字体”，在窄屏上出现竖排、错位和卡片层级混乱；MIUIx 虽已修过操作区，但预览、标题、状态和动作尺寸仍未与 Material 同步。

## 本次调整

- Material 字体卡片改为“标题区 / 双行预览 / 独立能力条 / 两个等宽操作按钮”的稳定层级；
- 删除能力标签、详情按钮和应用按钮在同一行争抢宽度的旧布局；
- 两套风格统一长标题两行省略、元数据单行、省略保护和 56dp 标题区；
- 两套风格统一 102dp 双行真实字体预览，避免样张裁切；
- “查看详情 / 应用字体 / 正在使用”固定单行、等宽和最小高度；
- 删除按钮改为独立方形次级操作，活动字体显示轻量状态胶囊；
- Material 补齐分区标题、系统字体卡片、搜索筛选卡片和概览层级；
- MIUIx 调整圆角、阴影、卡片间距、预览背景和按钮比例；
- 更新窄屏源码回归，同时约束 Material 与 MIUIx，不允许重新退回能力标签和按钮同排争宽。

## 验证计划

- Font library UI layout regression；
- Android Lint 与 Kotlin 单元测试；
- Debug APK 与单模块候选构建；
- 字体引擎 smoke tests。
