### PR TITLE
fix: recover Magic Mount font tasks

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModel.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModel.kt
@@ -42,7 +42,7 @@ internal data class TaskCenterItem(
 
 private val structuredLog = Regex("^\\[([^]]+)]\\s+\\[([^]]+)]\\s+(.*)$")
 private val percentPattern = Regex("(?:^|\\D)(\\d{1,3})%(?:\\D|$)")
-private val internalMixTelemetry = Regex("^\\[[^]]+)]\\s+mix\\s+(?:stage=|start:)", RegexOption.IGNORE_CASE)
+private val internalMixTelemetry = Regex("^\\[[^]]+]\\s+mix\\s+(?:stage=|start:)", RegexOption.IGNORE_CASE)
 
 internal fun taskKindFor(message: String, type: String = ""): TaskKind {
     val normalized = "$type $message".lowercase()

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModel.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModel.kt
@@ -42,6 +42,7 @@ internal data class TaskCenterItem(
 
 private val structuredLog = Regex("^\\[([^]]+)]\\s+\\[([^]]+)]\\s+(.*)$")
 private val percentPattern = Regex("(?:^|\\D)(\\d{1,3})%(?:\\D|$)")
+private val internalMixTelemetry = Regex("^\\[[^]]+)]\\s+mix\\s+(?:stage=|start:)", RegexOption.IGNORE_CASE)
 
 internal fun taskKindFor(message: String, type: String = ""): TaskKind {
     val normalized = "$type $message".lowercase()
@@ -83,6 +84,10 @@ internal fun parseTaskLogItems(content: String, limit: Int = 18): List<TaskCente
     val candidates = content.lineSequence().mapIndexedNotNull { index, raw ->
         val line = raw.trim()
         if (line.isBlank()) return@mapIndexedNotNull null
+        // Stage telemetry describes one mix task. The persisted current task already exposes its
+        // latest stage, so treating every telemetry line as a task permanently inflates the active
+        // count (for example, nine stages became "9 个任务正在处理").
+        if (internalMixTelemetry.containsMatchIn(line)) return@mapIndexedNotNull null
         val match = structuredLog.matchEntire(line)
         val time = match?.groupValues?.getOrNull(1).orEmpty()
         val level = match?.groupValues?.getOrNull(2).orEmpty()

--- a/android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModelTest.kt
+++ b/android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/logs/TaskCenterModelTest.kt
@@ -59,4 +59,17 @@ class TaskCenterModelTest {
         assertEquals(TaskPhase.RUNNING, task.phase)
         assertEquals(68, task.progress)
     }
+
+    @Test
+    fun internalMixStagesDoNotBecomeMultipleRunningTasks() {
+        val tasks = parseTaskLogItems(
+            """
+            [2026-07-22 19:02:40] mix stage=initialize percent=1 message=正在初始化字体组合任务
+            [2026-07-22 19:02:45] mix stage=mapping percent=91 message=正在生成系统字体映射
+            [2026-07-22 19:02:50] mix stage=mount-sync percent=96 message=正在同步元模块字体负载
+            """.trimIndent(),
+        )
+
+        assertTrue(tasks.isEmpty())
+    }
 }

--- a/common/app_bridge.sh
+++ b/common/app_bridge.sh
@@ -21,6 +21,7 @@ AXES_TASK_FILE="$MODDIR/config/axes_task.conf"
 SWITCH_TASK_FILE="$MODDIR/config/switch_task.conf"
 TEXT_REBOOT_REQUIRED="$MODDIR/config/text_reboot_required.conf"
 [ -f "$MODDIR/common/util_functions.sh" ] && . "$MODDIR/common/util_functions.sh"
+[ -f "$MODDIR/common/mount_compat.sh" ] && . "$MODDIR/common/mount_compat.sh"
 
 json_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '
@@ -47,11 +48,17 @@ root_manager() {
 }
 
 mount_engine() {
-    if { [ -d /data/adb/modules/mountify ] && [ ! -f /data/adb/modules/mountify/disable ] && [ ! -f /data/adb/modules/mountify/remove ]; } || [ -d /data/adb/mountify ]; then
-        printf 'Mountify'
-    else
-        printf '原生模块挂载'
+    if type luoshu_detect_mount_engine >/dev/null 2>&1; then
+        case "$(luoshu_detect_mount_engine)" in
+            magic-mount|magic-mount-rs) printf 'Magic Mount' ;;
+            mountify) printf 'Mountify' ;;
+            meta-overlayfs|dual-dir-metamodule) printf 'Meta OverlayFS' ;;
+            hybrid-mount) printf 'Hybrid Mount' ;;
+            *) printf '原生模块挂载' ;;
+        esac
+        return
     fi
