### PR TITLE
[已并入 v2.2.0 重构计划] Play 动态 Google Sans 单点方案

### DIFF
--- a/RELEASE_NOTES_v2.1.3.md
+++ b/RELEASE_NOTES_v2.1.3.md
@@ -1,0 +1,19 @@
+<!-- prerelease -->
+# LuoShu v2.1.3
+
+## 修复
+
+- 修复 Android 12+、ColorOS 及其他启用可更新字体服务的系统中，Play 商店搜索框、Gmail 等应用继续使用 `/data/fonts/files` 内置 Google Sans、绕过洛书字体的问题。
+- 修复逻辑已直接集成洛书模块，不需要用户运行任何外置脚本。
+- 洛书会在 `post-fs-data` 阶段、FontManagerService 建立共享字体表之前处理真实动态字体配置。
+- 保留 `/data/fonts/files` 中的系统签名字体、fs-verity、动态 Emoji、其他字体和全部 `updatedFontDir`，只隔离 `google-sans*` 与 `product-sans*` 命名字体族。
+- 将 Google Sans Regular、Text、Flex、Display、Medium、Bold 等名称按 400/500/700 字重指向当前洛书字体。
+- 切回系统默认字体或卸载洛书时自动解除配置桥，重启后恢复系统原始字体表。
+
+## 验证依据
+
+- ColorOS 16.1 / Android 16 真机诊断确认，系统分区的 `GoogleSans*.ttf` 已经是洛书字体，但运行时 `google-sans*` 仍指向 `/data/fonts/files`。
+- AOSP FontManagerService 会在启动时读取 `/data/fonts/config/config.xml`，并将后加载的同名 family 覆盖系统 family；因此后置复制字体文件和强停 Play 商店不会重建字体表。
+- 已完成 Shell 语法、PersistentSystemFontConfig 结构过滤、`updatedFontDir` 保留、Emoji family 保留和系统命名字体注入测试。
+
+> 安装或切换字体后需要完整重启。验收标准是重启后的 `dumpsys font` 中 `google-sans*` 不再指向 `/data/fonts/files`。

--- a/common/font_provider_cache.sh
+++ b/common/font_provider_cache.sh
@@ -1,107 +1,343 @@
 #!/system/bin/sh
-# LuoShu downloadable-fonts provider cache hijack.
+# LuoShu Android updatable-font named-family bridge.
 #
-# Play 商店、Gmail 等 Google 系应用不读 /system 或 /product 下的字体文件，
-# 而是通过 GMS 的 Fonts Provider（Downloadable Fonts）加载字体，
-# 缓存落在 /data/fonts/files/（按内容哈希命名）。系统分区的文件替换对它们无效。
-# 本脚本把已归一化的用户字体同步进该缓存，并 force-stop 相关进程使其重新加载。
+# Android 12+ merges /data/fonts/config/config.xml after the system font XML.
+# Downloaded Google Sans named families therefore override systemless GoogleSans files.
+# LuoShu fixes this before FontManagerService starts: keep every signed font file and
+# updatedFontDir entry, remove only Google/Product Sans family declarations from the
+# persistent config view, and expose the same family names from the active LuoShu fonts.
 set +e
 
-LUOSHU_PROVIDER_DIR="${LUOSHU_PROVIDER_DIR:-/data/fonts/files}"
+_luoshu_provider_module() {
+    printf '%s\n' "${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
+}
+
+_luoshu_provider_config_dir() {
+    printf '%s/config/font-provider-overlay\n' "$(_luoshu_provider_module)"
+}
+
+LUOSHU_PROVIDER_DATA_XML="${LUOSHU_PROVIDER_DATA_XML:-/data/fonts/config/config.xml}"
+LUOSHU_PROVIDER_SYSTEM_XML="${LUOSHU_PROVIDER_SYSTEM_XML:-/system/etc/fonts.xml}"
+LUOSHU_PROVIDER_STATE="${LUOSHU_PROVIDER_STATE:-$(_luoshu_provider_module)/config/font-provider-overlay.conf}"
 LUOSHU_PROVIDER_BACKUP_SUFFIX=".luoshu-bak"
 
 luoshu_provider_log() {
-    _lpl_msg="$1"
-    _lpl_mod="${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
-    mkdir -p "$_lpl_mod/logs" 2>/dev/null || true
-    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" "$_lpl_msg" >> "$_lpl_mod/logs/provider_cache.log" 2>/dev/null || true
+    _lpl_module="$(_luoshu_provider_module)"
+    mkdir -p "$_lpl_module/logs" 2>/dev/null || true
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" "$*" \
+        >> "$_lpl_module/logs/provider_cache.log" 2>/dev/null || true
 }
 
