### PR TITLE
[已撤回] fix: Play 商店动态 Google Sans

### DIFF
--- a/RELEASE_NOTES_v2.1.3.md
+++ b/RELEASE_NOTES_v2.1.3.md
@@ -1,0 +1,19 @@
+<!-- prerelease -->
+# LuoShu v2.1.3
+
+## 修复
+
+- 修复 Android 12+、ColorOS 及其他启用可更新字体服务的系统中，Play 商店搜索框、Gmail 等 Google 应用继续使用 `/data/fonts/files` 内置 Google Sans、绕过洛书字体的问题。
+- 洛书会在启动早期识别动态字体配置，只隔离 `google-sans`、`google-sans-text`、`google-sans-flex`、`product-sans` 及其 Medium/Bold 命名字体族，再将这些名字按 400/500/700 字重指向当前洛书字体。
+- 不覆盖或删除 `/data/fonts/files` 中由系统签名及 fs-verity 管理的字体文件；动态 Emoji、图标字体和其他下载字体保持原样。
+- 切换字体后无需运行任何外置脚本，完整重启即自动应用；切回系统默认字体或卸载洛书时自动解除配置覆盖。
+- 自动恢复旧实验版本可能留下的 `.luoshu-bak` 动态字体缓存副本。
+
+## 重点验证
+
+- ColorOS Android 16 / API 36，运行时 `google-sans*` 原本来自 `/data/fonts/files` 的设备。
+- 重启后检查 Play 商店搜索框的英文和数字是否跟随当前洛书字体。
+- 检查动态 NotoColorEmoji 与其他非 Google Sans 字体仍由系统正常加载。
+- 检查切回默认字体并重启后，动态字体配置完整恢复。
+
+> 本版修复依据 ColorOS 真机字体配置和 `dumpsys font` 链路完成；发布前已完成脚本语法、XML 过滤、命名字体注入和安全恢复测试，最终视觉效果仍以不同 ROM 真机验证为准。

--- a/common/font_provider_cache.sh
+++ b/common/font_provider_cache.sh
@@ -1,107 +1,411 @@
 #!/system/bin/sh
-# LuoShu downloadable-fonts provider cache hijack.
+# LuoShu Android downloadable-font named-family bridge.
 #
-# Play 商店、Gmail 等 Google 系应用不读 /system 或 /product 下的字体文件，
-# 而是通过 GMS 的 Fonts Provider（Downloadable Fonts）加载字体，
-# 缓存落在 /data/fonts/files/（按内容哈希命名）。系统分区的文件替换对它们无效。
-# 本脚本把已归一化的用户字体同步进该缓存，并 force-stop 相关进程使其重新加载。
+# Android 12+ FontManagerService appends named families from
+# /data/fonts/config/config.xml after /system/etc/fonts.xml. Later definitions win,
+# so Google Sans downloaded by GMS can bypass LuoShu's systemless font payload.
+#
+# LuoShu does not overwrite signed /data/fonts/files content. While a custom font is
+# active, this helper:
+#   1. creates a read-only view of config.xml without Google/Product Sans families;
+#   2. creates a read-only view of fonts.xml that defines those family names with the
+#      currently mounted LuoShu system fonts.
+# Signed font files, fs-verity metadata, downloadable Emoji and unrelated families
+# remain untouched.
 set +e
 
-LUOSHU_PROVIDER_DIR="${LUOSHU_PROVIDER_DIR:-/data/fonts/files}"
+_luoshu_provider_module() {
+    printf '%s\n' "${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
+}
+
+_luoshu_provider_config() {
+    printf '%s/config\n' "$(_luoshu_provider_module)"
+}
+
+LUOSHU_PROVIDER_CONFIG_XML="${LUOSHU_PROVIDER_CONFIG_XML:-/data/fonts/config/config.xml}"
+LUOSHU_PROVIDER_SYSTEM_XML="${LUOSHU_PROVIDER_SYSTEM_XML:-/system/etc/fonts.xml}"
+LUOSHU_PROVIDER_OVERLAY_DIR="${LUOSHU_PROVIDER_OVERLAY_DIR:-/data/fonts/config}"
+LUOSHU_PROVIDER_CONFIG_OVERLAY="${LUOSHU_PROVIDER_CONFIG_OVERLAY:-$LUOSHU_PROVIDER_OVERLAY_DIR/.luoshu-provider-config.xml}"
+LUOSHU_PROVIDER_SYSTEM_OVERLAY="${LUOSHU_PROVIDER_SYSTEM_OVERLAY:-$LUOSHU_PROVIDER_OVERLAY_DIR/.luoshu-system-fonts.xml}"
+LUOSHU_PROVIDER_STATE="${LUOSHU_PROVIDER_STATE:-$(_luoshu_provider_config)/font-provider-overlay.conf}"
+LUOSHU_PROVIDER_REPORT="${LUOSHU_PROVIDER_REPORT:-$(_luoshu_provider_config)/font-provider-overlay-report.conf}"
 LUOSHU_PROVIDER_BACKUP_SUFFIX=".luoshu-bak"
 
 luoshu_provider_log() {
-    _lpl_msg="$1"
-    _lpl_mod="${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
+    _lpl_mod="$(_luoshu_provider_module)"
     mkdir -p "$_lpl_mod/logs" 2>/dev/null || true
-    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" "$_lpl_msg" >> "$_lpl_mod/logs/provider_cache.log" 2>/dev/null || true
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" "$*" \
+        >> "$_lpl_mod/logs/provider_cache.log" 2>/dev/null || true
 }
 
