### PR TITLE
chore: run LuoShu CI smoke test

### DIFF
--- a/.github/ci-smoke-20260722.md
+++ b/.github/ci-smoke-20260722.md
@@ -1,0 +1,3 @@
+# CI smoke trigger
+
+Temporary branch-only marker used to trigger the LuoShu pull-request CI smoke test on 2026-07-22. This file is not intended to be merged.


### PR DESCRIPTION
Closed because this was only a temporary CI marker based on v2.0.2. The intended candidate is LuoShu v2.0.3-rc1 / 20003, so this PR must not be merged.