+    printf '原生模块挂载'
 }
 
 select_task_file() {

--- a/common/font_mix.sh
+++ b/common/font_mix.sh
@@ -505,7 +505,9 @@ apply_mix() {
     fi
     mix_stage mount-sync '正在同步元模块字体负载' 96
     if type luoshu_sync_mount_payload >/dev/null 2>&1 && ! luoshu_sync_mount_payload; then
-        set_mix_error '元模块真实挂载目录同步失败，已恢复旧字体'
+        _mount_detail=$(sed -n 's/^detail=//p' "$CONFIG_DIR/mount_compat.conf" 2>/dev/null | head -n1 | tr -d '\r')
+        [ -n "$_mount_detail" ] || _mount_detail='元模块真实挂载目录同步失败'
+        set_mix_error "${_mount_detail}，已恢复旧字体"
         return 7
     fi
     mix_stage manifest '正在生成安全启动清单' 98

--- a/common/mount_compat.sh
+++ b/common/mount_compat.sh
@@ -40,6 +40,25 @@ _luoshu_module_prop_id() {
     sed -n 's/^id=//p' "$1/module.prop" 2>/dev/null | head -n1 | tr -d '\r\n'
 }
 
+# Magic Mount has shipped under several module ids (including RC builds).  Detect it from
+# module metadata and its persistent configuration instead of relying on two directory names.
+luoshu_magic_mount_present() {
+    for _lmmp_prop in /data/adb/modules/*/module.prop; do
+        [ -f "$_lmmp_prop" ] || continue
+        _lmmp_dir=${_lmmp_prop%/*}
+        [ ! -e "$_lmmp_dir/disable" ] && [ ! -e "$_lmmp_dir/remove" ] || continue
+        _lmmp_meta=$(sed -n 's/^\(id\|name\|description\)=/\1=/p' "$_lmmp_prop" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr '\n' ' ')
+        case "$_lmmp_meta" in
+            *magic_mount*|*magic-mount*|*magic\ mount*|*id=meta-mm*) return 0 ;;
+        esac
+    done
+    # Some RC packages keep the stable config path while changing their module id.
+    [ -f /data/adb/magic_mount/config.toml ] && {
+        [ -x /data/adb/metamodule/meta-mm ] || [ -x /data/adb/metamodule/meta-mm-rs ] || \
+        [ -x /data/adb/modules/magic_mount_rs/meta-mm ] || [ -x /data/adb/modules/meta-mm/meta-mm ]
+    }
+}
+
 luoshu_detect_mount_engine() {
     [ -z "${LUOSHU_META_TEST_ENGINE:-}" ] || { printf '%s\n' "$LUOSHU_META_TEST_ENGINE"; return 0; }
 
@@ -65,8 +84,8 @@ luoshu_detect_mount_engine() {
         printf 'hybrid-mount\n'
         return 0
     fi
-    if [ -d /data/adb/modules/magic_mount_rs ] || [ -d /data/adb/modules/magic-mount-rs ]; then
-        printf 'magic-mount-rs\n'
+    if luoshu_magic_mount_present; then
+        printf 'magic-mount\n'
         return 0
     fi
     printf 'native-module-mount\n'
@@ -154,10 +173,32 @@ luoshu_mountify_module_selected() {
 }
 
 LUOSHU_MOUNT_PREFLIGHT_ERROR=''
+luoshu_recover_magic_mount_markers() {
+    _lrmm_engine="$1"
+    [ "$_lrmm_engine" = magic-mount ] || [ "$_lrmm_engine" = magic-mount-rs ] || return 0
+
+    # A previous Mountify/native-mount attempt can leave these markers behind.  Starting an
+    # explicit LuoShu font transaction is an intentional retry, so clear only LuoShu's own
+    # recoverable mount markers.  disable/remove remain hard failures.
+    _lrmm_cleared=''
+    for _lrmm_marker in skip_mount mount_error; do
+        [ -e "$LUOSHU_MOUNT_MODDIR/$_lrmm_marker" ] || continue
+        rm -f "$LUOSHU_MOUNT_MODDIR/$_lrmm_marker" 2>/dev/null || {
+            LUOSHU_MOUNT_PREFLIGHT_ERROR="无法清理 Magic Mount 遗留标记：$_lrmm_marker"
+            return 1
+        }
+        _lrmm_cleared="${_lrmm_cleared}${_lrmm_cleared:+,}$_lrmm_marker"
+    done
+    [ -z "$_lrmm_cleared" ] || luoshu_mount_log "Magic Mount 重试已清理洛书遗留标记：$_lrmm_cleared"
+    return 0
+}
+
 luoshu_mount_preflight() {
     LUOSHU_MOUNT_PREFLIGHT_ERROR=''
     _lmp_engine=$(luoshu_detect_mount_engine)
     _lmp_manager=$(luoshu_detect_root_manager)
+
+    luoshu_recover_magic_mount_markers "$_lmp_engine" || return 1
 
     for _lmp_marker in disable remove mount_error; do
         if [ -e "$LUOSHU_MOUNT_MODDIR/$_lmp_marker" ]; then
@@ -167,7 +208,7 @@ luoshu_mount_preflight() {
     done
 
     case "$_lmp_engine" in
-        meta-overlayfs|dual-dir-metamodule|hybrid-mount|magic-mount-rs)
+        meta-overlayfs|dual-dir-metamodule|hybrid-mount|magic-mount|magic-mount-rs)
             if [ -e "$LUOSHU_MOUNT_MODDIR/skip_mount" ]; then
                 LUOSHU_MOUNT_PREFLIGHT_ERROR='检测到 skip_mount，当前元模块会跳过洛书负载'
                 return 1

--- a/scripts/meta_module_sync_test.sh
+++ b/scripts/meta_module_sync_test.sh
@@ -41,8 +41,21 @@ export LUOSHU_META_TEST_ENGINE
 luoshu_sync_mount_payload Demo
 [ ! -e "$LUOSHU_META_TEST_ROOT/LuoShu" ]
 
+# Magic Mount reads the canonical module tree. An explicit font transaction must recover stale
+# skip_mount/mount_error markers left by a previous mount engine, then wait for reboot verification.
+touch "$MODDIR/skip_mount" "$MODDIR/mount_error"
+LUOSHU_META_TEST_ENGINE=magic-mount
+export LUOSHU_META_TEST_ENGINE
+luoshu_sync_mount_payload Demo
+[ ! -e "$MODDIR/skip_mount" ]
+[ ! -e "$MODDIR/mount_error" ]
+[ ! -e "$LUOSHU_META_TEST_ROOT/LuoShu" ]
+[ "$(sed -n 's/^engine=//p' "$MODDIR/config/mount_compat.conf")" = magic-mount ]
+
 # skip_mount is an actual compatibility failure for KernelSU metamodules.
 touch "$MODDIR/skip_mount"
+LUOSHU_META_TEST_ENGINE=meta-overlayfs
+export LUOSHU_META_TEST_ENGINE
 if luoshu_sync_mount_payload Demo; then
     echo 'skip_mount was not rejected' >&2
     exit 1

--- a/scripts/mount_compat_test.sh
+++ b/scripts/mount_compat_test.sh
@@ -45,6 +45,17 @@ MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=mountify LUOSHU_ME
 test ! -e "$META/LuoShu"
 grep -q '^engine=mountify$' "$MODULE/config/mount_compat.conf"
 
+# Magic Mount RC/RS is a direct-source engine and explicit retries clear stale LuoShu markers.
+touch "$MODULE/skip_mount" "$MODULE/mount_error"
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_META_TEST_ROOT="$META" sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_sync_mount_payload Demo
+'
+test ! -e "$MODULE/skip_mount"
+test ! -e "$MODULE/mount_error"
+test ! -e "$META/LuoShu"
+grep -q '^engine=magic-mount$' "$MODULE/config/mount_compat.conf"
+
 # Runtime syncing remains transaction-only. Never mirror from early boot scripts.
 grep -q 'common/mount_compat.sh' "$ROOT/common/font_mix.sh"
 grep -q 'luoshu_sync_mount_payload' "$ROOT/common/font_mix.sh"
@@ -59,6 +70,7 @@ cp -R "$ROOT/." "$STAGE/"
 rm -rf "$STAGE/.git" "$STAGE/dist" "$STAGE/common/python" 2>/dev/null || true
 ! find "$STAGE" -type f \( -name skip_mount -o -name skip_mountify \) | grep -q .
 sh -n "$ROOT/common/font_mix.sh"
+sh -n "$ROOT/common/app_bridge.sh"
 sh -n "$ROOT/post-fs-data.sh"
 sh -n "$ROOT/service.sh"
 


### PR DESCRIPTION
## 修复内容

- 按模块元数据识别 Magic Mount RC/RS，不再依赖两个固定目录名
- 用户主动执行字体事务时，清理洛书自身遗留的 `skip_mount` / `mount_error`，让 Magic Mount 在重启时重新读取标准模块目录
- 保留启动挂载探针，重启后仍会验证真实 `/system` 挂载，失败时继续安全回滚
- 96% 失败时显示 `mount_compat.conf` 的具体原因
- 任务中心忽略内部 `mix stage` 遥测，避免同一个组合任务显示成 9 个进行中任务
- App 状态页显示真实 Magic Mount / Mountify / Meta OverlayFS / Hybrid Mount 类型

## 根因

用户从先前挂载方案切换到 Magic Mount RC 后，洛书可能保留旧的 `skip_mount` 或 `mount_error`。现有预检将其当成不可恢复错误，并在 96% 回滚。同时任务中心把每个组合阶段日志都识别为独立的运行中任务。

## 验证

- `scripts/mount_compat_test.sh`
- `scripts/meta_module_sync_test.sh`
- `scripts/background_mix_worker_test.sh`
- `scripts/nested_mix_task_handoff_test.sh`
- `scripts/mix_finalize_performance_test.sh`
- Shell 语法检查与 `git diff --check`

完整 ARM64 Python/Android 构建由 GitHub Actions 准备运行时后验证。