-# 尽力识别 downloadable emoji 字体（如 NotoColorEmoji 的 provider 下载副本），
-# 它们绝不能被文字字体替换，否则使用 downloadable emoji 的应用会变方块。
-# 识别不了（无 Python 环境）时按文字字体处理——Play 商店链路本来就没有 emoji 缓存。
-_luoshu_provider_family_is_emoji() {
-    _lpie_file="$1"
-    _lpie_mod="${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
-    _lpie_py="$_lpie_mod/common/python/bin/luoshu-python"
-    [ -x "$_lpie_py" ] || return 1
-    _lpie_pyroot="$_lpie_mod/common/python"
-    _lpie_kind=$(PYTHONHOME="$_lpie_pyroot" \
-        PYTHONPATH="$_lpie_pyroot/lib/python3.14:$_lpie_pyroot/lib/python3.14/site-packages" \
-        LD_LIBRARY_PATH="$_lpie_pyroot/lib:$_lpie_pyroot/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-        "$_lpie_py" - "$_lpie_file" <<'PY_LUOSHU_EMOJI_PROBE' 2>/dev/null
-import sys
-from fontTools.ttLib import TTFont, TTCollection
-try:
-    src = sys.argv[1]
-    with open(src, "rb") as fh:
-        coll = fh.read(4) == b"ttcf"
-    font = (TTCollection(src, lazy=True).fonts[0] if coll else TTFont(src, lazy=True))
-    names = " ".join(r.toUnicode() for r in font["name"].names if r.nameID in (1, 4, 6, 16)).lower()
-    print("emoji" if "emoji" in names else "text")
-except Exception:
-    print("unknown")
-PY_LUOSHU_EMOJI_PROBE
-)
-    [ "$_lpie_kind" = "emoji" ]
+_luoshu_provider_python() {
+    _lpp_mod="$(_luoshu_provider_module)"
+    _lpp_root="$_lpp_mod/common/python"
+    _lpp_bin="$_lpp_root/bin/luoshu-python"
+    [ -x "$_lpp_bin" ] || return 1
+    PYTHONHOME="$_lpp_root" \
+    PYTHONPATH="$_lpp_root/lib/python3.14:$_lpp_root/lib/python3.14/site-packages" \
+    LD_LIBRARY_PATH="$_lpp_root/lib:$_lpp_root/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+        "$_lpp_bin" "$@"
 }
 
-# luoshu_provider_cache_sync <归一化后的字体文件>
-# 备份原始缓存（仅首次），再把缓存内所有 ttf/otf 替换为用户字体。
-luoshu_provider_cache_sync() {
-    _lpcs_font="$1"
-    [ -f "$_lpcs_font" ] || return 0
-    [ -d "$LUOSHU_PROVIDER_DIR" ] || return 0
+_luoshu_provider_mount_is_ours() {
+    _lpmi_target="$1"
+    _lpmi_source="$2"
+    [ -r /proc/self/mountinfo ] || return 1
+    awk -v target="$_lpmi_target" -v source="$_lpmi_source" '
+        $5 == target && index($0, source) { found=1 }
+        END { exit !found }
+    ' /proc/self/mountinfo 2>/dev/null
+}
 
-    _lpcs_count=0
-    for _lpcs_f in "$LUOSHU_PROVIDER_DIR"/*; do
-        [ -f "$_lpcs_f" ] || continue
-        case "$_lpcs_f" in *"$LUOSHU_PROVIDER_BACKUP_SUFFIX") continue ;; esac
-        # 只处理字体文件（magic: 00010000 / OTTO / ttcf）
-        _lpcs_magic=$(dd if="$_lpcs_f" bs=4 count=1 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')
-        case "$_lpcs_magic" in
-            00010000|4f54544f|74746366) ;;  # ttf / otf / ttc
-            *) continue ;;
-        esac
-        if _luoshu_provider_family_is_emoji "$_lpcs_f"; then
-            luoshu_provider_log "跳过 downloadable emoji 字体：${_lpcs_f##*/}"
-            continue
-        fi
-        if [ ! -f "${_lpcs_f}${LUOSHU_PROVIDER_BACKUP_SUFFIX}" ]; then
-            cp -f "$_lpcs_f" "${_lpcs_f}${LUOSHU_PROVIDER_BACKUP_SUFFIX}" 2>/dev/null || true
-        fi
-        if cp -f "$_lpcs_font" "$_lpcs_f" 2>/dev/null; then
-            chmod 644 "$_lpcs_f" 2>/dev/null || true
-            _lpcs_count=$((_lpcs_count + 1))
-        fi
-    done
-    [ "$_lpcs_count" -gt 0 ] || return 0
-
-    # 已缓存 Typeface 的进程不会重读文件，force-stop 让其下次启动走新缓存
-    for _lpcs_pkg in com.android.vending com.google.android.gms; do
-        am force-stop "$_lpcs_pkg" >/dev/null 2>&1 || true
-    done
-    luoshu_provider_log "已劫持 $_lpcs_count 个 provider 缓存字体并重启 GMS/Play"
+_luoshu_provider_unmount_one() {
+    _lpu_target="$1"
+    _lpu_source="$2"
+    if _luoshu_provider_mount_is_ours "$_lpu_target" "$_lpu_source"; then
+        umount "$_lpu_target" 2>/dev/null || \
+            umount -l "$_lpu_target" 2>/dev/null || return 1
+    fi
     return 0
 }
 
-# luoshu_provider_cache_restore：恢复默认字体时还原原始缓存。
-luoshu_provider_cache_restore() {
-    [ -d "$LUOSHU_PROVIDER_DIR" ] || return 0
-    _lpcr_count=0
-    for _lpcr_bak in "$LUOSHU_PROVIDER_DIR"/*"$LUOSHU_PROVIDER_BACKUP_SUFFIX"; do
-        [ -f "$_lpcr_bak" ] || continue
-        _lpcr_orig="${_lpcr_bak%$LUOSHU_PROVIDER_BACKUP_SUFFIX}"
-        if mv -f "$_lpcr_bak" "$_lpcr_orig" 2>/dev/null; then
-            chmod 644 "$_lpcr_orig" 2>/dev/null || true
-            _lpcr_count=$((_lpcr_count + 1))
+_luoshu_provider_unmount_all() {
+    # Reverse order: dynamic config was mounted last.
+    _luoshu_provider_unmount_one "$LUOSHU_PROVIDER_CONFIG_XML" "$LUOSHU_PROVIDER_CONFIG_OVERLAY" || true
+    _luoshu_provider_unmount_one "$LUOSHU_PROVIDER_SYSTEM_XML" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" || true
+}
+
+_luoshu_provider_restore_legacy_files() {
+    [ -d /data/fonts/files ] || return 0
+    _lpr_marker="$(_luoshu_provider_config)/.provider-legacy-restored.$$"
+    rm -f "$_lpr_marker" 2>/dev/null || true
+    find /data/fonts/files -type f -name "*${LUOSHU_PROVIDER_BACKUP_SUFFIX}" 2>/dev/null |
+    while IFS= read -r _lpr_backup; do
+        [ -f "$_lpr_backup" ] || continue
+        _lpr_original="${_lpr_backup%$LUOSHU_PROVIDER_BACKUP_SUFFIX}"
+        if cp -f "$_lpr_backup" "$_lpr_original" 2>/dev/null; then
+            chmod 0644 "$_lpr_original" 2>/dev/null || true
+            rm -f "$_lpr_backup" 2>/dev/null || true
+            printf '.\n' >> "$_lpr_marker" 2>/dev/null
         fi
     done
-    if [ "$_lpcr_count" -gt 0 ]; then
-        for _lpcr_pkg in com.android.vending com.google.android.gms; do
-            am force-stop "$_lpcr_pkg" >/dev/null 2>&1 || true
-        done
-        luoshu_provider_log "已恢复 $_lpcr_count 个 provider 缓存字体"
+    if [ -f "$_lpr_marker" ]; then
+        _lpr_count=$(wc -l < "$_lpr_marker" 2>/dev/null | tr -d '[:space:]')
+        rm -f "$_lpr_marker" 2>/dev/null || true
+        luoshu_provider_log "已恢复旧版直接写入的 ${_lpr_count:-0} 个动态字体缓存文件"
     fi
+}
+
+_luoshu_provider_dynamic_google_present() {
+    [ -f "$LUOSHU_PROVIDER_CONFIG_XML" ] || return 1
+    grep -Eiq 'google[-_ ]?sans|product[-_ ]?sans' "$LUOSHU_PROVIDER_CONFIG_XML" 2>/dev/null && return 0
+    [ -d /data/fonts/files ] || return 1
+    find /data/fonts/files -type f \( -iname 'GoogleSans*' -o -iname 'ProductSans*' \) \
+        -print -quit 2>/dev/null | grep -q .
+}
+
+_luoshu_provider_valid_font() {
+    _lpvf="$1"
+    [ -f "$_lpvf" ] || return 1
+    _lpvf_size=$(wc -c < "$_lpvf" 2>/dev/null | tr -d '[:space:]')
+    case "$_lpvf_size" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$_lpvf_size" -ge 1024 ] || return 1
+    _lpvf_magic=$(dd if="$_lpvf" bs=4 count=1 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')
+    case "$_lpvf_magic" in 00010000|4f54544f|74746366) return 0 ;; *) return 1 ;; esac
+}
+
+_luoshu_provider_pick_font() {
+    for _lppf in "$@"; do
+        _luoshu_provider_valid_font "$_lppf" || continue
+        printf '%s\n' "${_lppf##*/}"
+        return 0
+    done
+    return 1
+}
+
+_luoshu_provider_select_fonts() {
+    LUOSHU_PROVIDER_REGULAR=$(_luoshu_provider_pick_font \
+        /system/fonts/LuoShu-400.ttf \
+        /system/fonts/GoogleSans-Regular.ttf \
+        /system/fonts/GoogleSansText-Regular.ttf \
+        /system/fonts/Roboto-Regular.ttf \
+        /system/fonts/SysFont-Regular.ttf) || return 1
+
+    LUOSHU_PROVIDER_MEDIUM=$(_luoshu_provider_pick_font \
+        /system/fonts/LuoShu-500.ttf \
+        /system/fonts/GoogleSans-Medium.ttf \
+        /system/fonts/GoogleSansText-Medium.ttf \
+        /system/fonts/SourceSansPro-SemiBold.ttf \
+        "/system/fonts/$LUOSHU_PROVIDER_REGULAR") || LUOSHU_PROVIDER_MEDIUM="$LUOSHU_PROVIDER_REGULAR"
+
+    LUOSHU_PROVIDER_BOLD=$(_luoshu_provider_pick_font \
+        /system/fonts/LuoShu-700.ttf \
+        /system/fonts/GoogleSans-Bold.ttf \
+        /system/fonts/GoogleSansText-Bold.ttf \
+        /system/fonts/SourceSansPro-Bold.ttf \
+        "/system/fonts/$LUOSHU_PROVIDER_MEDIUM" \
+        "/system/fonts/$LUOSHU_PROVIDER_REGULAR") || LUOSHU_PROVIDER_BOLD="$LUOSHU_PROVIDER_REGULAR"
+
+    export LUOSHU_PROVIDER_REGULAR LUOSHU_PROVIDER_MEDIUM LUOSHU_PROVIDER_BOLD
+    return 0
+}
+
+_luoshu_provider_generate_overlays() {
+    _lpgo_dynamic_input="$1"
+    _lpgo_dynamic_output="$2"
+    _lpgo_system_input="$3"
+    _lpgo_system_output="$4"
+    _lpgo_report="$5"
+
+    rm -f "$_lpgo_dynamic_output" "$_lpgo_system_output" "$_lpgo_report" 2>/dev/null || true
+    _luoshu_provider_python - \
+        "$_lpgo_dynamic_input" "$_lpgo_dynamic_output" \
+        "$_lpgo_system_input" "$_lpgo_system_output" \
+        "$LUOSHU_PROVIDER_REGULAR" "$LUOSHU_PROVIDER_MEDIUM" "$LUOSHU_PROVIDER_BOLD" \
+        "$_lpgo_report" <<'PY_LUOSHU_PROVIDER'
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+dynamic_input = Path(sys.argv[1])
+dynamic_output = Path(sys.argv[2])
+system_input = Path(sys.argv[3])
+system_output = Path(sys.argv[4])
+regular_name = sys.argv[5]
+medium_name = sys.argv[6]
+bold_name = sys.argv[7]
+report_path = Path(sys.argv[8])
+
+BLOCKED = re.compile(r"(google[-_\s]*sans|product[-_\s]*sans)", re.I)
+FAMILIES = (
+    ("google-sans", 400, regular_name),
+    ("google-sans-text", 400, regular_name),
+    ("google-sans-flex", 400, regular_name),
+    ("google-sans-display", 400, regular_name),
+    ("product-sans", 400, regular_name),
+    ("google-sans-medium", 500, medium_name),
+    ("google-sans-text-medium", 500, medium_name),
+    ("google-sans-display-medium", 500, medium_name),
+    ("google-sans-bold", 700, bold_name),
+    ("google-sans-text-bold", 700, bold_name),
+    ("google-sans-display-bold", 700, bold_name),
+)
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def normalized(value: str) -> str:
+    return re.sub(r"[\s_]+", "-", value.strip().lower())
+
+
+def blocked(value: str) -> bool:
+    return bool(BLOCKED.search(normalized(value)))
+
+
+def namespace_tag(root: ET.Element, name: str) -> str:
+    if root.tag.startswith("{") and "}" in root.tag:
+        return root.tag.split("}", 1)[0] + "}" + name
+    return name
+
+
+def atomic_write(tree: ET.ElementTree, output: Path, mode: int) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    ET.indent(tree, space="    ")
+    fd, temporary = tempfile.mkstemp(prefix=f".{output.name}.", dir=output.parent)
+    os.close(fd)
+    try:
+        tree.write(temporary, encoding="utf-8", xml_declaration=True)
+        os.chmod(temporary, mode)
+        os.replace(temporary, output)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+# Keep every signed directory and every non-Google family declaration intact.
+dynamic_tree = ET.parse(dynamic_input)
+removed: list[str] = []
+for parent in dynamic_tree.getroot().iter():
+    for child in list(parent):
+        if local_name(child.tag) != "family":
+            continue
+        name = child.attrib.get("name", "")
+        if name and blocked(name):
+            removed.append(name)
+            parent.remove(child)
+if not removed:
+    raise SystemExit(3)
+atomic_write(dynamic_tree, dynamic_output, 0o600)
+
+# Add authoritative Google/Product Sans names to the active system font map.
+system_tree = ET.parse(system_input)
+root = system_tree.getroot()
+family_tag = namespace_tag(root, "family")
+font_tag = namespace_tag(root, "font")
+existing: dict[str, list[ET.Element]] = {}
+for family in root.iter():
+    if local_name(family.tag) != "family":
+        continue
+    name = normalized(family.attrib.get("name", ""))
+    if name:
+        existing.setdefault(name, []).append(family)
+
+for family_name, weight, filename in FAMILIES:
+    candidates = existing.get(family_name, [])
+    family = candidates[-1] if candidates else ET.SubElement(
+        root, family_tag, {"name": family_name}
+    )
+    family.attrib["name"] = family_name
+    for key in ("lang", "variant", "fallbackFor", "fallbackfor", "supportedAxes"):
+        family.attrib.pop(key, None)
+    for child in list(family):
+        if local_name(child.tag) == "font":
+            family.remove(child)
+    font = ET.SubElement(
+        family,
+        font_tag,
+        {"weight": str(weight), "style": "normal"},
+    )
+    font.text = filename
+
+atomic_write(system_tree, system_output, 0o644)
+report_path.write_text(
+    "removed=" + str(len(removed)) + "\n"
+    + "\n".join(f"family={name}" for name in sorted(set(removed))) + "\n"
+    + f"regular={regular_name}\nmedium={medium_name}\nbold={bold_name}\n",
+    encoding="utf-8",
+)
+PY_LUOSHU_PROVIDER
+}
+
+_luoshu_provider_match_metadata() {
+    _lpm_source="$1"
+    _lpm_target="$2"
+    _lpm_uid=$(stat -c '%u' "$_lpm_target" 2>/dev/null)
+    _lpm_gid=$(stat -c '%g' "$_lpm_target" 2>/dev/null)
+    _lpm_mode=$(stat -c '%a' "$_lpm_target" 2>/dev/null)
+    [ -n "$_lpm_uid" ] && [ -n "$_lpm_gid" ] && chown "$_lpm_uid:$_lpm_gid" "$_lpm_source" 2>/dev/null || true
+    chmod "${_lpm_mode:-644}" "$_lpm_source" 2>/dev/null || true
+
+    if command -v ls >/dev/null 2>&1 && command -v chcon >/dev/null 2>&1; then
+        _lpm_context=$(ls -Zd "$_lpm_target" 2>/dev/null | awk '{print $1}')
+        case "$_lpm_context" in *:*:*:*) chcon "$_lpm_context" "$_lpm_source" 2>/dev/null || true ;; esac
+    fi
+}
+
+_luoshu_provider_bind_one() {
+    _lpb_source="$1"
+    _lpb_target="$2"
+    mount --bind "$_lpb_source" "$_lpb_target" 2>/dev/null || return 1
+    mount -o remount,bind,ro "$_lpb_target" 2>/dev/null || true
+    _luoshu_provider_mount_is_ours "$_lpb_target" "$_lpb_source"
+}
+
+luoshu_provider_cache_sync() {
+    _lpcs_font="${1:-custom}"
+    _lpcs_cfg="$(_luoshu_provider_config)"
+    mkdir -p "$_lpcs_cfg" 2>/dev/null || true
+    {
+        printf 'mode=pending-reboot\n'
+        printf 'font=%s\n' "$(head -n1 "$_lpcs_cfg/active_font.conf" 2>/dev/null | tr -d '\r\n')"
+        printf 'source=%s\n' "$_lpcs_font"
+        printf 'time=%s\n' "$(date +%s)"
+    } > "$LUOSHU_PROVIDER_STATE" 2>/dev/null || true
+    chmod 0644 "$LUOSHU_PROVIDER_STATE" 2>/dev/null || true
+    luoshu_provider_log "已准备 Android 动态 Google Sans 命名字体桥；完整重启后生效"
+    return 0
+}
+
+luoshu_provider_cache_restore() {
+    _luoshu_provider_unmount_all
+    _luoshu_provider_restore_legacy_files
+    rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+        "$LUOSHU_PROVIDER_STATE" "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+    return 0
+}
+
+# Called from post-fs-data before FontManagerService builds the system font map.
+luoshu_provider_cache_boot() {
+    _lpcb_active="${1:-default}"
+    _lpcb_cfg="$(_luoshu_provider_config)"
+
+    if [ "$_lpcb_active" = default ] || [ -z "$_lpcb_active" ]; then
+        luoshu_provider_cache_restore
+        return 0
+    fi
+
+    _luoshu_provider_restore_legacy_files
+    _luoshu_provider_dynamic_google_present || return 2
+    [ -s "$LUOSHU_PROVIDER_CONFIG_XML" ] && [ -s "$LUOSHU_PROVIDER_SYSTEM_XML" ] || return 2
+    _luoshu_provider_select_fonts || {
+        luoshu_provider_log "未找到可供 Google Sans family 使用的洛书系统字体"
+        return 1
+    }
+
+    mkdir -p "$LUOSHU_PROVIDER_OVERLAY_DIR" "$_lpcb_cfg" 2>/dev/null || return 1
+    _luoshu_provider_unmount_all
+
+    if ! _luoshu_provider_generate_overlays \
+        "$LUOSHU_PROVIDER_CONFIG_XML" "$LUOSHU_PROVIDER_CONFIG_OVERLAY" \
+        "$LUOSHU_PROVIDER_SYSTEM_XML" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+        "$LUOSHU_PROVIDER_REPORT"; then
+        _lpcb_rc=$?
+        rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+            "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+        luoshu_provider_log "动态字体命名字体桥生成失败：code=$_lpcb_rc"
+        return 1
+    fi
+
+    grep -Eiq 'google[-_ ]?sans|product[-_ ]?sans' "$LUOSHU_PROVIDER_CONFIG_OVERLAY" 2>/dev/null && {
+        rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+            "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+        luoshu_provider_log "净化后的动态配置仍包含 Google/Product Sans，拒绝挂载"
+        return 1
+    }
+    grep -Eq '<family[[:space:]][^>]*name="google-sans"' "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" 2>/dev/null || {
+        rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+            "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+        luoshu_provider_log "系统字体配置没有生成 google-sans family，拒绝挂载"
+        return 1
+    }
+
+    _luoshu_provider_match_metadata "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_XML"
+    _luoshu_provider_match_metadata "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_CONFIG_XML"
+
+    if ! _luoshu_provider_bind_one "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_XML"; then
+        rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+            "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+        luoshu_provider_log "无法挂载系统 Google Sans 命名字体配置"
+        return 1
+    fi
+    if ! _luoshu_provider_bind_one "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_CONFIG_XML"; then
+        _luoshu_provider_unmount_one "$LUOSHU_PROVIDER_SYSTEM_XML" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" || true
+        rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+            "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+        luoshu_provider_log "无法挂载动态字体配置隔离层"
+        return 1
+    fi
+
+    _lpcb_removed=$(sed -n 's/^removed=//p' "$LUOSHU_PROVIDER_REPORT" 2>/dev/null | head -n1)
+    {
+        printf 'mode=mounted\n'
+        printf 'font=%s\n' "$_lpcb_active"
+        printf 'removed=%s\n' "${_lpcb_removed:-0}"
+        printf 'regular=%s\n' "$LUOSHU_PROVIDER_REGULAR"
+        printf 'medium=%s\n' "$LUOSHU_PROVIDER_MEDIUM"
+        printf 'bold=%s\n' "$LUOSHU_PROVIDER_BOLD"
+        printf 'time=%s\n' "$(date +%s)"
+    } > "$LUOSHU_PROVIDER_STATE" 2>/dev/null || true
+    chmod 0644 "$LUOSHU_PROVIDER_STATE" "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+    luoshu_provider_log "动态 Google Sans 命名字体桥已启用：移除 ${_lpcb_removed:-0} 个动态 family"
     return 0
 }

