### PR TITLE
chore: 清理非正式版本和开发分支

### DIFF
--- a/.github/workflows/cleanup-nonstable.yml
+++ b/.github/workflows/cleanup-nonstable.yml
@@ -1,3 +1,4 @@
+# One-time cleanup run. This file deletes itself after success.
 name: Cleanup non-stable refs
 
 on:


### PR DESCRIPTION
保留 `main`、所有正式稳定 Release 及其标签；删除全部开发分支、预发行/草稿 Release、测试标签和无正式 Release 对应的孤立标签。清理成功后自动删除一次性工作流。