-# 尽力识别 downloadable emoji 字体（如 NotoColorEmoji 的 provider 下载副本），
-# 它们绝不能被文字字体替换，否则使用 downloadable emoji 的应用会变方块。
-# 识别不了（无 Python 环境）时按文字字体处理——Play 商店链路本来就没有 emoji 缓存。
-_luoshu_provider_family_is_emoji() {
-    _lpie_file="$1"
-    _lpie_mod="${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
-    _lpie_py="$_lpie_mod/common/python/bin/luoshu-python"
-    [ -x "$_lpie_py" ] || return 1
-    _lpie_pyroot="$_lpie_mod/common/python"
-    _lpie_kind=$(PYTHONHOME="$_lpie_pyroot" \
-        PYTHONPATH="$_lpie_pyroot/lib/python3.14:$_lpie_pyroot/lib/python3.14/site-packages" \
-        LD_LIBRARY_PATH="$_lpie_pyroot/lib:$_lpie_pyroot/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-        "$_lpie_py" - "$_lpie_file" <<'PY_LUOSHU_EMOJI_PROBE' 2>/dev/null
-import sys
-from fontTools.ttLib import TTFont, TTCollection
-try:
-    src = sys.argv[1]
-    with open(src, "rb") as fh:
-        coll = fh.read(4) == b"ttcf"
-    font = (TTCollection(src, lazy=True).fonts[0] if coll else TTFont(src, lazy=True))
-    names = " ".join(r.toUnicode() for r in font["name"].names if r.nameID in (1, 4, 6, 16)).lower()
-    print("emoji" if "emoji" in names else "text")
-except Exception:
-    print("unknown")
-PY_LUOSHU_EMOJI_PROBE
-)
-    [ "$_lpie_kind" = "emoji" ]
+_luoshu_provider_python() {
+    _lpp_module="$(_luoshu_provider_module)"
+    _lpp_root="$_lpp_module/common/python"
+    _lpp_bin="$_lpp_root/bin/luoshu-python"
+    [ -x "$_lpp_bin" ] || return 1
+    PYTHONHOME="$_lpp_root" \
+    PYTHONPATH="$_lpp_root/lib/python3.14:$_lpp_root/lib/python3.14/site-packages" \
+    LD_LIBRARY_PATH="$_lpp_root/lib:$_lpp_root/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+        "$_lpp_bin" "$@"
 }
 
-# luoshu_provider_cache_sync <归一化后的字体文件>
-# 备份原始缓存（仅首次），再把缓存内所有 ttf/otf 替换为用户字体。
-luoshu_provider_cache_sync() {
-    _lpcs_font="$1"
-    [ -f "$_lpcs_font" ] || return 0
-    [ -d "$LUOSHU_PROVIDER_DIR" ] || return 0
+_luoshu_provider_mount_is_ours() {
+    _lpmi_target="$1"
+    _lpmi_source="$2"
+    [ -r /proc/self/mountinfo ] && [ -f "$_lpmi_source" ] && [ -f "$_lpmi_target" ] || return 1
+    awk -v target="$_lpmi_target" '$5 == target { found=1 } END { exit !found }' \
+        /proc/self/mountinfo 2>/dev/null || return 1
+    _lpmi_source_id=$(stat -c '%d:%i' "$_lpmi_source" 2>/dev/null)
+    _lpmi_target_id=$(stat -c '%d:%i' "$_lpmi_target" 2>/dev/null)
+    [ -n "$_lpmi_source_id" ] && [ "$_lpmi_source_id" = "$_lpmi_target_id" ]
+}
 
-    _lpcs_count=0
-    for _lpcs_f in "$LUOSHU_PROVIDER_DIR"/*; do
-        [ -f "$_lpcs_f" ] || continue
-        case "$_lpcs_f" in *"$LUOSHU_PROVIDER_BACKUP_SUFFIX") continue ;; esac
-        # 只处理字体文件（magic: 00010000 / OTTO / ttcf）
-        _lpcs_magic=$(dd if="$_lpcs_f" bs=4 count=1 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')
-        case "$_lpcs_magic" in
-            00010000|4f54544f|74746366) ;;  # ttf / otf / ttc
-            *) continue ;;
-        esac
-        if _luoshu_provider_family_is_emoji "$_lpcs_f"; then
-            luoshu_provider_log "跳过 downloadable emoji 字体：${_lpcs_f##*/}"
-            continue
-        fi
-        if [ ! -f "${_lpcs_f}${LUOSHU_PROVIDER_BACKUP_SUFFIX}" ]; then
-            cp -f "$_lpcs_f" "${_lpcs_f}${LUOSHU_PROVIDER_BACKUP_SUFFIX}" 2>/dev/null || true
-        fi
-        if cp -f "$_lpcs_font" "$_lpcs_f" 2>/dev/null; then
-            chmod 644 "$_lpcs_f" 2>/dev/null || true
-            _lpcs_count=$((_lpcs_count + 1))
-        fi
-    done
-    [ "$_lpcs_count" -gt 0 ] || return 0
-
-    # 已缓存 Typeface 的进程不会重读文件，force-stop 让其下次启动走新缓存
-    for _lpcs_pkg in com.android.vending com.google.android.gms; do
-        am force-stop "$_lpcs_pkg" >/dev/null 2>&1 || true
-    done
-    luoshu_provider_log "已劫持 $_lpcs_count 个 provider 缓存字体并重启 GMS/Play"
+_luoshu_provider_unmount_one() {
+    _lpu_target="$1"
+    _lpu_source="$2"
+    if _luoshu_provider_mount_is_ours "$_lpu_target" "$_lpu_source"; then
+        umount "$_lpu_target" 2>/dev/null || umount -l "$_lpu_target" 2>/dev/null || return 1
+    fi
     return 0
 }
 
-# luoshu_provider_cache_restore：恢复默认字体时还原原始缓存。
-luoshu_provider_cache_restore() {
-    [ -d "$LUOSHU_PROVIDER_DIR" ] || return 0
-    _lpcr_count=0
-    for _lpcr_bak in "$LUOSHU_PROVIDER_DIR"/*"$LUOSHU_PROVIDER_BACKUP_SUFFIX"; do
-        [ -f "$_lpcr_bak" ] || continue
-        _lpcr_orig="${_lpcr_bak%$LUOSHU_PROVIDER_BACKUP_SUFFIX}"
-        if mv -f "$_lpcr_bak" "$_lpcr_orig" 2>/dev/null; then
-            chmod 644 "$_lpcr_orig" 2>/dev/null || true
-            _lpcr_count=$((_lpcr_count + 1))
-        fi
+_luoshu_provider_restore_legacy_files() {
+    [ -d /data/fonts/files ] || return 0
+    find /data/fonts/files -type f -name "*${LUOSHU_PROVIDER_BACKUP_SUFFIX}" 2>/dev/null |
+    while IFS= read -r _lpr_backup; do
+        [ -f "$_lpr_backup" ] || continue
+        _lpr_original="${_lpr_backup%$LUOSHU_PROVIDER_BACKUP_SUFFIX}"
+        cp -f "$_lpr_backup" "$_lpr_original" 2>/dev/null || continue
+        chmod 0644 "$_lpr_original" 2>/dev/null || true
+        rm -f "$_lpr_backup" 2>/dev/null || true
     done
-    if [ "$_lpcr_count" -gt 0 ]; then
-        for _lpcr_pkg in com.android.vending com.google.android.gms; do
-            am force-stop "$_lpcr_pkg" >/dev/null 2>&1 || true
-        done
-        luoshu_provider_log "已恢复 $_lpcr_count 个 provider 缓存字体"
+}
+
+_luoshu_provider_valid_font() {
+    _lpvf="$1"
+    [ -f "$_lpvf" ] || return 1
+    _lpvf_size=$(wc -c < "$_lpvf" 2>/dev/null | tr -d '[:space:]')
+    case "$_lpvf_size" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$_lpvf_size" -ge 1024 ] || return 1
+    _lpvf_magic=$(dd if="$_lpvf" bs=4 count=1 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')
+    case "$_lpvf_magic" in 00010000|4f54544f|74746366) return 0 ;; *) return 1 ;; esac
+}
+
+_luoshu_provider_pick_name() {
+    for _lppn in "$@"; do
+        _luoshu_provider_valid_font "/system/fonts/$_lppn" || continue
+        printf '%s\n' "$_lppn"
+        return 0
+    done
+    return 1
+}
+
+_luoshu_provider_select_fonts() {
+    LUOSHU_PROVIDER_REGULAR=$(_luoshu_provider_pick_name \
+        LuoShu-400.ttf GoogleSans-Regular.ttf GoogleSansText-Regular.ttf \
+        Roboto-Regular.ttf SysFont-Regular.ttf OPSans-En-Regular.ttf) || return 1
+    LUOSHU_PROVIDER_MEDIUM=$(_luoshu_provider_pick_name \
+        LuoShu-500.ttf GoogleSans-Medium.ttf GoogleSansText-Medium.ttf \
+        SourceSansPro-SemiBold.ttf SysFont-Regular.ttf "$LUOSHU_PROVIDER_REGULAR") || \
+        LUOSHU_PROVIDER_MEDIUM="$LUOSHU_PROVIDER_REGULAR"
+    LUOSHU_PROVIDER_BOLD=$(_luoshu_provider_pick_name \
+        LuoShu-700.ttf GoogleSans-Bold.ttf GoogleSansText-Bold.ttf \
+        SourceSansPro-Bold.ttf SysFont-Regular.ttf "$LUOSHU_PROVIDER_MEDIUM" \
+        "$LUOSHU_PROVIDER_REGULAR") || LUOSHU_PROVIDER_BOLD="$LUOSHU_PROVIDER_REGULAR"
+    export LUOSHU_PROVIDER_REGULAR LUOSHU_PROVIDER_MEDIUM LUOSHU_PROVIDER_BOLD
+}
+
+_luoshu_provider_match_metadata() {
+    _lpmm_source="$1"
+    _lpmm_target="$2"
+    _lpmm_uid=$(stat -c '%u' "$_lpmm_target" 2>/dev/null)
+    _lpmm_gid=$(stat -c '%g' "$_lpmm_target" 2>/dev/null)
+    _lpmm_mode=$(stat -c '%a' "$_lpmm_target" 2>/dev/null)
+    [ -n "$_lpmm_uid" ] && [ -n "$_lpmm_gid" ] && chown "$_lpmm_uid:$_lpmm_gid" "$_lpmm_source" 2>/dev/null || true
+    chmod "${_lpmm_mode:-644}" "$_lpmm_source" 2>/dev/null || true
+    if command -v chcon >/dev/null 2>&1; then
+        chcon --reference="$_lpmm_target" "$_lpmm_source" 2>/dev/null || true
     fi
+}
+
+_luoshu_provider_bind_one() {
+    _lpbo_source="$1"
+    _lpbo_target="$2"
+    mount --bind "$_lpbo_source" "$_lpbo_target" 2>/dev/null || return 1
+    mount -o remount,bind,ro "$_lpbo_target" 2>/dev/null || true
+    _luoshu_provider_mount_is_ours "$_lpbo_target" "$_lpbo_source"
+}
+
+_luoshu_provider_generate() {
+    _lpg_data_in="$1"
+    _lpg_data_out="$2"
+    _lpg_system_in="$3"
+    _lpg_system_out="$4"
+    _lpg_report="$5"
+    rm -f "$_lpg_data_out" "$_lpg_system_out" "$_lpg_report" 2>/dev/null || true
+
+    _luoshu_provider_python - \
+        "$_lpg_data_in" "$_lpg_data_out" "$_lpg_system_in" "$_lpg_system_out" \
+        "$LUOSHU_PROVIDER_REGULAR" "$LUOSHU_PROVIDER_MEDIUM" "$LUOSHU_PROVIDER_BOLD" \
+        "$_lpg_report" <<'PY_LUOSHU_PROVIDER'
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+data_in = Path(sys.argv[1])
+data_out = Path(sys.argv[2])
+system_in = Path(sys.argv[3])
+system_out = Path(sys.argv[4])
+regular = sys.argv[5]
+medium = sys.argv[6]
+bold = sys.argv[7]
+report = Path(sys.argv[8])
+
+blocked = re.compile(r"^(?:google[-_\s]*sans|product[-_\s]*sans)", re.I)
+family_names = (
+    ("google-sans", 400, regular),
+    ("google-sans-text", 400, regular),
+    ("google-sans-flex", 400, regular),
+    ("google-sans-display", 400, regular),
+    ("product-sans", 400, regular),
+    ("google-sans-medium", 500, medium),
+    ("google-sans-text-medium", 500, medium),
+    ("google-sans-display-medium", 500, medium),
+    ("google-sans-bold", 700, bold),
+    ("google-sans-text-bold", 700, bold),
+    ("google-sans-display-bold", 700, bold),
+)
+
+
+def local(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def norm(value: str) -> str:
+    return re.sub(r"[\s_]+", "-", value.strip().lower())
+
+
+def atomic_write(tree: ET.ElementTree, output: Path, mode: int) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    ET.indent(tree, space="    ")
+    fd, temp = tempfile.mkstemp(prefix=f".{output.name}.", dir=output.parent)
+    os.close(fd)
+    try:
+        tree.write(temp, encoding="utf-8", xml_declaration=True)
+        os.chmod(temp, mode)
+        os.replace(temp, output)
+    finally:
+        try:
+            os.unlink(temp)
+        except FileNotFoundError:
+            pass
+
+# PersistentSystemFontConfig uses <family name="..."><font name="PostScriptName"/></family>.
+# Keep lastModifiedDate and every updatedFontDir so FontManagerService keeps signed files.
+data_tree = ET.parse(data_in)
+removed: list[str] = []
+for parent in data_tree.getroot().iter():
+    for child in list(parent):
+        if local(child.tag) != "family":
+            continue
+        name = child.attrib.get("name", "")
+        if name and blocked.match(norm(name)):
+            removed.append(name)
+            parent.remove(child)
+if not removed:
+    raise SystemExit(3)
+atomic_write(data_tree, data_out, 0o600)
+
+# System fonts.xml is parsed before the persistent updatable config. Add the family names here;
+# after the filtered persistent view is loaded, nothing later can override them.
+system_tree = ET.parse(system_in)
+root = system_tree.getroot()
+namespace = root.tag.split("}", 1)[0] + "}" if root.tag.startswith("{") else ""
+for parent in root.iter():
+    for child in list(parent):
+        if local(child.tag) == "family" and blocked.match(norm(child.attrib.get("name", ""))):
+            parent.remove(child)
+for name, weight, filename in family_names:
+    family = ET.SubElement(root, namespace + "family", {"name": name})
+    font = ET.SubElement(family, namespace + "font", {"weight": str(weight), "style": "normal"})
+    font.text = filename
+atomic_write(system_tree, system_out, 0o644)
+
+# Structural validation: only blocked named families disappear from data config, and all
+# injected family names point to a basename in /system/fonts.
+check_data = ET.parse(data_out).getroot()
+for node in check_data.iter():
+    if local(node.tag) == "family" and blocked.match(norm(node.attrib.get("name", ""))):
+        raise SystemExit(4)
+check_system = ET.parse(system_out).getroot()
+seen = set()
+for node in check_system.iter():
+    if local(node.tag) == "family":
+        seen.add(norm(node.attrib.get("name", "")))
+required = {name for name, _, _ in family_names}
+if not required.issubset(seen):
+    raise SystemExit(5)
+if any("/" in filename or not filename for _, _, filename in family_names):
+    raise SystemExit(6)
+
+report.write_text(
+    "removed=" + str(len(removed)) + "\n"
+    + "\n".join(f"family={name}" for name in sorted(set(removed))) + "\n"
+    + f"regular={regular}\nmedium={medium}\nbold={bold}\n",
+    encoding="utf-8",
+)
+PY_LUOSHU_PROVIDER
+}
+
+luoshu_provider_cache_sync() {
+    _lpcs_source="${1:-custom}"
+    mkdir -p "${LUOSHU_PROVIDER_STATE%/*}" 2>/dev/null || true
+    {
+        printf 'mode=pending-reboot\n'
+        printf 'font=%s\n' "$(head -n1 "$(_luoshu_provider_module)/config/active_font.conf" 2>/dev/null | tr -d '\r\n')"
+        printf 'source=%s\n' "$_lpcs_source"
+        printf 'time=%s\n' "$(date +%s)"
+    } > "$LUOSHU_PROVIDER_STATE" 2>/dev/null || true
+    chmod 0644 "$LUOSHU_PROVIDER_STATE" 2>/dev/null || true
+    return 0
+}
+
+luoshu_provider_cache_restore() {
+    _lpcr_dir="$(_luoshu_provider_config_dir)"
+    _lpcr_data="$_lpcr_dir/data-config.xml"
+    _lpcr_system="$_lpcr_dir/system-fonts.xml"
+    _luoshu_provider_unmount_one "$LUOSHU_PROVIDER_DATA_XML" "$_lpcr_data" || true
+    _luoshu_provider_unmount_one "$LUOSHU_PROVIDER_SYSTEM_XML" "$_lpcr_system" || true
+    _luoshu_provider_restore_legacy_files
+    rm -rf "$_lpcr_dir" 2>/dev/null || true
+    rm -f "$LUOSHU_PROVIDER_STATE" 2>/dev/null || true
+    return 0
+}
+
+# Must run from post-fs-data before FontManagerService initializes its shared font map.
+luoshu_provider_cache_boot() {
+    _lpcb_active="${1:-default}"
+    _lpcb_dir="$(_luoshu_provider_config_dir)"
+    _lpcb_data="$_lpcb_dir/data-config.xml"
+    _lpcb_system="$_lpcb_dir/system-fonts.xml"
+    _lpcb_report="$_lpcb_dir/report.conf"
+
+    if [ -z "$_lpcb_active" ] || [ "$_lpcb_active" = default ]; then
+        luoshu_provider_cache_restore
+        return 0
+    fi
+
+    [ -s "$LUOSHU_PROVIDER_DATA_XML" ] && [ -s "$LUOSHU_PROVIDER_SYSTEM_XML" ] || return 2
+    _luoshu_provider_select_fonts || {
+        luoshu_provider_log '动态 Google Sans 桥未找到可用的洛书系统字体'
+        return 1
+    }
+
+    mkdir -p "$_lpcb_dir" 2>/dev/null || return 1
+    _luoshu_provider_unmount_one "$LUOSHU_PROVIDER_DATA_XML" "$_lpcb_data" || true
+    _luoshu_provider_unmount_one "$LUOSHU_PROVIDER_SYSTEM_XML" "$_lpcb_system" || true
+
+    _luoshu_provider_generate "$LUOSHU_PROVIDER_DATA_XML" "$_lpcb_data" \
+        "$LUOSHU_PROVIDER_SYSTEM_XML" "$_lpcb_system" "$_lpcb_report"
+    _lpcb_rc=$?
+    if [ "$_lpcb_rc" -eq 3 ]; then
+        rm -rf "$_lpcb_dir" 2>/dev/null || true
+        return 2
+    elif [ "$_lpcb_rc" -ne 0 ]; then
+        rm -rf "$_lpcb_dir" 2>/dev/null || true
+        luoshu_provider_log "动态 Google Sans 配置生成失败：code=$_lpcb_rc"
+        return 1
+    fi
+
+    _luoshu_provider_match_metadata "$_lpcb_data" "$LUOSHU_PROVIDER_DATA_XML"
+    _luoshu_provider_match_metadata "$_lpcb_system" "$LUOSHU_PROVIDER_SYSTEM_XML"
+
+    if ! _luoshu_provider_bind_one "$_lpcb_system" "$LUOSHU_PROVIDER_SYSTEM_XML"; then
+        rm -rf "$_lpcb_dir" 2>/dev/null || true
+        luoshu_provider_log '无法在 FontManagerService 初始化前挂载系统字体配置'
+        return 1
+    fi
+    if ! _luoshu_provider_bind_one "$_lpcb_data" "$LUOSHU_PROVIDER_DATA_XML"; then
+        _luoshu_provider_unmount_one "$LUOSHU_PROVIDER_SYSTEM_XML" "$_lpcb_system" || true
+        rm -rf "$_lpcb_dir" 2>/dev/null || true
+        luoshu_provider_log '无法在 FontManagerService 初始化前挂载动态字体配置'
+        return 1
+    fi
+
+    _lpcb_removed=$(sed -n 's/^removed=//p' "$_lpcb_report" 2>/dev/null | head -n1)
+    {
+        printf 'mode=mounted-preboot\n'
+        printf 'font=%s\n' "$_lpcb_active"
+        printf 'removed=%s\n' "${_lpcb_removed:-0}"
+        printf 'regular=%s\n' "$LUOSHU_PROVIDER_REGULAR"
+        printf 'medium=%s\n' "$LUOSHU_PROVIDER_MEDIUM"
+        printf 'bold=%s\n' "$LUOSHU_PROVIDER_BOLD"
+        printf 'time=%s\n' "$(date +%s)"
+    } > "$LUOSHU_PROVIDER_STATE" 2>/dev/null || true
+    chmod 0644 "$LUOSHU_PROVIDER_STATE" "$_lpcb_report" 2>/dev/null || true
+    luoshu_provider_log "开机前动态 Google Sans 桥已启用：移除 ${_lpcb_removed:-0} 个覆盖 family"
     return 0
 }

--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v2.1.2
-summary=HyperOS 紧凑控件排版与时钟字体覆盖修复
-notes=v2.1.2 基于 v2.1.1 修复 HyperOS：为 MiSans、Roboto、GoogleSans 与数字字重物理槽使用固定紧凑行框，处理 QQ 回复栏错位、年龄标签裁切和酷安标题/热度重叠；补齐 mi_ext 分区，并覆盖 Mitype、MiClock、AndroidClock、Clockopia 等时钟及系统管理页面直连字体槽，使英文数字跟随用户字体。模块 versionCode 20102，正式 App versionCode 2010201。
+version=v2.1.3
+summary=修复 Play 商店等应用继续使用动态 Google Sans
+notes=v2.1.3 修复 Android 12+ 可更新字体服务覆盖洛书的问题：在 FontManagerService 建立共享字体表前，保留 /data/fonts/files 的签名字体、fs-verity、Emoji 与所有 updatedFontDir，仅从持久配置视图移除 google-sans、google-sans-text、google-sans-flex、product-sans 及 Medium/Bold 命名字体族，并将同名族按 400/500/700 指向当前洛书字体。切换字体后完整重启自动生效，切回默认或卸载自动解除覆盖。模块 versionCode 20103，正式 App versionCode 2010301。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v2.1.2
-versionCode=20102
+version=v2.1.3
+versionCode=20103
 author=惜故里丶
 description=Android 无 Hook 全局字体引擎：系统字体配置、真实字重、复合字体、高刷新率与安全回退
 updateJson=

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -14,6 +14,21 @@ MODULE_DIR="$MODDIR"
 [ -f "$MODDIR/common/mount_compat.sh" ] && . "$MODDIR/common/mount_compat.sh"
 [ -f "$MODDIR/common/font_provider_cache.sh" ] && . "$MODDIR/common/font_provider_cache.sh"
 
+# Android toybox 的 chcon 不支持 GNU --reference；启动路径按目标文件实际标签复制。
+_luoshu_provider_match_metadata() {
+    _lpmm_source="$1"
+    _lpmm_target="$2"
+    _lpmm_uid=$(stat -c '%u' "$_lpmm_target" 2>/dev/null)
+    _lpmm_gid=$(stat -c '%g' "$_lpmm_target" 2>/dev/null)
+    _lpmm_mode=$(stat -c '%a' "$_lpmm_target" 2>/dev/null)
+    [ -n "$_lpmm_uid" ] && [ -n "$_lpmm_gid" ] && chown "$_lpmm_uid:$_lpmm_gid" "$_lpmm_source" 2>/dev/null || true
+    chmod "${_lpmm_mode:-644}" "$_lpmm_source" 2>/dev/null || true
+    if command -v chcon >/dev/null 2>&1; then
+        _lpmm_context=$(ls -Zd "$_lpmm_target" 2>/dev/null | awk '{print $1}')
+        case "$_lpmm_context" in *:*:*:*) chcon "$_lpmm_context" "$_lpmm_source" 2>/dev/null || true ;; esac
+    fi
+}
+
 type init_module >/dev/null 2>&1 && init_module
 type ensure_public_storage >/dev/null 2>&1 && ensure_public_storage
 mkdir -p "$MODDIR/config" "$MODDIR/logs" "$MODDIR/system/fonts" 2>/dev/null || true

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -12,6 +12,7 @@ MODULE_DIR="$MODDIR"
 [ -f "$MODDIR/common/font_config_runtime.sh" ] && . "$MODDIR/common/font_config_runtime.sh"
 [ -f "$MODDIR/common/font_config_partitions.sh" ] && . "$MODDIR/common/font_config_partitions.sh"
 [ -f "$MODDIR/common/mount_compat.sh" ] && . "$MODDIR/common/mount_compat.sh"
+[ -f "$MODDIR/common/font_provider_cache.sh" ] && . "$MODDIR/common/font_provider_cache.sh"
 
 type init_module >/dev/null 2>&1 && init_module
 type ensure_public_storage >/dev/null 2>&1 && ensure_public_storage
@@ -55,14 +56,24 @@ elif type font_config_boot_guard >/dev/null 2>&1; then
     font_config_boot_guard "$ACTIVE_TEXT" || true
 fi
 
+# Android 12+ 会在系统字体配置之后追加 /data/fonts/config/config.xml 中的命名字体族。
+# Play 商店等应用请求 google-sans* 时会绕过 /system/fonts 的洛书文件，因此必须在
+# FontManagerService 初始化共享字体表之前完成配置桥接。这里只覆盖 XML 视图，不改写
+# /data/fonts/files 的签名字体、fs-verity、Emoji 或其他动态字体。
+if type luoshu_provider_cache_boot >/dev/null 2>&1; then
+    _provider_rc=0
+    luoshu_provider_cache_boot "$ACTIVE_TEXT" || _provider_rc=$?
+    case "$_provider_rc" in
+        0) log_message "INFO" "开机前动态 Google Sans 字体桥已启用" ;;
+        2) log_message "INFO" "设备没有动态 Google Sans family，无需桥接" ;;
+        *) log_message "ERROR" "动态 Google Sans 字体桥失败（code=$_provider_rc），继续使用 ROM 原配置" ;;
+    esac
+fi
+
 for _partition in system system_ext product vendor odm oem my_product my_engineering my_company my_preload my_region my_stock oplus_product oplus_engineering oplus_version oplus_region mi_ext cust; do
     [ -d "$MODDIR/$_partition" ] || continue
     set_perm_recursive "$MODDIR/$_partition" 0 0 0755 0644 2>/dev/null || true
 done
-
-# 无 Hook 版不读写 /data/fonts。Android 的动态字体数据库由 FontManagerService、签名权限
-# 和 fs-verity 管理；洛书只使用启动前的 systemless 分区负载与字体配置。
-log_message "INFO" "动态字体数据库保持原样；使用 systemless XML/字体负载"
 
 # 字体索引由原生 App 按需刷新，启动早期不扫描或复制大字体。
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# 洛书 v2.0.0：安全卸载。只恢复洛书明确记录的系统设置，不触碰 /data/fonts。
+# 洛书 v2：安全卸载。恢复系统设置并解除动态字体配置桥。
 set +e
 MODDIR="${0%/*}"
 MODULE_VERSION=$(sed -n 's/^version=//p' "$MODDIR/module.prop" 2>/dev/null | head -n1)
@@ -15,15 +15,13 @@ if command -v settings >/dev/null 2>&1; then
         settings put secure font_weight_adjustment "$_fw_restore" >/dev/null 2>&1 || true
 fi
 
-# 还原 GMS Fonts Provider 缓存劫持（切换字体时写入 /data/fonts/files 的副本），
-# 否则卸载模块后 Play 商店等应用仍停留在用户字体。
+# 解除开机前 Google Sans 命名字体桥；完整重启后系统自然恢复原始字体表。
 if [ -f "$MODDIR/common/font_provider_cache.sh" ]; then
     MODULE_DIR="$MODDIR"
     . "$MODDIR/common/font_provider_cache.sh"
     luoshu_provider_cache_restore >/dev/null 2>&1 || true
 fi
 
-# v2 使用 systemless 字体与 XML 负载，不删除 Android/OEM 管理的动态字体数据库。
 rm -f "$MODDIR/.first_boot" "$MODDIR/.font_switch.lock" 2>/dev/null || true
 mkdir -p "$MODDIR/logs" 2>/dev/null || true
 echo "[$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null)] 洛书 $MODULE_VERSION 已卸载" >> "$MODDIR/logs/fontswitch.log" 2>/dev/null || true


### PR DESCRIPTION
该 PR 不再作为独立 v2.1.3 发布。Play 动态字体问题将并入 v2.2.0 的逐设备原厂模板引擎统一处理：真实槽位扫描、原厂度量模板、逐字重派生、系统/OEM/动态字体配置统一映射与真机渲染验收。当前分支保留为研究记录，避免把单点方案误当成最终架构。