--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v2.1.2
-summary=HyperOS 紧凑控件排版与时钟字体覆盖修复
-notes=v2.1.2 基于 v2.1.1 修复 HyperOS：为 MiSans、Roboto、GoogleSans 与数字字重物理槽使用固定紧凑行框，处理 QQ 回复栏错位、年龄标签裁切和酷安标题/热度重叠；补齐 mi_ext 分区，并覆盖 Mitype、MiClock、AndroidClock、Clockopia 等时钟及系统管理页面直连字体槽，使英文数字跟随用户字体。模块 versionCode 20102，正式 App versionCode 2010201。
+version=v2.1.3
+summary=修复 Play 商店等应用绕过洛书继续使用动态 Google Sans
+notes=v2.1.3 修复 Android 12+ 可更新字体服务覆盖系统字体的问题：开机早期保留 /data/fonts/files 中所有签名字体、fs-verity、Emoji 与其他动态字体，仅从动态配置中隔离 Google/Product Sans 命名字体族，同时向当前 system fonts.xml 注入同名 family 并按 400/500/700 字重指向洛书现有字体槽。切换字体后无需额外脚本，完整重启自动生效；切回默认字体或卸载模块自动解除覆盖。模块 versionCode 20103，正式 App versionCode 2010301。

--- a/docs/DYNAMIC_FONT_OVERLAY.md
+++ b/docs/DYNAMIC_FONT_OVERLAY.md
@@ -1,0 +1,5 @@
+# Android dynamic Google Sans overlay
+
+LuoShu v2.1.3 handles Android 12+ downloadable Google Sans named families during `post-fs-data`.
+
+The runtime keeps signed `/data/fonts/files` font payloads untouched. It filters only Google/Product Sans named-family declarations from `/data/fonts/config/config.xml`, injects matching 400/500/700 families into the active system `fonts.xml`, and bind-mounts the generated XML views before `FontManagerService` builds its map. Switching to the default font or uninstalling removes the bind mounts and generated state.

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v2.1.2
-versionCode=20102
+version=v2.1.3
+versionCode=20103
 author=惜故里丶
 description=Android 无 Hook 全局字体引擎：系统字体配置、真实字重、复合字体、高刷新率与安全回退
 updateJson=

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -12,6 +12,7 @@ MODULE_DIR="$MODDIR"
 [ -f "$MODDIR/common/font_config_runtime.sh" ] && . "$MODDIR/common/font_config_runtime.sh"
 [ -f "$MODDIR/common/font_config_partitions.sh" ] && . "$MODDIR/common/font_config_partitions.sh"
 [ -f "$MODDIR/common/mount_compat.sh" ] && . "$MODDIR/common/mount_compat.sh"
+[ -f "$MODDIR/common/font_provider_cache.sh" ] && . "$MODDIR/common/font_provider_cache.sh"
 
 type init_module >/dev/null 2>&1 && init_module
 type ensure_public_storage >/dev/null 2>&1 && ensure_public_storage
@@ -55,14 +56,25 @@ elif type font_config_boot_guard >/dev/null 2>&1; then
     font_config_boot_guard "$ACTIVE_TEXT" || true
 fi
 
+# Android 12+ 的 FontManagerService 会在系统 XML 之后追加 /data/fonts 中的命名字体族，
+# Play 商店因此可能继续使用下载版 Google Sans。必须在 FontManagerService 初始化前：
+# 1. 保留所有签名字体文件、Emoji 与其他动态字体；
+# 2. 只隐藏 Google/Product Sans 的动态 family；
+# 3. 向当前 system fonts.xml 注入同名 family，指向洛书现有字体槽。
+if type luoshu_provider_cache_boot >/dev/null 2>&1; then
+    _provider_rc=0
+    luoshu_provider_cache_boot "$ACTIVE_TEXT" || _provider_rc=$?
+    case "$_provider_rc" in
+        0) log_message "INFO" "Android 动态 Google Sans 命名字体桥已准备完成" ;;
+        2) log_message "INFO" "设备没有动态 Google Sans 字体，无需额外处理" ;;
+        *) log_message "ERROR" "Android 动态字体命名覆盖准备失败（code=$_provider_rc），继续使用原配置" ;;
+    esac
+fi
+
 for _partition in system system_ext product vendor odm oem my_product my_engineering my_company my_preload my_region my_stock oplus_product oplus_engineering oplus_version oplus_region mi_ext cust; do
     [ -d "$MODDIR/$_partition" ] || continue
     set_perm_recursive "$MODDIR/$_partition" 0 0 0755 0644 2>/dev/null || true
 done
-
-# 无 Hook 版不读写 /data/fonts。Android 的动态字体数据库由 FontManagerService、签名权限
-# 和 fs-verity 管理；洛书只使用启动前的 systemless 分区负载与字体配置。
-log_message "INFO" "动态字体数据库保持原样；使用 systemless XML/字体负载"
 
 # 字体索引由原生 App 按需刷新，启动早期不扫描或复制大字体。
 

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -14,6 +14,116 @@ MODULE_DIR="$MODDIR"
 [ -f "$MODDIR/common/mount_compat.sh" ] && . "$MODDIR/common/mount_compat.sh"
 [ -f "$MODDIR/common/font_provider_cache.sh" ] && . "$MODDIR/common/font_provider_cache.sh"
 
+# Bind mount 的 mountinfo 根路径会省略 /data 前缀，不能用绝对源路径字符串判断。
+# 同时确认目标是独立挂载点且内容与洛书生成文件一致，避免误卸载其他模块的挂载。
+_luoshu_provider_mount_is_ours() {
+    _lpmi_target="$1"
+    _lpmi_source="$2"
+    [ -r /proc/self/mountinfo ] && [ -f "$_lpmi_source" ] || return 1
+    awk -v target="$_lpmi_target" '$5 == target { found=1 } END { exit !found }' \
+        /proc/self/mountinfo 2>/dev/null || return 1
+    cmp -s "$_lpmi_source" "$_lpmi_target" 2>/dev/null
+}
+
+# post-fs-data 专用启动实现：用 XML 节点校验，而不是搜索整个文件文本。
+# /data/fonts/config/config.xml 仍会保留 GoogleSans 文件目录，只有同名 family 必须移除。
+luoshu_provider_cache_boot() {
+    _lpcb_active="${1:-default}"
+    _lpcb_cfg="$(_luoshu_provider_config)"
+
+    if [ "$_lpcb_active" = default ] || [ -z "$_lpcb_active" ]; then
+        luoshu_provider_cache_restore
+        return 0
+    fi
+
+    _luoshu_provider_restore_legacy_files
+    _luoshu_provider_dynamic_google_present || return 2
+    [ -s "$LUOSHU_PROVIDER_CONFIG_XML" ] && [ -s "$LUOSHU_PROVIDER_SYSTEM_XML" ] || return 2
+    _luoshu_provider_select_fonts || {
+        luoshu_provider_log "未找到可供 Google Sans family 使用的洛书系统字体"
+        return 1
+    }
+
+    mkdir -p "$LUOSHU_PROVIDER_OVERLAY_DIR" "$_lpcb_cfg" 2>/dev/null || return 1
+    _luoshu_provider_unmount_all
+
+    _luoshu_provider_generate_overlays \
+        "$LUOSHU_PROVIDER_CONFIG_XML" "$LUOSHU_PROVIDER_CONFIG_OVERLAY" \
+        "$LUOSHU_PROVIDER_SYSTEM_XML" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+        "$LUOSHU_PROVIDER_REPORT"
+    _lpcb_rc=$?
+    if [ "$_lpcb_rc" -ne 0 ]; then
+        rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+            "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+        luoshu_provider_log "动态字体命名字体桥生成失败：code=$_lpcb_rc"
+        return 1
+    fi
+
+    _luoshu_provider_python - \
+        "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" <<'PY_LUOSHU_PROVIDER_VALIDATE' >/dev/null 2>&1
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+blocked = re.compile(r"(google[-_\s]*sans|product[-_\s]*sans)", re.I)
+
+def local_name(tag):
+    return tag.rsplit("}", 1)[-1]
+
+provider = ET.parse(sys.argv[1]).getroot()
+for node in provider.iter():
+    if local_name(node.tag) == "family" and blocked.search(node.attrib.get("name", "")):
+        raise SystemExit(2)
+
+system = ET.parse(sys.argv[2]).getroot()
+seen = set()
+for node in system.iter():
+    if local_name(node.tag) == "family":
+        seen.add(node.attrib.get("name", "").strip().lower())
+required = {"google-sans", "google-sans-text", "google-sans-medium", "google-sans-bold"}
+if not required.issubset(seen):
+    raise SystemExit(3)
+PY_LUOSHU_PROVIDER_VALIDATE
+    _lpcb_rc=$?
+    if [ "$_lpcb_rc" -ne 0 ]; then
+        rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+            "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+        luoshu_provider_log "动态字体 XML 节点校验失败：code=$_lpcb_rc"
+        return 1
+    fi
+
+    _luoshu_provider_match_metadata "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_XML"
+    _luoshu_provider_match_metadata "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_CONFIG_XML"
+
+    if ! _luoshu_provider_bind_one "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_XML"; then
+        rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+            "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+        luoshu_provider_log "无法挂载系统 Google Sans 命名字体配置"
+        return 1
+    fi
+    if ! _luoshu_provider_bind_one "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_CONFIG_XML"; then
+        _luoshu_provider_unmount_one "$LUOSHU_PROVIDER_SYSTEM_XML" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" || true
+        rm -f "$LUOSHU_PROVIDER_CONFIG_OVERLAY" "$LUOSHU_PROVIDER_SYSTEM_OVERLAY" \
+            "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+        luoshu_provider_log "无法挂载动态字体配置隔离层"
+        return 1
+    fi
+
+    _lpcb_removed=$(sed -n 's/^removed=//p' "$LUOSHU_PROVIDER_REPORT" 2>/dev/null | head -n1)
+    {
+        printf 'mode=mounted\n'
+        printf 'font=%s\n' "$_lpcb_active"
+        printf 'removed=%s\n' "${_lpcb_removed:-0}"
+        printf 'regular=%s\n' "$LUOSHU_PROVIDER_REGULAR"
+        printf 'medium=%s\n' "$LUOSHU_PROVIDER_MEDIUM"
+        printf 'bold=%s\n' "$LUOSHU_PROVIDER_BOLD"
+        printf 'time=%s\n' "$(date +%s)"
+    } > "$LUOSHU_PROVIDER_STATE" 2>/dev/null || true
+    chmod 0644 "$LUOSHU_PROVIDER_STATE" "$LUOSHU_PROVIDER_REPORT" 2>/dev/null || true
+    luoshu_provider_log "动态 Google Sans 命名字体桥已启用：移除 ${_lpcb_removed:-0} 个动态 family"
+    return 0
+}
+
 type init_module >/dev/null 2>&1 && init_module
 type ensure_public_storage >/dev/null 2>&1 && ensure_public_storage
 mkdir -p "$MODDIR/config" "$MODDIR/logs" "$MODDIR/system/fonts" 2>/dev/null || true

--- a/scripts/font_provider_overlay_fixture.xml
+++ b/scripts/font_provider_overlay_fixture.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<fontConfig>
+  <family name="google-sans"><font weight="400" style="normal">/data/fonts/files/hash/GoogleSans-Regular.ttf</font></family>
+  <family name="google-sans-medium"><font weight="500" style="normal">/data/fonts/files/hash/GoogleSans-Medium.ttf</font></family>
+  <family name="emoji-family"><font weight="400" style="normal">/data/fonts/files/hash/NotoColorEmoji.ttf</font></family>
+</fontConfig>

--- a/scripts/font_provider_overlay_test.sh
+++ b/scripts/font_provider_overlay_test.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT HUP INT TERM
+mkdir -p "$ROOT/data/fonts/config" "$ROOT/data/fonts/files/hash" "$ROOT/system/etc" "$ROOT/system/fonts" "$ROOT/module/config" "$ROOT/module/logs" "$ROOT/module/common/python/bin"
+
+cat > "$ROOT/data/fonts/config/config.xml" <<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<fontConfig>
+  <family name="google-sans"><font weight="400" style="normal">/data/fonts/files/hash/GoogleSans-Regular.ttf</font></family>
+  <family name="google-sans-medium"><font weight="500" style="normal">/data/fonts/files/hash/GoogleSans-Medium.ttf</font></family>
+  <family name="emoji-family"><font weight="400" style="normal">/data/fonts/files/hash/NotoColorEmoji.ttf</font></family>
+</fontConfig>
+XML
+cat > "$ROOT/system/etc/fonts.xml" <<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<familyset>
+  <family name="sans-serif"><font weight="400" style="normal">Roboto-Regular.ttf</font></family>
+</familyset>
+XML
+
+# This focused test validates the XML policy used by the provider bridge without
+# requiring Android mount namespaces or the packaged ARM64 Python runtime.
+python3 - "$ROOT/data/fonts/config/config.xml" "$ROOT/system/etc/fonts.xml" <<'PY'
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+dynamic = ET.parse(sys.argv[1])
+blocked = re.compile(r"(google[-_\s]*sans|product[-_\s]*sans)", re.I)
+removed = []
+for parent in dynamic.getroot().iter():
+    for child in list(parent):
+        if child.tag.rsplit('}', 1)[-1] != 'family':
+            continue
+        name = child.attrib.get('name', '')
+        if name and blocked.search(name):
+            removed.append(name)
+            parent.remove(child)
+assert set(removed) == {'google-sans', 'google-sans-medium'}
+remaining = {node.attrib.get('name') for node in dynamic.getroot().iter() if node.tag.rsplit('}', 1)[-1] == 'family'}
+assert 'emoji-family' in remaining
+
+system = ET.parse(sys.argv[2])
+root = system.getroot()
+for name, weight, filename in (
+    ('google-sans', 400, 'LuoShu-400.ttf'),
+    ('google-sans-text', 400, 'LuoShu-400.ttf'),
+    ('google-sans-flex', 400, 'LuoShu-400.ttf'),
+    ('google-sans-medium', 500, 'LuoShu-500.ttf'),
+    ('google-sans-bold', 700, 'LuoShu-700.ttf'),
+):
+    family = ET.SubElement(root, 'family', {'name': name})
+    font = ET.SubElement(family, 'font', {'weight': str(weight), 'style': 'normal'})
+    font.text = filename
+families = {node.attrib.get('name'): node for node in root if node.tag == 'family'}
+assert families['google-sans'].find('font').text == 'LuoShu-400.ttf'
+assert families['google-sans-medium'].find('font').text == 'LuoShu-500.ttf'
+assert families['google-sans-bold'].find('font').text == 'LuoShu-700.ttf'
+print('Font provider overlay policy test passed.')
+PY
+
+sh -n common/font_provider_cache.sh
+sh -n post-fs-data.sh
+sh -n uninstall.sh

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# 洛书 v2.0.0：安全卸载。只恢复洛书明确记录的系统设置，不触碰 /data/fonts。
+# 洛书 v2：安全卸载。恢复洛书记录的系统设置与动态字体配置视图。
 set +e
 MODDIR="${0%/*}"
 MODULE_VERSION=$(sed -n 's/^version=//p' "$MODDIR/module.prop" 2>/dev/null | head -n1)
@@ -15,15 +15,22 @@ if command -v settings >/dev/null 2>&1; then
         settings put secure font_weight_adjustment "$_fw_restore" >/dev/null 2>&1 || true
 fi
 
-# 还原 GMS Fonts Provider 缓存劫持（切换字体时写入 /data/fonts/files 的副本），
-# 否则卸载模块后 Play 商店等应用仍停留在用户字体。
+# 解除 Android 动态 Google Sans 命名字体桥，并恢复旧版本曾直接写入的缓存副本。
+# 即使当前 mount namespace 无法立即解除，完整重启后挂载也会自然消失。
 if [ -f "$MODDIR/common/font_provider_cache.sh" ]; then
     MODULE_DIR="$MODDIR"
     . "$MODDIR/common/font_provider_cache.sh"
+    _luoshu_provider_mount_is_ours() {
+        _lpmi_target="$1"
+        _lpmi_source="$2"
+        [ -r /proc/self/mountinfo ] && [ -f "$_lpmi_source" ] || return 1
+        awk -v target="$_lpmi_target" '$5 == target { found=1 } END { exit !found }' \
+            /proc/self/mountinfo 2>/dev/null || return 1
+        cmp -s "$_lpmi_source" "$_lpmi_target" 2>/dev/null
+    }
     luoshu_provider_cache_restore >/dev/null 2>&1 || true
 fi
 
-# v2 使用 systemless 字体与 XML 负载，不删除 Android/OEM 管理的动态字体数据库。
 rm -f "$MODDIR/.first_boot" "$MODDIR/.font_switch.lock" 2>/dev/null || true
 mkdir -p "$MODDIR/logs" 2>/dev/null || true
 echo "[$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null)] 洛书 $MODULE_VERSION 已卸载" >> "$MODDIR/logs/fontswitch.log" 2>/dev/null || true


### PR DESCRIPTION
已撤回：外置脚本的真机验证无效，当前方案不发布、不合并。原因是 Android FontManagerService 已在 system_server 中构建并序列化运行时字体映射，仅在系统启动后替换 `/data/fonts/files` 并 force-stop Play 商店不会刷新字体映射。后续修复必须在 FontManagerService 初始化前完成真实配置覆盖，并以重启后的 `cmd font dump` 真机结果为准。