### PR TITLE
fix: 强化元模块同步与逐分区挂载验证

### DIFF
--- a/common/mount_compat.sh
+++ b/common/mount_compat.sh
@@ -1,27 +1,46 @@
 #!/system/bin/sh
-# LuoShu metamodule compatibility adapters.
-# Each mount engine has a different content contract; never mirror into guessed runtime paths.
+# LuoShu metamodule compatibility layer.
+#
+# The canonical module tree lives under /data/adb/modules/LuoShu. Some
+# metamodules use a second persistent content tree, while others read the
+# canonical tree directly. This file detects that contract, updates payloads
+# transactionally, and verifies every partition after reboot.
 set +e
 
 LUOSHU_MOUNT_MODDIR="${MODDIR:-${MODULE_DIR:-/data/adb/modules/LuoShu}}"
 LUOSHU_MOUNT_LOG="${LUOSHU_MOUNT_LOG:-$LUOSHU_MOUNT_MODDIR/logs/mount_compat.log}"
 LUOSHU_MOUNT_LOCK="$LUOSHU_MOUNT_MODDIR/.mount_compat.lock"
-LUOSHU_MOUNT_TIMEOUT="${LUOSHU_MOUNT_TIMEOUT:-120}"
+LUOSHU_MOUNT_TIMEOUT="${LUOSHU_MOUNT_TIMEOUT:-55}"
+LUOSHU_MOUNT_PREFLIGHT_ERROR=''
+LUOSHU_MOUNT_DETECTION_WARNING=''
+LUOSHU_MOUNT_STARTED_AT=0
+LUOSHU_MOUNT_DEADLINE=0
+
+case "$LUOSHU_MOUNT_TIMEOUT" in
+    ''|*[!0-9]*) LUOSHU_MOUNT_TIMEOUT=55 ;;
+esac
+if [ -z "${LUOSHU_META_TEST_ENGINE:-}" ] && [ "$LUOSHU_MOUNT_TIMEOUT" -lt 10 ] 2>/dev/null; then
+    LUOSHU_MOUNT_TIMEOUT=10
+fi
+[ "$LUOSHU_MOUNT_TIMEOUT" -ge 1 ] 2>/dev/null || LUOSHU_MOUNT_TIMEOUT=1
+[ "$LUOSHU_MOUNT_TIMEOUT" -le 300 ] 2>/dev/null || LUOSHU_MOUNT_TIMEOUT=300
 
 luoshu_mount_log() {
-    _lml_msg="$1"
+    _lml_message="$1"
     mkdir -p "${LUOSHU_MOUNT_LOG%/*}" 2>/dev/null || true
-    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" "$_lml_msg" >> "$LUOSHU_MOUNT_LOG" 2>/dev/null || true
+    printf '[%s] %s\n' \
+        "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" \
+        "$_lml_message" >> "$LUOSHU_MOUNT_LOG" 2>/dev/null || true
 }
 
 luoshu_module_id() {
     _lmi_id=$(sed -n 's/^id=//p' "$LUOSHU_MOUNT_MODDIR/module.prop" 2>/dev/null | head -n1 | tr -d '\r\n')
-    [ -n "$_lmi_id" ] || _lmi_id=$(basename "$LUOSHU_MOUNT_MODDIR")
+    [ -n "$_lmi_id" ] || _lmi_id=${LUOSHU_MOUNT_MODDIR##*/}
     printf '%s\n' "$_lmi_id"
 }
 
 luoshu_payload_partitions() {
-    printf '%s\n' 'system system_ext product vendor odm oem my_product my_engineering my_company my_preload my_region my_stock oplus_product oplus_engineering oplus_version oplus_region mi_ext cust'
+    printf '%s\n' 'system system_ext product vendor odm oem my_product my_engineering my_company my_preload my_region my_stock oplus_product oplus_engineering oplus_version oplus_region mi_ext cust hw_product'
 }
 
 luoshu_detect_root_manager() {
@@ -29,7 +48,7 @@ luoshu_detect_root_manager() {
         printf 'APatch\n'
     elif [ -n "${KSU:-}" ] || [ -d /data/adb/ksu ]; then
         printf 'KernelSU\n'
-    elif [ -n "${MAGISK_VER_CODE:-}" ] || [ -d /data/adb/magisk ] || [ -x /data/adb/magisk/magisk ]; then
+    elif [ -n "${MAGISK_VER_CODE:-}" ] || [ -d /data/adb/magisk ]; then
         printf 'Magisk\n'
     else
         printf 'unknown\n'
@@ -40,66 +59,165 @@ _luoshu_module_prop_id() {
     sed -n 's/^id=//p' "$1/module.prop" 2>/dev/null | head -n1 | tr -d '\r\n'
 }
 
-# Magic Mount has shipped under several module ids (including RC builds).  Detect it from
-# module metadata and its persistent configuration instead of relying on two directory names.
-luoshu_magic_mount_present() {
-    for _lmmp_prop in /data/adb/modules/*/module.prop; do
-        [ -f "$_lmmp_prop" ] || continue
-        _lmmp_dir=${_lmmp_prop%/*}
-        [ ! -e "$_lmmp_dir/disable" ] && [ ! -e "$_lmmp_dir/remove" ] || continue
-        _lmmp_meta=$(sed -n 's/^\(id\|name\|description\)=/\1=/p' "$_lmmp_prop" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr '\n' ' ')
-        case "$_lmmp_meta" in
-            *magic_mount*|*magic-mount*|*magic\ mount*|*id=meta-mm*) return 0 ;;
+_luoshu_module_enabled() {
+    [ -f "$1/module.prop" ] && [ ! -e "$1/disable" ] && [ ! -e "$1/remove" ]
+}
+
+_luoshu_module_metadata_matches() {
+    _lmmm_path="$1"
+    shift
+    _luoshu_module_enabled "$_lmmm_path" || return 1
+    _lmmm_metadata=$(sed -n 's/^\(id\|name\|description\)=/\1=/p' "$_lmmm_path/module.prop" 2>/dev/null \
+        | tr '[:upper:]' '[:lower:]' | tr '\n' ' ')
+    for _lmmm_token in "$@"; do
+        case "$_lmmm_metadata" in
+            *"$_lmmm_token"*) return 0 ;;
         esac
     done
-    # Some RC packages keep the stable config path while changing their module id.
+    return 1
+}
+
+luoshu_mountpoint_ready() {
+    _lmr_path="$1"
+    [ -n "${LUOSHU_META_TEST_ROOT:-}" ] && return 0
+    [ -e "$_lmr_path" ] || return 1
+    if command -v mountpoint >/dev/null 2>&1; then
+        mountpoint -q "$_lmr_path" 2>/dev/null && return 0
+    fi
+    awk -v path="$_lmr_path" '$2 == path { found=1 } END { exit !found }' /proc/mounts 2>/dev/null
+}
+
+_luoshu_magic_mount_present() {
+    for _lmmp_path in /data/adb/modules/*; do
+        [ -d "$_lmmp_path" ] || continue
+        _luoshu_module_metadata_matches "$_lmmp_path" \
+            magic_mount magic-mount 'magic mount' id=meta-mm && return 0
+    done
     [ -f /data/adb/magic_mount/config.toml ] && {
-        [ -x /data/adb/metamodule/meta-mm ] || [ -x /data/adb/metamodule/meta-mm-rs ] || \
-        [ -x /data/adb/modules/magic_mount_rs/meta-mm ] || [ -x /data/adb/modules/meta-mm/meta-mm ]
+        [ -x /data/adb/metamodule/meta-mm ] ||
+        [ -x /data/adb/metamodule/meta-mm-rs ] ||
+        [ -x /data/adb/modules/magic_mount_rs/meta-mm ]
     }
 }
 
-luoshu_detect_mount_engine() {
-    [ -z "${LUOSHU_META_TEST_ENGINE:-}" ] || { printf '%s\n' "$LUOSHU_META_TEST_ENGINE"; return 0; }
+_luoshu_mountify_present() {
+    for _lmp_path in \
+        /data/adb/modules/mountify \
+        /data/adb/modules/Mountify \
+        /data/adb/modules/*mountify*; do
+        [ -d "$_lmp_path" ] || continue
+        _luoshu_module_metadata_matches "$_lmp_path" mountify && return 0
+    done
+    return 1
+}
 
-    _ldme_meta_id=$(_luoshu_module_prop_id /data/adb/metamodule)
-    case "$_ldme_meta_id" in
-        meta-overlay|meta-overlayfs|meta-overlayfsUltra) printf 'meta-overlayfs\n'; return 0 ;;
+_luoshu_hybrid_mount_present() {
+    command -v hybrid-mount >/dev/null 2>&1 && return 0
+    for _lhmp_path in \
+        /data/adb/modules/meta-hybrid_mount \
+        /data/adb/modules/hybrid_mount \
+        /data/adb/modules/*hybrid*mount*; do
+        [ -d "$_lhmp_path" ] || continue
+        _luoshu_module_metadata_matches "$_lhmp_path" \
+            hybrid_mount hybrid-mount 'hybrid mount' && return 0
+    done
+    return 1
+}
+
+luoshu_hybrid_backend() {
+    if [ -n "${LUOSHU_META_TEST_BACKEND:-}" ]; then
+        printf '%s\n' "$LUOSHU_META_TEST_BACKEND"
+        return 0
+    fi
+
+    for _lhb_file in \
+        /data/adb/hybrid-mount/config.toml \
+        /data/adb/hybrid-mount/config.conf \
+        /data/adb/modules/meta-hybrid_mount/config.toml \
+        /data/adb/modules/meta-hybrid_mount/config.conf \
+        /data/adb/modules/hybrid_mount/config.toml; do
+        [ -f "$_lhb_file" ] || continue
+        _lhb_value=$(sed -n 's/^[[:space:]]*\(backend\|mount_backend\|mount_mode\|mode\)[[:space:]]*=[[:space:]]*//p' "$_lhb_file" 2>/dev/null \
+            | tail -n1 | cut -d'#' -f1 | tr -d "\"'[:space:]" | tr '[:upper:]' '[:lower:]')
+        case "$_lhb_value" in
+            *overlay*) printf 'overlayfs\n'; return 0 ;;
+            *magic*) printf 'magic-mount\n'; return 0 ;;
+            *kasumi*) printf 'kasumi\n'; return 0 ;;
+        esac
+    done
+    printf 'unknown\n'
+}
+
+_luoshu_meta_overlayfs_active() {
+    _lmoa_id=$(_luoshu_module_prop_id /data/adb/metamodule)
+    case "$_lmoa_id" in
+        meta-overlay|meta-overlayfs|meta-overlayfsUltra) ;;
+        *) return 1 ;;
     esac
+    [ ! -e /data/adb/metamodule/disable ] || return 1
+    [ ! -e /data/adb/metamodule/remove ] || return 1
+    [ -d /data/adb/metamodule/mnt ] || return 1
+    luoshu_mountpoint_ready /data/adb/metamodule/mnt && return 0
+    [ -f /data/adb/metamodule/modules.img ] || [ -L /data/adb/metamodule ]
+}
+
+_luoshu_mount_candidates() {
+    if [ -n "${LUOSHU_META_TEST_CANDIDATES:-}" ]; then
+        printf '%s\n' "$LUOSHU_META_TEST_CANDIDATES"
+        return 0
+    fi
+
+    _lmc_candidates=''
+    _luoshu_meta_overlayfs_active && _lmc_candidates="$_lmc_candidates meta-overlayfs"
+    _luoshu_hybrid_mount_present && _lmc_candidates="$_lmc_candidates hybrid-mount"
+    _luoshu_mountify_present && _lmc_candidates="$_lmc_candidates mountify"
+    _luoshu_magic_mount_present && _lmc_candidates="$_lmc_candidates magic-mount"
+    printf '%s\n' "$_lmc_candidates"
+}
+
+luoshu_mount_detection_warning() {
+    _lmdw_candidates=$(_luoshu_mount_candidates)
+    _lmdw_count=$(printf '%s\n' "$_lmdw_candidates" | awk '{ print NF }')
+    [ "${_lmdw_count:-0}" -le 1 ] && return 0
+    printf '检测到多个已启用挂载模块：%s\n' \
+        "$(printf '%s\n' "$_lmdw_candidates" | sed 's/^ *//; s/  */、/g')"
+}
+
+luoshu_detect_mount_engine() {
+    LUOSHU_MOUNT_DETECTION_WARNING=''
+    if [ -n "${LUOSHU_META_TEST_ENGINE:-}" ]; then
+        printf '%s\n' "$LUOSHU_META_TEST_ENGINE"
+        return 0
+    fi
     if [ -n "${MODULE_CONTENT_DIR:-}" ] && [ -n "${MODULE_METADATA_DIR:-}" ]; then
         printf 'dual-dir-metamodule\n'
         return 0
     fi
-    if [ -d /data/adb/metamodule/mnt ] && { [ -f /data/adb/metamodule/modules.img ] || [ -L /data/adb/metamodule ]; }; then
-        printf 'meta-overlayfs\n'
-        return 0
+
+    _ldme_candidates=$(_luoshu_mount_candidates)
+    _ldme_count=$(printf '%s\n' "$_ldme_candidates" | awk '{ print NF }')
+    if [ "${_ldme_count:-0}" -gt 1 ]; then
+        LUOSHU_MOUNT_DETECTION_WARNING=$(luoshu_mount_detection_warning)
+        luoshu_mount_log "$LUOSHU_MOUNT_DETECTION_WARNING"
     fi
 
-    if [ -d /data/adb/mountify ] || [ -d /data/adb/modules/mountify ] || [ -d /data/adb/modules/Mountify ]; then
-        printf 'mountify\n'
-        return 0
-    fi
-    if command -v hybrid-mount >/dev/null 2>&1 || [ -d /data/adb/hybrid-mount ] || \
-       [ -d /data/adb/modules/meta-hybrid_mount ] || [ -d /data/adb/modules/hybrid_mount ]; then
-        printf 'hybrid-mount\n'
-        return 0
-    fi
-    if luoshu_magic_mount_present; then
-        printf 'magic-mount\n'
-        return 0
-    fi
-    printf 'native-module-mount\n'
+    case " $_ldme_candidates " in
+        *' meta-overlayfs '*) printf 'meta-overlayfs\n' ;;
+        *' hybrid-mount '*) printf 'hybrid-mount\n' ;;
+        *' mountify '*) printf 'mountify\n' ;;
+        *' magic-mount '*) printf 'magic-mount\n' ;;
+        *) printf 'native-module-mount\n' ;;
+    esac
 }
 
-luoshu_engine_partitions() {
-    case "${1:-$(luoshu_detect_mount_engine)}" in
-        meta-overlayfs|dual-dir-metamodule)
-            # Official meta-overlayfs relocates only these six partitions during installation.
-            printf '%s\n' 'system vendor product system_ext odm oem'
-            ;;
-        *)
-            luoshu_payload_partitions
-            ;;
+luoshu_mount_backend() {
+    _lmb_engine="${1:-$(luoshu_detect_mount_engine)}"
+    case "$_lmb_engine" in
+        hybrid-mount) luoshu_hybrid_backend ;;
+        meta-overlayfs|dual-dir-metamodule) printf 'overlayfs\n' ;;
+        mountify) printf 'mountify\n' ;;
+        magic-mount|magic-mount-rs) printf 'magic-mount\n' ;;
+        *) printf 'native\n' ;;
     esac
 }
 
@@ -113,48 +231,45 @@ luoshu_dual_content_base() {
     fi
 }
 
-# Only dual-directory metamodules expose a second persistent module tree.
-# Mountify, Hybrid Mount and Magic Mount read /data/adb/modules directly and must never be mirrored.
 luoshu_meta_content_roots() {
     _lmcr_engine=$(luoshu_detect_mount_engine)
-    case "$_lmcr_engine" in meta-overlayfs|dual-dir-metamodule) ;; *) return 0 ;; esac
+    case "$_lmcr_engine" in
+        meta-overlayfs|dual-dir-metamodule) ;;
+        *) return 0 ;;
+    esac
+
     _lmcr_base=$(luoshu_dual_content_base)
     _lmcr_id=$(luoshu_module_id)
-    case "$_lmcr_base" in */"$_lmcr_id") _lmcr_root="$_lmcr_base" ;; *) _lmcr_root="$_lmcr_base/$_lmcr_id" ;; esac
-    [ "$_lmcr_root" != "$LUOSHU_MOUNT_MODDIR" ] || return 0
-    printf '%s\n' "$_lmcr_root"
+    case "$_lmcr_base" in
+        */"$_lmcr_id") _lmcr_root="$_lmcr_base" ;;
+        *) _lmcr_root="$_lmcr_base/$_lmcr_id" ;;
+    esac
+    [ "$_lmcr_root" = "$LUOSHU_MOUNT_MODDIR" ] || printf '%s\n' "$_lmcr_root"
 }
 
 luoshu_mount_lock_acquire() {
     if [ -f "$LUOSHU_MOUNT_LOCK" ]; then
         _lmla_pid=$(cat "$LUOSHU_MOUNT_LOCK" 2>/dev/null)
         if [ -n "$_lmla_pid" ] && kill -0 "$_lmla_pid" 2>/dev/null; then
-            luoshu_mount_log "拒绝并发元模块更新：pid=$_lmla_pid"
             return 1
         fi
         rm -f "$LUOSHU_MOUNT_LOCK" 2>/dev/null || true
     fi
-    printf '%s\n' "$$" > "$LUOSHU_MOUNT_LOCK" 2>/dev/null || return 1
+    printf '%s\n' "$$" > "$LUOSHU_MOUNT_LOCK" 2>/dev/null
 }
 
 luoshu_mount_lock_release() {
     rm -f "$LUOSHU_MOUNT_LOCK" 2>/dev/null || true
 }
 
-luoshu_mountpoint_ready() {
-    _lmr_path="$1"
-    [ -n "${LUOSHU_META_TEST_ROOT:-}" ] && return 0
-    if command -v mountpoint >/dev/null 2>&1; then
-        mountpoint -q "$_lmr_path" 2>/dev/null && return 0
-    fi
-    awk -v p="$_lmr_path" '$2 == p { found=1 } END { exit !found }' /proc/mounts 2>/dev/null
-}
-
 luoshu_mountify_value() {
     _lmv_key="$1"
-    for _lmv_conf in /data/adb/mountify/config.sh /data/adb/modules/mountify/config.sh /data/adb/modules/Mountify/config.sh; do
-        [ -f "$_lmv_conf" ] || continue
-        sed -n "s/^[[:space:]]*${_lmv_key}[[:space:]]*=[[:space:]]*[\"']\{0,1\}\([^\"'#[:space:]]*\).*/\1/p" "$_lmv_conf" 2>/dev/null | tail -n1
+    for _lmv_file in \
+        /data/adb/mountify/config.sh \
+        /data/adb/modules/mountify/config.sh \
+        /data/adb/modules/Mountify/config.sh; do
+        [ -f "$_lmv_file" ] || continue
+        sed -n "s/^[[:space:]]*${_lmv_key}[[:space:]]*=[[:space:]]*[\"']\{0,1\}\([^\"'#[:space:]]*\).*/\1/p" "$_lmv_file" 2>/dev/null | tail -n1
         return 0
     done
     return 1
@@ -165,51 +280,116 @@ luoshu_mountify_module_selected() {
     _lmms_mode=$(luoshu_mountify_value mountify_mounts)
     [ -n "$_lmms_mode" ] || _lmms_mode=2
     [ "$_lmms_mode" != 1 ] && return 0
-    for _lmms_list in /data/adb/mountify/modules.txt /data/adb/modules/mountify/modules.txt /data/adb/modules/Mountify/modules.txt; do
-        [ -f "$_lmms_list" ] || continue
-        grep -Fxq "$_lmms_id" "$_lmms_list" 2>/dev/null && return 0
+
+    for _lmms_file in \
+        /data/adb/mountify/modules.txt \
+        /data/adb/modules/mountify/modules.txt \
+        /data/adb/modules/Mountify/modules.txt; do
+        [ -f "$_lmms_file" ] || continue
+        grep -Fxq "$_lmms_id" "$_lmms_file" 2>/dev/null && return 0
     done
     return 1
 }
 
-LUOSHU_MOUNT_PREFLIGHT_ERROR=''
 luoshu_recover_explicit_disable() {
     [ -e "$LUOSHU_MOUNT_MODDIR/disable" ] || return 0
     rm -f "$LUOSHU_MOUNT_MODDIR/disable" 2>/dev/null || {
         LUOSHU_MOUNT_PREFLIGHT_ERROR='无法解除洛书模块的 disable 标记'
         return 1
     }
-    rm -f "$LUOSHU_MOUNT_MODDIR/config/font-boot-failures" \
-          "$LUOSHU_MOUNT_MODDIR/config/font-payload-quarantine.conf" 2>/dev/null || true
-    luoshu_mount_log '用户已明确发起字体事务；已解除洛书 disable 标记并恢复模块'
-    return 0
+    rm -f \
+        "$LUOSHU_MOUNT_MODDIR/config/font-boot-failures" \
+        "$LUOSHU_MOUNT_MODDIR/config/font-payload-quarantine.conf" 2>/dev/null || true
+    luoshu_mount_log '已解除洛书 disable 标记'
 }
 
 luoshu_recover_magic_mount_markers() {
     _lrmm_engine="$1"
-    [ "$_lrmm_engine" = magic-mount ] || [ "$_lrmm_engine" = magic-mount-rs ] || return 0
+    case "$_lrmm_engine" in
+        magic-mount|magic-mount-rs) ;;
+        *) return 0 ;;
+    esac
 
-    # A previous Mountify/native-mount attempt can leave these markers behind.  Starting an
-    # explicit LuoShu font transaction is an intentional retry, so clear only LuoShu's own
-    # recoverable mount markers.  disable/remove remain hard failures.
-    _lrmm_cleared=''
     for _lrmm_marker in skip_mount mount_error; do
         [ -e "$LUOSHU_MOUNT_MODDIR/$_lrmm_marker" ] || continue
         rm -f "$LUOSHU_MOUNT_MODDIR/$_lrmm_marker" 2>/dev/null || {
             LUOSHU_MOUNT_PREFLIGHT_ERROR="无法清理 Magic Mount 遗留标记：$_lrmm_marker"
             return 1
         }
-        _lrmm_cleared="${_lrmm_cleared}${_lrmm_cleared:+,}$_lrmm_marker"
     done
-    [ -z "$_lrmm_cleared" ] || luoshu_mount_log "Magic Mount 重试已清理洛书遗留标记：$_lrmm_cleared"
-    return 0
+}
+
+_luoshu_partition_has_payload() {
+    _lphp_partition="$1"
+    [ -d "$LUOSHU_MOUNT_MODDIR/$_lphp_partition" ] || return 1
+    find "$LUOSHU_MOUNT_MODDIR/$_lphp_partition" -type f -print -quit 2>/dev/null | grep -q .
+}
+
+luoshu_used_partitions() {
+    _lup_content_root="${1:-}"
+    for _lup_partition in $(luoshu_payload_partitions); do
+        if _luoshu_partition_has_payload "$_lup_partition"; then
+            printf '%s\n' "$_lup_partition"
+        elif [ -n "$_lup_content_root" ] && [ -e "$_lup_content_root/$_lup_partition" ]; then
+            printf '%s\n' "$_lup_partition"
+        fi
+    done
+}
+
+_luoshu_meta_declared_partitions() {
+    printf '%s\n' "${LUOSHU_META_EXTRA_PARTITIONS:-}"
+    for _lmdp_file in \
+        /data/adb/metamodule/config.toml \
+        /data/adb/metamodule/config.conf \
+        /data/adb/modules/meta-overlayfs/config.toml; do
+        [ -f "$_lmdp_file" ] || continue
+        awk -F'"' '/partition|mount/ { for (i=2; i<=NF; i+=2) if ($i ~ /^[A-Za-z0-9_]+$/) print $i }' "$_lmdp_file"
+    done
+}
+
+luoshu_meta_partition_supported() {
+    _lmps_partition="$1"
+    case "$_lmps_partition" in
+        system|vendor|product|system_ext|odm|oem) return 0 ;;
+    esac
+    _lmps_declared=$(_luoshu_meta_declared_partitions | tr '\n' ' ')
+    case " $_lmps_declared " in
+        *" $_lmps_partition "*) return 0 ;;
+    esac
+    return 1
+}
+
+luoshu_engine_partitions() {
+    _lep_engine="${1:-$(luoshu_detect_mount_engine)}"
+    case "$_lep_engine" in
+        meta-overlayfs|dual-dir-metamodule)
+            for _lep_partition in $(luoshu_payload_partitions); do
+                luoshu_meta_partition_supported "$_lep_partition" && printf '%s\n' "$_lep_partition"
+            done
+            ;;
+        *) luoshu_payload_partitions ;;
+    esac
 }
 
 luoshu_magic_mount_ensure_partitions() {
     _lmep_engine="$1"
-    [ "$_lmep_engine" = magic-mount ] || [ "$_lmep_engine" = magic-mount-rs ] || return 0
+    case "$_lmep_engine" in
+        magic-mount|magic-mount-rs) ;;
+        *) return 0 ;;
+    esac
+
     _lmep_config="${LUOSHU_MAGIC_MOUNT_CONFIG:-/data/adb/magic_mount/config.toml}"
     [ -f "$_lmep_config" ] || return 0
+    _lmep_lock="$_lmep_config.luoshu.lock"
+    if [ -f "$_lmep_lock" ]; then
+        _lmep_pid=$(cat "$_lmep_lock" 2>/dev/null)
+        if [ -n "$_lmep_pid" ] && kill -0 "$_lmep_pid" 2>/dev/null; then
+            LUOSHU_MOUNT_PREFLIGHT_ERROR='Magic Mount 配置正在被修改'
+            return 1
+        fi
+        rm -f "$_lmep_lock" 2>/dev/null || true
+    fi
+    printf '%s\n' "$$" > "$_lmep_lock" 2>/dev/null || return 1
 
     _lmep_current=$(awk '
         /^[[:space:]]*partitions[[:space:]]*=/ { capture=1 }
@@ -217,35 +397,37 @@ luoshu_magic_mount_ensure_partitions() {
         capture && /]/ { exit }
     ' "$_lmep_config" 2>/dev/null)
     _lmep_list=''
-    for _lmep_item in $(printf '%s\n' "$_lmep_current" | awk -F'"' '{ for (i=2; i<=NF; i+=2) print $i }' 2>/dev/null); do
+    for _lmep_item in $(printf '%s\n' "$_lmep_current" | awk -F'"' '{ for (i=2; i<=NF; i+=2) print $i }'); do
         case "$_lmep_item" in ''|*[!A-Za-z0-9_]*) continue ;; esac
-        case " $_lmep_list " in *" $_lmep_item "*) ;; *) _lmep_list="${_lmep_list}${_lmep_list:+ }$_lmep_item" ;; esac
+        case " $_lmep_list " in
+            *" $_lmep_item "*) ;;
+            *) _lmep_list="$_lmep_list $_lmep_item" ;;
+        esac
     done
 
     _lmep_added=''
-    for _lmep_part in system_ext product vendor odm oem my_product my_engineering my_company \
-        my_preload my_region my_stock oplus_product oplus_engineering oplus_version oplus_region mi_ext cust; do
-        _lmep_dir="$LUOSHU_MOUNT_MODDIR/$_lmep_part"
-        [ -d "$_lmep_dir" ] || continue
-        find "$_lmep_dir" -type f -print -quit 2>/dev/null | grep -q . || continue
+    for _lmep_partition in $(luoshu_used_partitions); do
+        [ "$_lmep_partition" = system ] && continue
         case " $_lmep_list " in
-            *" $_lmep_part "*) ;;
+            *" $_lmep_partition "*) ;;
             *)
-                _lmep_list="${_lmep_list}${_lmep_list:+ }$_lmep_part"
-                _lmep_added="${_lmep_added}${_lmep_added:+,}$_lmep_part"
+                _lmep_list="$_lmep_list $_lmep_partition"
+                _lmep_added="${_lmep_added}${_lmep_added:+,}$_lmep_partition"
                 ;;
         esac
     done
-    [ -n "$_lmep_added" ] || return 0
+    if [ -z "$_lmep_added" ]; then
+        rm -f "$_lmep_lock" 2>/dev/null || true
+        return 0
+    fi
 
     _lmep_array=''
     for _lmep_item in $_lmep_list; do
         _lmep_array="${_lmep_array}${_lmep_array:+, }\"$_lmep_item\""
     done
-    _lmep_replacement="partitions = [$_lmep_array]"
-    _lmep_temp="${_lmep_config}.tmp.$$"
-    [ -f "${_lmep_config}.luoshu.bak" ] || cp -f "$_lmep_config" "${_lmep_config}.luoshu.bak" 2>/dev/null || true
-    awk -v replacement="$_lmep_replacement" '
+    _lmep_temp="$_lmep_config.luoshu.$$"
+    [ -f "$_lmep_config.luoshu.bak" ] || cp -pf "$_lmep_config" "$_lmep_config.luoshu.bak" 2>/dev/null || true
+    awk -v replacement="partitions = [$_lmep_array]" '
         BEGIN { replaced=0; skipping=0 }
         skipping { if ($0 ~ /]/) skipping=0; next }
         /^[[:space:]]*partitions[[:space:]]*=/ {
@@ -257,18 +439,23 @@ luoshu_magic_mount_ensure_partitions() {
         { print }
         END { if (!replaced) print replacement }
     ' "$_lmep_config" > "$_lmep_temp" 2>/dev/null || {
-        rm -f "$_lmep_temp" 2>/dev/null || true
-        LUOSHU_MOUNT_PREFLIGHT_ERROR="无法更新 Magic Mount 分区配置：$_lmep_added"
+        rm -f "$_lmep_temp" "$_lmep_lock" 2>/dev/null || true
+        LUOSHU_MOUNT_PREFLIGHT_ERROR='无法更新 Magic Mount 配置'
         return 1
     }
+    if [ "$(grep -c '^[[:space:]]*partitions[[:space:]]*=' "$_lmep_temp" 2>/dev/null)" -ne 1 ]; then
+        rm -f "$_lmep_temp" "$_lmep_lock" 2>/dev/null || true
+        LUOSHU_MOUNT_PREFLIGHT_ERROR='Magic Mount 配置校验失败'
+        return 1
+    fi
     chmod --reference="$_lmep_config" "$_lmep_temp" 2>/dev/null || chmod 0644 "$_lmep_temp" 2>/dev/null || true
     mv -f "$_lmep_temp" "$_lmep_config" 2>/dev/null || {
-        rm -f "$_lmep_temp" 2>/dev/null || true
-        LUOSHU_MOUNT_PREFLIGHT_ERROR="无法提交 Magic Mount 分区配置：$_lmep_added"
+        rm -f "$_lmep_temp" "$_lmep_lock" 2>/dev/null || true
+        LUOSHU_MOUNT_PREFLIGHT_ERROR='无法提交 Magic Mount 配置'
         return 1
     }
-    luoshu_mount_log "已补齐 Magic Mount 字体负载分区：$_lmep_added"
-    return 0
+    rm -f "$_lmep_lock" 2>/dev/null || true
+    luoshu_mount_log "Magic Mount 增加分区：$_lmep_added"
 }
 
 luoshu_mount_preflight() {
@@ -277,137 +464,261 @@ luoshu_mount_preflight() {
     _lmp_engine=$(luoshu_detect_mount_engine)
     _lmp_manager=$(luoshu_detect_root_manager)
 
-    # Applying a font or restoring the ROM default is an explicit module action. Older builds could
-    # leave disable behind but later discard the evidence that created it, so every explicit font
-    # transaction is also an explicit re-enable request. remove remains a hard failure.
     luoshu_recover_explicit_disable || return 1
-    if [ "$_lmp_active" != default ]; then
-        luoshu_recover_magic_mount_markers "$_lmp_engine" || return 1
+    [ "$_lmp_active" = default ] || luoshu_recover_magic_mount_markers "$_lmp_engine" || return 1
+    [ ! -e "$LUOSHU_MOUNT_MODDIR/remove" ] || {
+        LUOSHU_MOUNT_PREFLIGHT_ERROR='模块存在 remove 标记'
+        return 1
+    }
+    if [ "$_lmp_active" != default ] && [ -e "$LUOSHU_MOUNT_MODDIR/mount_error" ]; then
+        LUOSHU_MOUNT_PREFLIGHT_ERROR='模块存在 mount_error 标记'
+        return 1
     fi
-
-    for _lmp_marker in disable remove mount_error; do
-        if [ -e "$LUOSHU_MOUNT_MODDIR/$_lmp_marker" ]; then
-            [ "$_lmp_active" = default ] && continue
-            LUOSHU_MOUNT_PREFLIGHT_ERROR="模块存在 $_lmp_marker 标记，元模块不会挂载洛书"
-            return 1
-        fi
-    done
 
     case "$_lmp_engine" in
         meta-overlayfs|dual-dir-metamodule|hybrid-mount|magic-mount|magic-mount-rs)
             if [ "$_lmp_active" != default ] && [ -e "$LUOSHU_MOUNT_MODDIR/skip_mount" ]; then
-                LUOSHU_MOUNT_PREFLIGHT_ERROR='检测到 skip_mount，当前元模块会跳过洛书负载'
+                LUOSHU_MOUNT_PREFLIGHT_ERROR='检测到 skip_mount'
                 return 1
             fi
             ;;
         mountify)
             if [ "$_lmp_active" != default ]; then
-                if [ "$_lmp_manager" = Magisk ]; then
-                    if [ -e "$LUOSHU_MOUNT_MODDIR/skip_mountify" ]; then
-                        LUOSHU_MOUNT_PREFLIGHT_ERROR='检测到 skip_mountify，Mountify 已排除洛书'
-                        return 1
-                    fi
-                elif [ -e "$LUOSHU_MOUNT_MODDIR/skip_mount" ]; then
-                    LUOSHU_MOUNT_PREFLIGHT_ERROR='检测到 skip_mount，Mountify 已排除洛书'
+                if [ "$_lmp_manager" = Magisk ] && [ -e "$LUOSHU_MOUNT_MODDIR/skip_mountify" ]; then
+                    LUOSHU_MOUNT_PREFLIGHT_ERROR='检测到 skip_mountify'
                     return 1
                 fi
-                if ! luoshu_mountify_module_selected; then
-                    LUOSHU_MOUNT_PREFLIGHT_ERROR='Mountify 当前为白名单模式，但 modules.txt 未包含 LuoShu'
+                luoshu_mountify_module_selected || {
+                    LUOSHU_MOUNT_PREFLIGHT_ERROR='Mountify 白名单未包含 LuoShu'
                     return 1
-                fi
+                }
             fi
             ;;
     esac
 
-    if [ "$_lmp_active" != default ]; then
-        luoshu_magic_mount_ensure_partitions "$_lmp_engine" || return 1
-    fi
+    [ "$_lmp_active" = default ] || luoshu_magic_mount_ensure_partitions "$_lmp_engine" || return 1
 
     case "$_lmp_engine" in
         meta-overlayfs|dual-dir-metamodule)
             _lmp_base=$(luoshu_dual_content_base)
-            if ! luoshu_mountpoint_ready "$_lmp_base"; then
-                LUOSHU_MOUNT_PREFLIGHT_ERROR="元模块内容镜像未挂载：$_lmp_base；请先完整重启或重装元模块"
+            luoshu_mountpoint_ready "$_lmp_base" || {
+                LUOSHU_MOUNT_PREFLIGHT_ERROR="元模块内容镜像未挂载：$_lmp_base"
                 return 1
-            fi
+            }
             [ -w "$_lmp_base" ] || {
                 LUOSHU_MOUNT_PREFLIGHT_ERROR="元模块内容镜像不可写：$_lmp_base"
                 return 1
             }
+            _lmp_unsupported=''
+            for _lmp_partition in $(luoshu_used_partitions); do
+                luoshu_meta_partition_supported "$_lmp_partition" || \
+                    _lmp_unsupported="${_lmp_unsupported}${_lmp_unsupported:+,}$_lmp_partition"
+            done
+            [ -z "$_lmp_unsupported" ] || {
+                LUOSHU_MOUNT_PREFLIGHT_ERROR="meta-overlayfs 未声明支持分区：$_lmp_unsupported"
+                return 1
+            }
             ;;
     esac
-    return 0
+}
+
+_luoshu_now() {
+    date +%s 2>/dev/null || echo 0
+}
+
+luoshu_mount_budget_begin() {
+    LUOSHU_MOUNT_STARTED_AT=$(_luoshu_now)
+    LUOSHU_MOUNT_DEADLINE=$((LUOSHU_MOUNT_STARTED_AT + LUOSHU_MOUNT_TIMEOUT))
+}
+
+luoshu_mount_remaining() {
+    _lmr_now=$(_luoshu_now)
+    _lmr_left=$((LUOSHU_MOUNT_DEADLINE - _lmr_now))
+    [ "$_lmr_left" -gt 0 ] || _lmr_left=0
+    printf '%s\n' "$_lmr_left"
+}
+
+luoshu_kill_tree() {
+    _lkt_pid="$1"
+    if command -v pgrep >/dev/null 2>&1; then
+        for _lkt_child in $(pgrep -P "$_lkt_pid" 2>/dev/null); do
+            luoshu_kill_tree "$_lkt_child"
+        done
+    fi
+    kill -TERM "$_lkt_pid" 2>/dev/null || true
+    sleep 1
+    kill -KILL "$_lkt_pid" 2>/dev/null || true
+}
+
+luoshu_run_bounded() {
+    _lrb_seconds="$1"
+    shift
+    [ "$_lrb_seconds" -gt 0 ] || return 124
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$_lrb_seconds" "$@"
+        return $?
+    fi
+    if command -v toybox >/dev/null 2>&1 && toybox timeout --help >/dev/null 2>&1; then
+        toybox timeout "$_lrb_seconds" "$@"
+        return $?
+    fi
+
+    "$@" &
+    _lrb_pid=$!
+    _lrb_elapsed=0
+    while kill -0 "$_lrb_pid" 2>/dev/null && [ "$_lrb_elapsed" -lt "$_lrb_seconds" ]; do
+        sleep 1
+        _lrb_elapsed=$((_lrb_elapsed + 1))
+    done
+    if kill -0 "$_lrb_pid" 2>/dev/null; then
+        luoshu_kill_tree "$_lrb_pid"
+        wait "$_lrb_pid" 2>/dev/null || true
+        return 124
+    fi
+    wait "$_lrb_pid"
 }
 
 luoshu_copy_tree_bounded() {
-    _lctb_src="$1"
-    _lctb_dst="$2"
-    if command -v timeout >/dev/null 2>&1; then
-        timeout "$LUOSHU_MOUNT_TIMEOUT" cp -af "$_lctb_src" "$_lctb_dst" 2>/dev/null && return 0
-    elif command -v toybox >/dev/null 2>&1 && toybox timeout --help >/dev/null 2>&1; then
-        toybox timeout "$LUOSHU_MOUNT_TIMEOUT" cp -af "$_lctb_src" "$_lctb_dst" 2>/dev/null && return 0
-    else
-        cp -af "$_lctb_src" "$_lctb_dst" 2>/dev/null && return 0
-    fi
-    rm -rf "$_lctb_dst" 2>/dev/null || true
-    mkdir -p "$_lctb_dst" 2>/dev/null || return 1
-    cp -rfp "$_lctb_src/." "$_lctb_dst/" 2>/dev/null
+    _lctb_source="$1"
+    _lctb_destination="$2"
+    _lctb_remaining=$(luoshu_mount_remaining)
+    [ "$_lctb_remaining" -gt 0 ] || return 124
+    luoshu_run_bounded "$_lctb_remaining" cp -af "$_lctb_source" "$_lctb_destination"
 }
 
 luoshu_copy_partition_atomic() {
-    _lcpa_src="$1"
-    _lcpa_dst="$2"
-    _lcpa_parent=${_lcpa_dst%/*}
-    _lcpa_name=${_lcpa_dst##*/}
-    _lcpa_tmp="$_lcpa_parent/.${_lcpa_name}.luoshu.$$"
+    _lcpa_source="$1"
+    _lcpa_destination="$2"
+    _lcpa_parent=${_lcpa_destination%/*}
+    _lcpa_name=${_lcpa_destination##*/}
+    _lcpa_temp="$_lcpa_parent/.${_lcpa_name}.luoshu.$$"
     _lcpa_backup="$_lcpa_parent/.${_lcpa_name}.luoshu-backup.$$"
+
     mkdir -p "$_lcpa_parent" 2>/dev/null || return 1
-    rm -rf "$_lcpa_tmp" "$_lcpa_backup" 2>/dev/null || true
-    luoshu_copy_tree_bounded "$_lcpa_src" "$_lcpa_tmp" || { rm -rf "$_lcpa_tmp"; return 1; }
-    chmod -R u=rwX,go=rX "$_lcpa_tmp" 2>/dev/null || true
-    [ ! -e "$_lcpa_dst" ] || mv "$_lcpa_dst" "$_lcpa_backup" 2>/dev/null || { rm -rf "$_lcpa_tmp"; return 1; }
-    if mv "$_lcpa_tmp" "$_lcpa_dst" 2>/dev/null; then
+    rm -rf "$_lcpa_temp" "$_lcpa_backup" 2>/dev/null || true
+    luoshu_copy_tree_bounded "$_lcpa_source" "$_lcpa_temp" || {
+        _lcpa_result=$?
+        rm -rf "$_lcpa_temp" 2>/dev/null || true
+        return "$_lcpa_result"
+    }
+    chmod -R u=rwX,go=rX "$_lcpa_temp" 2>/dev/null || true
+
+    if [ -e "$_lcpa_destination" ]; then
+        mv "$_lcpa_destination" "$_lcpa_backup" 2>/dev/null || {
+            rm -rf "$_lcpa_temp" 2>/dev/null || true
+            return 1
+        }
+    fi
+    if mv "$_lcpa_temp" "$_lcpa_destination" 2>/dev/null; then
         rm -rf "$_lcpa_backup" 2>/dev/null || true
         return 0
     fi
-    rm -rf "$_lcpa_dst" 2>/dev/null || true
-    [ ! -e "$_lcpa_backup" ] || mv "$_lcpa_backup" "$_lcpa_dst" 2>/dev/null || true
-    rm -rf "$_lcpa_tmp" 2>/dev/null || true
+
+    rm -rf "$_lcpa_destination" 2>/dev/null || true
+    [ ! -e "$_lcpa_backup" ] || mv "$_lcpa_backup" "$_lcpa_destination" 2>/dev/null || true
+    rm -rf "$_lcpa_temp" 2>/dev/null || true
     return 1
 }
 
-luoshu_write_mount_probe() {
+_luoshu_probe_path() {
+    if [ "$1" = system ]; then
+        printf '/system/etc/luoshu/mount-probe.conf\n'
+    else
+        printf '/%s/etc/luoshu/mount-probe.conf\n' "$1"
+    fi
+}
+
+luoshu_write_mount_probes() {
     _lwmp_active="${1:-unknown}"
     _lwmp_engine=$(luoshu_detect_mount_engine)
     _lwmp_id=$(luoshu_module_id)
-    _lwmp_nonce="$(date +%s 2>/dev/null || echo 0)-$$"
-    _lwmp_dir="$LUOSHU_MOUNT_MODDIR/system/etc/luoshu"
-    mkdir -p "$_lwmp_dir" "$LUOSHU_MOUNT_MODDIR/config" 2>/dev/null || return 1
-    {
-        printf 'id=%s\n' "$_lwmp_id"
-        printf 'font=%s\n' "$_lwmp_active"
-        printf 'engine=%s\n' "$_lwmp_engine"
-        printf 'nonce=%s\n' "$_lwmp_nonce"
-    } > "$_lwmp_dir/mount-probe.conf.tmp.$$" 2>/dev/null || return 1
-    mv -f "$_lwmp_dir/mount-probe.conf.tmp.$$" "$_lwmp_dir/mount-probe.conf" 2>/dev/null || return 1
-    cp -f "$_lwmp_dir/mount-probe.conf" "$LUOSHU_MOUNT_MODDIR/config/mount-probe-expected.conf" 2>/dev/null || return 1
-    chmod 0644 "$_lwmp_dir/mount-probe.conf" "$LUOSHU_MOUNT_MODDIR/config/mount-probe-expected.conf" 2>/dev/null || true
+    _lwmp_nonce="$(_luoshu_now)-$$"
+    _lwmp_manifest="$LUOSHU_MOUNT_MODDIR/config/mount-probes-expected.conf"
+    _lwmp_temp="$_lwmp_manifest.tmp.$$"
+    _lwmp_count=0
+
+    mkdir -p "$LUOSHU_MOUNT_MODDIR/config" 2>/dev/null || return 1
+    : > "$_lwmp_temp" 2>/dev/null || return 1
+    for _lwmp_partition in $(luoshu_used_partitions); do
+        _lwmp_directory="$LUOSHU_MOUNT_MODDIR/$_lwmp_partition/etc/luoshu"
+        mkdir -p "$_lwmp_directory" 2>/dev/null || return 1
+        {
+            printf 'id=%s\n' "$_lwmp_id"
+            printf 'font=%s\n' "$_lwmp_active"
+            printf 'engine=%s\n' "$_lwmp_engine"
+            printf 'partition=%s\n' "$_lwmp_partition"
+            printf 'nonce=%s-%s\n' "$_lwmp_nonce" "$_lwmp_partition"
+        } > "$_lwmp_directory/mount-probe.conf.tmp.$$" 2>/dev/null || return 1
+        mv -f "$_lwmp_directory/mount-probe.conf.tmp.$$" "$_lwmp_directory/mount-probe.conf" 2>/dev/null || return 1
+        chmod 0644 "$_lwmp_directory/mount-probe.conf" 2>/dev/null || true
+        printf '%s|%s-%s|%s\n' \
+            "$_lwmp_partition" "$_lwmp_nonce" "$_lwmp_partition" \
+            "$(_luoshu_probe_path "$_lwmp_partition")" >> "$_lwmp_temp"
+        _lwmp_count=$((_lwmp_count + 1))
+    done
+
+    if [ "$_lwmp_count" -eq 0 ]; then
+        _lwmp_directory="$LUOSHU_MOUNT_MODDIR/system/etc/luoshu"
+        mkdir -p "$_lwmp_directory" 2>/dev/null || return 1
+        {
+            printf 'id=%s\n' "$_lwmp_id"
+            printf 'font=%s\n' "$_lwmp_active"
+            printf 'engine=%s\n' "$_lwmp_engine"
+            printf 'partition=system\n'
+            printf 'nonce=%s-system\n' "$_lwmp_nonce"
+        } > "$_lwmp_directory/mount-probe.conf" 2>/dev/null || return 1
+        printf 'system|%s-system|/system/etc/luoshu/mount-probe.conf\n' "$_lwmp_nonce" >> "$_lwmp_temp"
+    fi
+
+    mv -f "$_lwmp_temp" "$_lwmp_manifest" 2>/dev/null || return 1
+    chmod 0644 "$_lwmp_manifest" 2>/dev/null || true
+    cp -f \
+        "$LUOSHU_MOUNT_MODDIR/system/etc/luoshu/mount-probe.conf" \
+        "$LUOSHU_MOUNT_MODDIR/config/mount-probe-expected.conf" 2>/dev/null || true
+}
+
+# Compatibility with callers from earlier releases.
+luoshu_write_mount_probe() {
+    luoshu_write_mount_probes "$@"
 }
 
 luoshu_mount_record() {
-    _lmr_state="$1"; _lmr_detail="$2"; _lmr_root="$3"; _lmr_synced="$4"; _lmr_failed="$5"
+    _lmr_state="$1"
+    _lmr_detail="$2"
+    _lmr_root="$3"
+    _lmr_synced="$4"
+    _lmr_failed="$5"
+    _lmr_partitions="${6:-}"
+    _lmr_verified="${7:-}"
+    _lmr_failed_partitions="${8:-}"
+    _lmr_unsupported="${9:-}"
+    _lmr_time=$(_luoshu_now)
+    _lmr_duration=0
+    [ "$LUOSHU_MOUNT_STARTED_AT" -gt 0 ] && _lmr_duration=$((_lmr_time - LUOSHU_MOUNT_STARTED_AT))
+    _lmr_warning="$LUOSHU_MOUNT_DETECTION_WARNING"
+    [ -n "$_lmr_warning" ] || _lmr_warning=$(luoshu_mount_detection_warning)
+
     mkdir -p "$LUOSHU_MOUNT_MODDIR/config" 2>/dev/null || true
     {
         printf 'manager=%s\n' "$(luoshu_detect_root_manager)"
         printf 'engine=%s\n' "$(luoshu_detect_mount_engine)"
+        printf 'backend=%s\n' "$(luoshu_mount_backend)"
         printf 'state=%s\n' "$_lmr_state"
         printf 'detail=%s\n' "$_lmr_detail"
+        printf 'warning=%s\n' "$_lmr_warning"
         printf 'contentRoot=%s\n' "$_lmr_root"
         printf 'synced=%s\n' "$_lmr_synced"
         printf 'failed=%s\n' "$_lmr_failed"
-        printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
-    } > "$LUOSHU_MOUNT_MODDIR/config/mount_compat.conf.tmp.$$" 2>/dev/null || return 0
-    mv -f "$LUOSHU_MOUNT_MODDIR/config/mount_compat.conf.tmp.$$" "$LUOSHU_MOUNT_MODDIR/config/mount_compat.conf" 2>/dev/null || true
+        printf 'partitions=%s\n' "$_lmr_partitions"
+        printf 'verifiedPartitions=%s\n' "$_lmr_verified"
+        printf 'failedPartitions=%s\n' "$_lmr_failed_partitions"
+        printf 'unsupportedPartitions=%s\n' "$_lmr_unsupported"
+        printf 'durationSeconds=%s\n' "$_lmr_duration"
+        printf 'time=%s\n' "$_lmr_time"
+    } > "$LUOSHU_MOUNT_MODDIR/config/mount_compat.conf.tmp.$$" 2>/dev/null && \
+        mv -f "$LUOSHU_MOUNT_MODDIR/config/mount_compat.conf.tmp.$$" \
+            "$LUOSHU_MOUNT_MODDIR/config/mount_compat.conf" 2>/dev/null || true
 }
 
 luoshu_sync_mount_payload() {
@@ -417,71 +728,88 @@ luoshu_sync_mount_payload() {
     _lsmp_synced=0
     _lsmp_failed=0
     _lsmp_root=''
+    _lsmp_partitions=''
+    _lsmp_failed_partitions=''
 
+    luoshu_mount_budget_begin
     luoshu_mount_lock_acquire || return 1
     trap 'luoshu_mount_lock_release' EXIT HUP INT TERM
+
     if ! luoshu_mount_preflight "$_lsmp_active"; then
         luoshu_mount_record failed "$LUOSHU_MOUNT_PREFLIGHT_ERROR" '' 0 1
-        luoshu_mount_log "元模块预检失败：engine=$_lsmp_engine error=$LUOSHU_MOUNT_PREFLIGHT_ERROR"
         luoshu_mount_lock_release
         trap - EXIT HUP INT TERM
         return 1
     fi
-    luoshu_write_mount_probe "$_lsmp_active" || {
-        luoshu_mount_record failed '无法生成挂载探针' '' 0 1
+    if ! luoshu_write_mount_probes "$_lsmp_active"; then
+        luoshu_mount_record failed '无法生成分区挂载探针' '' 0 1
         luoshu_mount_lock_release
         trap - EXIT HUP INT TERM
         return 1
-    }
+    fi
 
     case "$_lsmp_engine" in
         meta-overlayfs|dual-dir-metamodule)
             _lsmp_root=$(luoshu_meta_content_roots | head -n1)
-            [ -n "$_lsmp_root" ] || _lsmp_failed=1
+            [ -n "$_lsmp_root" ] && mkdir -p "$_lsmp_root" 2>/dev/null || _lsmp_failed=1
             if [ "$_lsmp_failed" -eq 0 ]; then
-                mkdir -p "$_lsmp_root" 2>/dev/null || _lsmp_failed=1
-            fi
-            if [ "$_lsmp_failed" -eq 0 ]; then
-                for _lsmp_part in $(luoshu_engine_partitions "$_lsmp_engine"); do
-                    _lsmp_src="$LUOSHU_MOUNT_MODDIR/$_lsmp_part"
-                    _lsmp_dst="$_lsmp_root/$_lsmp_part"
-                    if [ -d "$_lsmp_src" ]; then
-                        if luoshu_copy_partition_atomic "$_lsmp_src" "$_lsmp_dst"; then
+                for _lsmp_partition in $(luoshu_used_partitions "$_lsmp_root"); do
+                    _lsmp_partitions="${_lsmp_partitions}${_lsmp_partitions:+,}$_lsmp_partition"
+                    _lsmp_source="$LUOSHU_MOUNT_MODDIR/$_lsmp_partition"
+                    _lsmp_destination="$_lsmp_root/$_lsmp_partition"
+                    if [ -d "$_lsmp_source" ]; then
+                        if luoshu_copy_partition_atomic "$_lsmp_source" "$_lsmp_destination"; then
                             _lsmp_synced=$((_lsmp_synced + 1))
                         else
+                            _lsmp_result=$?
                             _lsmp_failed=$((_lsmp_failed + 1))
+                            _lsmp_failed_partitions="${_lsmp_failed_partitions}${_lsmp_failed_partitions:+,}$_lsmp_partition"
+                            if [ "$_lsmp_result" -eq 124 ]; then
+                                LUOSHU_MOUNT_PREFLIGHT_ERROR="元模块同步超过 ${LUOSHU_MOUNT_TIMEOUT} 秒总时限"
+                            fi
                             break
                         fi
-                    else
-                        rm -rf "$_lsmp_dst" 2>/dev/null || _lsmp_failed=$((_lsmp_failed + 1))
+                    elif ! rm -rf "$_lsmp_destination" 2>/dev/null; then
+                        _lsmp_failed=$((_lsmp_failed + 1))
+                        _lsmp_failed_partitions="${_lsmp_failed_partitions}${_lsmp_failed_partitions:+,}$_lsmp_partition"
+                        break
                     fi
                 done
             fi
             ;;
         *)
-            # Direct-source engines rescan the canonical module tree on the next reboot.
-            _lsmp_synced=0
+            for _lsmp_partition in $(luoshu_used_partitions); do
+                _lsmp_partitions="${_lsmp_partitions}${_lsmp_partitions:+,}$_lsmp_partition"
+            done
             ;;
     esac
 
     luoshu_mount_lock_release
     trap - EXIT HUP INT TERM
     if [ "$_lsmp_failed" -gt 0 ]; then
-        luoshu_mount_record failed '元模块内容更新失败，已保留旧分区目录' "$_lsmp_root" "$_lsmp_synced" "$_lsmp_failed"
-        luoshu_mount_log "元模块更新失败：engine=$_lsmp_engine root=$_lsmp_root synced=$_lsmp_synced failed=$_lsmp_failed"
+        luoshu_mount_record failed \
+            "${LUOSHU_MOUNT_PREFLIGHT_ERROR:-元模块内容更新失败，已保留旧分区目录}" \
+            "$_lsmp_root" "$_lsmp_synced" "$_lsmp_failed" \
+            "$_lsmp_partitions" '' "$_lsmp_failed_partitions"
         return 1
     fi
-    if [ "$_lsmp_engine" = meta-overlayfs ] || [ "$_lsmp_engine" = dual-dir-metamodule ]; then
-        luoshu_mount_record prepared '已写入元模块真实内容镜像，等待重启验证' "$_lsmp_root" "$_lsmp_synced" 0
-    else
-        luoshu_mount_record prepared '当前引擎直接读取标准模块目录，等待重启验证' '' 0 0
-    fi
-    luoshu_mount_log "元模块适配完成：engine=$_lsmp_engine root=$_lsmp_root synced=$_lsmp_synced"
-    return 0
+
+    case "$_lsmp_engine" in
+        meta-overlayfs|dual-dir-metamodule)
+            luoshu_mount_record prepared \
+                '已原子写入元模块真实内容镜像，等待重启逐分区验证' \
+                "$_lsmp_root" "$_lsmp_synced" 0 "$_lsmp_partitions"
+            ;;
+        *)
+            luoshu_mount_record prepared \
+                '当前引擎直接读取标准模块目录，等待重启逐分区验证' \
+                '' 0 0 "$_lsmp_partitions"
+            ;;
+    esac
+    luoshu_mount_log \
+        "engine=$_lsmp_engine backend=$(luoshu_mount_backend "$_lsmp_engine") synced=$_lsmp_synced partitions=$_lsmp_partitions"
 }
 
-# Called after a payload transaction rollback. For dual-directory engines this writes the restored
-# canonical tree back to the real content image; direct-source engines need no extra copy.
 luoshu_restore_mount_payload() {
     _lrmp_active=$(head -n1 "$LUOSHU_MOUNT_MODDIR/config/active_font.conf" 2>/dev/null | tr -d '\r\n')
     [ -n "$_lrmp_active" ] || _lrmp_active=default
@@ -491,57 +819,136 @@ luoshu_restore_mount_payload() {
 luoshu_mount_verify_active() {
     _lmva_active="${1:-$(head -n1 "$LUOSHU_MOUNT_MODDIR/config/active_font.conf" 2>/dev/null)}"
     [ -n "$_lmva_active" ] || _lmva_active=default
-    [ "$_lmva_active" != default ] || { luoshu_mount_record verified '系统默认字体无需挂载验证' '' 0 0; return 0; }
-    _lmva_expected="$LUOSHU_MOUNT_MODDIR/config/mount-probe-expected.conf"
-    _lmva_visible="${LUOSHU_VISIBLE_PROBE:-/system/etc/luoshu/mount-probe.conf}"
-    _lmva_nonce=$(sed -n 's/^nonce=//p' "$_lmva_expected" 2>/dev/null | head -n1)
-    _lmva_seen=$(sed -n 's/^nonce=//p' "$_lmva_visible" 2>/dev/null | head -n1)
-    if [ -n "$_lmva_nonce" ] && [ "$_lmva_nonce" = "$_lmva_seen" ]; then
-        luoshu_mount_record verified '挂载探针已从系统分区读取，元模块生效' '' 0 0
+    if [ "$_lmva_active" = default ]; then
+        luoshu_mount_record verified '系统默认字体无需挂载验证' '' 0 0
         return 0
     fi
-    luoshu_mount_record unverified "系统未读取到洛书挂载探针：expected=$_lmva_nonce seen=$_lmva_seen" '' 0 1
-    luoshu_mount_log "挂载验证失败：engine=$(luoshu_detect_mount_engine) expected=$_lmva_nonce seen=$_lmva_seen"
+
+    _lmva_manifest="$LUOSHU_MOUNT_MODDIR/config/mount-probes-expected.conf"
+    if [ ! -s "$_lmva_manifest" ]; then
+        luoshu_mount_record unverified '缺少分区挂载探针清单' '' 0 1 '' '' manifest
+        return 1
+    fi
+
+    _lmva_partitions=''
+    _lmva_verified=''
+    _lmva_failed=''
+    _lmva_failed_count=0
+    while IFS='|' read -r _lmva_partition _lmva_expected _lmva_visible_path; do
+        [ -n "$_lmva_partition" ] || continue
+        _lmva_partitions="${_lmva_partitions}${_lmva_partitions:+,}$_lmva_partition"
+        if [ -n "${LUOSHU_VISIBLE_PROBE:-}" ] && [ "$_lmva_partition" = system ]; then
+            _lmva_visible="$LUOSHU_VISIBLE_PROBE"
+        elif [ -n "${LUOSHU_VISIBLE_PROBE_ROOT:-}" ]; then
+            _lmva_visible="${LUOSHU_VISIBLE_PROBE_ROOT%/}$_lmva_visible_path"
+        else
+            _lmva_visible="$_lmva_visible_path"
+        fi
+        _lmva_seen=$(sed -n 's/^nonce=//p' "$_lmva_visible" 2>/dev/null | head -n1)
+        _lmva_seen_partition=$(sed -n 's/^partition=//p' "$_lmva_visible" 2>/dev/null | head -n1)
+        if [ "$_lmva_expected" = "$_lmva_seen" ] && [ "$_lmva_partition" = "$_lmva_seen_partition" ]; then
+            _lmva_verified="${_lmva_verified}${_lmva_verified:+,}$_lmva_partition"
+        else
+            _lmva_failed="${_lmva_failed}${_lmva_failed:+,}$_lmva_partition"
+            _lmva_failed_count=$((_lmva_failed_count + 1))
+        fi
+    done < "$_lmva_manifest"
+
+    if [ "$_lmva_failed_count" -eq 0 ]; then
+        luoshu_mount_record verified \
+            '所有字体负载分区均已从系统路径读取' '' 0 0 \
+            "$_lmva_partitions" "$_lmva_verified"
+        return 0
+    fi
+    luoshu_mount_record unverified \
+        "部分字体分区未挂载：$_lmva_failed" '' 0 "$_lmva_failed_count" \
+        "$_lmva_partitions" "$_lmva_verified" "$_lmva_failed"
     return 1
 }
 
-# Override the base confirmation: a completed Android boot is not enough; the selected mount engine
-# must also expose LuoShu's probe from the real system partition before the payload is trusted.
+# A completed Android boot is not enough. The selected mount engine must expose
+# every generated probe before the payload transaction is trusted.
 font_config_mark_boot_success() {
     _lmbs_config="${CONFIG_DIR:-$LUOSHU_MOUNT_MODDIR/config}"
     _lmbs_state=$(sed -n 's/^state=//p' "$_lmbs_config/font-payload-boot.conf" 2>/dev/null | head -n1)
     [ "$_lmbs_state" = booting ] || return 0
     _lmbs_font=$(sed -n 's/^font=//p' "$_lmbs_config/font-payload-boot.conf" 2>/dev/null | head -n1)
-    if ! luoshu_mount_verify_active "${_lmbs_font:-unknown}"; then
-        type _luoshu_safety_log >/dev/null 2>&1 && _luoshu_safety_log ERROR 'Android 已开机，但元模块未挂载洛书负载；本次事务不确认'
-        return 1
-    fi
-    {
-        printf 'state=confirmed\n'
-        printf 'font=%s\n' "${_lmbs_font:-unknown}"
-        printf 'time=%s\n' "$(date +%s)"
-    } > "$_lmbs_config/font-payload-boot.conf.tmp.$$" 2>/dev/null || return 1
-    mv -f "$_lmbs_config/font-payload-boot.conf.tmp.$$" "$_lmbs_config/font-payload-boot.conf" 2>/dev/null || return 1
-    rm -f "$_lmbs_config/font-boot-failures" "$_lmbs_config/font-payload-quarantine.conf" 2>/dev/null || true
-    printf 'time=%s\n' "$(date +%s)" > "$_lmbs_config/font-last-boot-success.conf" 2>/dev/null || true
-    chmod 0644 "$_lmbs_config/font-payload-boot.conf" "$_lmbs_config/font-last-boot-success.conf" 2>/dev/null || true
-    type _luoshu_safety_log >/dev/null 2>&1 && _luoshu_safety_log INFO 'Android 已完成开机且元模块挂载验证通过，字体负载事务确认成功'
+    luoshu_mount_verify_active "${_lmbs_font:-unknown}" || return 1
+    printf 'state=confirmed\nfont=%s\ntime=%s\n' \
+        "${_lmbs_font:-unknown}" "$(_luoshu_now)" \
+        > "$_lmbs_config/font-payload-boot.conf.tmp.$$" 2>/dev/null || return 1
+    mv -f "$_lmbs_config/font-payload-boot.conf.tmp.$$" \
+        "$_lmbs_config/font-payload-boot.conf" 2>/dev/null || return 1
+    rm -f \
+        "$_lmbs_config/font-boot-failures" \
+        "$_lmbs_config/font-payload-quarantine.conf" 2>/dev/null || true
+    printf 'time=%s\n' "$(_luoshu_now)" > "$_lmbs_config/font-last-boot-success.conf" 2>/dev/null || true
+    chmod 0644 \
+        "$_lmbs_config/font-payload-boot.conf" \
+        "$_lmbs_config/font-last-boot-success.conf" 2>/dev/null || true
+}
+
+_luoshu_json_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '
 }
 
 luoshu_mount_status_json() {
-    _lmsj_conf="$LUOSHU_MOUNT_MODDIR/config/mount_compat.conf"
-    _lmsj_state=$(sed -n 's/^state=//p' "$_lmsj_conf" 2>/dev/null | head -n1)
-    _lmsj_detail=$(sed -n 's/^detail=//p' "$_lmsj_conf" 2>/dev/null | head -n1 | sed 's/\\/\\\\/g; s/"/\\"/g')
-    _lmsj_root=$(sed -n 's/^contentRoot=//p' "$_lmsj_conf" 2>/dev/null | head -n1 | sed 's/\\/\\\\/g; s/"/\\"/g')
-    _lmsj_synced=$(sed -n 's/^synced=//p' "$_lmsj_conf" 2>/dev/null | head -n1)
-    _lmsj_failed=$(sed -n 's/^failed=//p' "$_lmsj_conf" 2>/dev/null | head -n1)
-    _lmsj_time=$(sed -n 's/^time=//p' "$_lmsj_conf" 2>/dev/null | head -n1)
-    printf '{"manager":"%s","engine":"%s","state":"%s","detail":"%s","contentRoot":"%s","synced":%s,"failed":%s,"time":%s}' \
-        "$(luoshu_detect_root_manager)" "$(luoshu_detect_mount_engine)" "${_lmsj_state:-unknown}" "$_lmsj_detail" "$_lmsj_root" \
-        "${_lmsj_synced:-0}" "${_lmsj_failed:-0}" "${_lmsj_time:-0}"
+    _lmsj_config="$LUOSHU_MOUNT_MODDIR/config/mount_compat.conf"
+    _lmsj_get() {
+        sed -n "s/^$1=//p" "$_lmsj_config" 2>/dev/null | head -n1
+    }
+    _lmsj_state=$(_lmsj_get state)
+    _lmsj_detail=$(_lmsj_get detail)
+    _lmsj_warning=$(_lmsj_get warning)
+    _lmsj_root=$(_lmsj_get contentRoot)
+    _lmsj_backend=$(_lmsj_get backend)
+    _lmsj_partitions=$(_lmsj_get partitions)
+    _lmsj_verified=$(_lmsj_get verifiedPartitions)
+    _lmsj_failed_partitions=$(_lmsj_get failedPartitions)
+    _lmsj_unsupported=$(_lmsj_get unsupportedPartitions)
+    _lmsj_synced=$(_lmsj_get synced)
+    _lmsj_failed=$(_lmsj_get failed)
+    _lmsj_duration=$(_lmsj_get durationSeconds)
+    _lmsj_time=$(_lmsj_get time)
+
+    printf '{"manager":"%s","engine":"%s","backend":"%s","state":"%s","detail":"%s","warning":"%s","contentRoot":"%s","partitions":"%s","verifiedPartitions":"%s","failedPartitions":"%s","unsupportedPartitions":"%s","synced":%s,"failed":%s,"durationSeconds":%s,"time":%s}' \
+        "$(_luoshu_json_escape "$(luoshu_detect_root_manager)")" \
+        "$(_luoshu_json_escape "$(luoshu_detect_mount_engine)")" \
+        "$(_luoshu_json_escape "${_lmsj_backend:-$(luoshu_mount_backend)}")" \
+        "$(_luoshu_json_escape "${_lmsj_state:-unknown}")" \
+        "$(_luoshu_json_escape "$_lmsj_detail")" \
+        "$(_luoshu_json_escape "$_lmsj_warning")" \
+        "$(_luoshu_json_escape "$_lmsj_root")" \
+        "$(_luoshu_json_escape "$_lmsj_partitions")" \
+        "$(_luoshu_json_escape "$_lmsj_verified")" \
+        "$(_luoshu_json_escape "$_lmsj_failed_partitions")" \
+        "$(_luoshu_json_escape "$_lmsj_unsupported")" \
+        "${_lmsj_synced:-0}" "${_lmsj_failed:-0}" \
+        "${_lmsj_duration:-0}" "${_lmsj_time:-0}"
 }
 
 _luoshu_hyperos_helper="${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}/common/hyperos_global.sh"
 [ -f "$_luoshu_hyperos_helper" ] && . "$_luoshu_hyperos_helper"
 _luoshu_font_config_partitions="${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}/common/font_config_partitions.sh"
 [ -f "$_luoshu_font_config_partitions" ] && . "$_luoshu_font_config_partitions"
+
+if [ "${0##*/}" = mount_compat.sh ]; then
+    case "${1:-status}" in
+        status)
+            luoshu_mount_status_json
+            printf '\n'
+            ;;
+        detect)
+            printf 'engine=%s\n' "$(luoshu_detect_mount_engine)"
+            printf 'backend=%s\n' "$(luoshu_mount_backend)"
+            printf 'warning=%s\n' "$(luoshu_mount_detection_warning)"
+            ;;
+        verify)
+            luoshu_mount_verify_active "${2:-}"
+            ;;
+        *)
+            printf 'usage: %s {status|detect|verify [font]}\n' "$0" >&2
+            exit 2
+            ;;
+    esac
+fi

--- a/scripts/mount_compat_test.sh
+++ b/scripts/mount_compat_test.sh
@@ -7,25 +7,27 @@ trap 'rm -rf "$TMP"' EXIT HUP INT TERM
 
 MODULE="$TMP/modules/LuoShu"
 META="$TMP/meta"
-mkdir -p "$MODULE/common" "$MODULE/system/fonts" "$MODULE/product/fonts" "$MODULE/config" "$MODULE/logs" "$META"
+VISIBLE="$TMP/visible"
+mkdir -p "$MODULE/common" "$MODULE/system/fonts" "$MODULE/product/fonts" "$MODULE/config" "$MODULE/logs" "$META" "$VISIBLE"
 cp "$ROOT/common/mount_compat.sh" "$MODULE/common/mount_compat.sh"
-printf 'id=LuoShu\nversion=v2.0.0\nversionCode=20000\n' > "$MODULE/module.prop"
+printf 'id=LuoShu\nversion=v2.2.5\nversionCode=20205\n' > "$MODULE/module.prop"
 printf 'font-a' > "$MODULE/system/fonts/Roboto-Regular.ttf"
 printf 'product-a' > "$MODULE/product/fonts/Test.ttf"
 
+# Dual-directory engines copy all used supported partitions and write one probe per partition.
 MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" sh -c '
     . "$MODDIR/common/mount_compat.sh"
     luoshu_sync_mount_payload Demo
 '
-
 test -f "$META/LuoShu/system/fonts/Roboto-Regular.ttf"
 test -f "$META/LuoShu/product/fonts/Test.ttf"
-grep -q 'font-a' "$META/LuoShu/system/fonts/Roboto-Regular.ttf"
+test -f "$META/LuoShu/system/etc/luoshu/mount-probe.conf"
+test -f "$META/LuoShu/product/etc/luoshu/mount-probe.conf"
 grep -q '^engine=meta-overlayfs$' "$MODULE/config/mount_compat.conf"
 grep -q '^state=prepared$' "$MODULE/config/mount_compat.conf"
-test -s "$MODULE/system/etc/luoshu/mount-probe.conf"
+grep -q '^partitions=system,product$' "$MODULE/config/mount_compat.conf"
 
-# A second real-content update must replace the whole partition, not retain stale files.
+# Replacing a partition must remove stale files instead of merging trees.
 rm -f "$MODULE/system/fonts/Roboto-Regular.ttf"
 printf stale > "$META/LuoShu/system/fonts/Old.ttf"
 MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" sh -c '
@@ -36,7 +38,46 @@ test ! -e "$META/LuoShu/system/fonts/Old.ttf"
 test ! -e "$META/LuoShu/system/fonts/Roboto-Regular.ttf"
 test -s "$META/LuoShu/system/etc/luoshu/mount-probe.conf"
 
-# Direct-source engines must not create a second module tree.
+# Verify every used partition, not merely /system.
+mkdir -p "$VISIBLE/system/etc/luoshu" "$VISIBLE/product/etc/luoshu"
+cp "$MODULE/system/etc/luoshu/mount-probe.conf" "$VISIBLE/system/etc/luoshu/mount-probe.conf"
+cp "$MODULE/product/etc/luoshu/mount-probe.conf" "$VISIBLE/product/etc/luoshu/mount-probe.conf"
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" LUOSHU_VISIBLE_PROBE_ROOT="$VISIBLE" sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_mount_verify_active Demo
+'
+grep -q '^state=verified$' "$MODULE/config/mount_compat.conf"
+grep -q '^verifiedPartitions=system,product$' "$MODULE/config/mount_compat.conf"
+rm -f "$VISIBLE/product/etc/luoshu/mount-probe.conf"
+if MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" LUOSHU_VISIBLE_PROBE_ROOT="$VISIBLE" sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_mount_verify_active Demo
+'; then
+    echo 'partition verification unexpectedly passed with product missing' >&2
+    exit 1
+fi
+grep -q '^state=unverified$' "$MODULE/config/mount_compat.conf"
+grep -q '^failedPartitions=product$' "$MODULE/config/mount_compat.conf"
+
+# Unsupported vendor partitions are rejected explicitly rather than silently ignored.
+mkdir -p "$MODULE/my_product/fonts"
+printf vendor-font > "$MODULE/my_product/fonts/Oem.ttf"
+if MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_sync_mount_payload Demo
+'; then
+    echo 'unsupported meta-overlayfs partition unexpectedly succeeded' >&2
+    exit 1
+fi
+grep -q 'my_product' "$MODULE/config/mount_compat.conf"
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" LUOSHU_META_EXTRA_PARTITIONS=my_product sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_sync_mount_payload Demo
+'
+test -f "$META/LuoShu/my_product/fonts/Oem.ttf"
+rm -rf "$MODULE/my_product" "$META/LuoShu/my_product"
+
+# Direct-source engines never create a guessed second module tree.
 rm -rf "$META/LuoShu"
 MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=mountify LUOSHU_META_TEST_ROOT="$META" sh -c '
     . "$MODDIR/common/mount_compat.sh"
@@ -45,12 +86,19 @@ MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=mountify LUOSHU_ME
 test ! -e "$META/LuoShu"
 grep -q '^engine=mountify$' "$MODULE/config/mount_compat.conf"
 
-# Magic Mount RC/RS is a direct-source engine and explicit retries clear stale LuoShu markers.
+# Hybrid Mount records the selected backend for diagnostics.
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=hybrid-mount LUOSHU_META_TEST_BACKEND=kasumi sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_sync_mount_payload Demo
+'
+grep -q '^engine=hybrid-mount$' "$MODULE/config/mount_compat.conf"
+grep -q '^backend=kasumi$' "$MODULE/config/mount_compat.conf"
+
+# Magic Mount retries clear recoverable markers and update partitions under a config lock.
 touch "$MODULE/skip_mount" "$MODULE/mount_error"
 MAGIC_CONFIG="$TMP/magic-mount-config.toml"
 printf 'mountsource = "KSU"\numount = false\npartitions = [\n  "vendor", # keep existing\n]\n' > "$MAGIC_CONFIG"
-MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_META_TEST_ROOT="$META" \
-LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG" sh -c '
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG" sh -c '
     . "$MODDIR/common/mount_compat.sh"
     luoshu_sync_mount_payload Demo
 '
@@ -58,50 +106,67 @@ test ! -e "$MODULE/skip_mount"
 test ! -e "$MODULE/mount_error"
 grep -q '"vendor"' "$MAGIC_CONFIG"
 grep -q '"product"' "$MAGIC_CONFIG"
-! grep -q '"keep"' "$MAGIC_CONFIG"
 test "$(grep -c '^[[:space:]]*partitions[[:space:]]*=' "$MAGIC_CONFIG")" -eq 1
 test -s "$MAGIC_CONFIG.luoshu.bak"
+test ! -e "$MAGIC_CONFIG.luoshu.lock"
 
-# Legacy LuoShu safety failures created disable itself and later updates could discard the failure
-# counter. Every explicit font transaction must therefore recover disable even without that state.
-MODDIR="$MODULE"
-MODULE_DIR="$MODULE"
-LUOSHU_META_TEST_ENGINE=magic-mount
-LUOSHU_META_TEST_ROOT="$META"
-LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG"
-export MODDIR MODULE_DIR LUOSHU_META_TEST_ENGINE LUOSHU_META_TEST_ROOT LUOSHU_MAGIC_MOUNT_CONFIG
-. "$MODULE/common/mount_compat.sh"
+# Explicit font transactions recover an old LuoShu disable marker, but never remove remove.
 touch "$MODULE/disable"
 printf '2\n' > "$MODULE/config/font-boot-failures"
-luoshu_sync_mount_payload FontA
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG" sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_sync_mount_payload FontA
+'
 test ! -e "$MODULE/disable"
 test ! -e "$MODULE/config/font-boot-failures"
-
-touch "$MODULE/disable"
-luoshu_sync_mount_payload FontA
-test ! -e "$MODULE/disable"
-
-# Restoring the ROM default is cleanup and must also leave the module enabled for the next action.
-touch "$MODULE/disable"
-luoshu_sync_mount_payload default
-test ! -e "$MODULE/disable"
-test ! -e "$META/LuoShu"
-grep -q '^engine=magic-mount$' "$MODULE/config/mount_compat.conf"
-
-# A pending removal is not recoverable through a font transaction.
 touch "$MODULE/remove"
-if luoshu_sync_mount_payload FontA; then
+if MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG" sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_sync_mount_payload FontA
+'; then
     echo 'remove marker was unexpectedly cleared' >&2
     exit 1
 fi
 test -e "$MODULE/remove"
 rm -f "$MODULE/remove"
 
+# A copy timeout has one bounded attempt only and preserves the old destination tree.
+SLOWBIN="$TMP/slowbin"
+mkdir -p "$SLOWBIN" "$TMP/source/system" "$TMP/dest/system"
+printf new > "$TMP/source/system/new.ttf"
+printf old > "$TMP/dest/system/old.ttf"
+cat > "$SLOWBIN/cp" <<'EOS'
+#!/bin/sh
+sleep 10
+exit 1
+EOS
+chmod 0755 "$SLOWBIN/cp"
+if PATH="$SLOWBIN:$PATH" MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_MOUNT_TIMEOUT=2 LUOSHU_META_TEST_ENGINE=native-module-mount sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_mount_budget_begin
+    luoshu_copy_partition_atomic "$1" "$2"
+' sh "$TMP/source/system" "$TMP/dest/system"; then
+    echo 'slow copy unexpectedly succeeded' >&2
+    exit 1
+fi
+test -f "$TMP/dest/system/old.ttf"
+test ! -e "$TMP/dest/system/new.ttf"
+
+# Conflicting enabled mount modules are surfaced in diagnostics instead of being silently guessed.
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=mountify LUOSHU_META_TEST_CANDIDATES="mountify magic-mount" sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    luoshu_sync_mount_payload Demo
+    luoshu_mount_status_json > "$MODDIR/config/mount_status.json"
+'
+grep -q '^warning=检测到多个已启用挂载模块：mountify、magic-mount$' "$MODULE/config/mount_compat.conf"
+grep -q '"backend":"mountify"' "$MODULE/config/mount_status.json"
+grep -q '"warning":"检测到多个已启用挂载模块：mountify、magic-mount"' "$MODULE/config/mount_status.json"
+
 # The flash installer must recover both the staging tree and the currently active module tree.
 grep -q 'for _enable_dir in "$MODPATH" "$OLD_MOD"' "$ROOT/customize.sh"
 grep -q 'rm -f "$_enable_dir/disable"' "$ROOT/customize.sh"
 
-# Runtime syncing remains transaction-only. Never mirror from early boot scripts.
+# Runtime syncing remains transaction-only. Never mirror blindly from early boot scripts.
 grep -q 'common/mount_compat.sh' "$ROOT/common/font_mix.sh"
 grep -q 'luoshu_sync_mount_payload' "$ROOT/common/font_mix.sh"
 ! grep -q 'luoshu_sync_mount_payload' "$ROOT/post-fs-data.sh"
@@ -114,6 +179,7 @@ mkdir -p "$STAGE"
 cp -R "$ROOT/." "$STAGE/"
 rm -rf "$STAGE/.git" "$STAGE/dist" "$STAGE/common/python" 2>/dev/null || true
 ! find "$STAGE" -type f \( -name skip_mount -o -name skip_mountify \) | grep -q .
+sh -n "$ROOT/common/mount_compat.sh"
 sh -n "$ROOT/common/font_mix.sh"
 sh -n "$ROOT/common/app_bridge.sh"
 sh -n "$ROOT/post-fs-data.sh"


### PR DESCRIPTION
## 改动内容

- 不再仅凭残留目录判断元模块，改为检查模块元数据、启用状态和真实挂载证据；检测到多个已启用挂载模块时写入明确警告。
- 区分 Hybrid Mount 的 OverlayFS、Magic Mount、Kasumi 和未知后端，并把真实后端写入诊断状态。
- 将元模块同步改为单一总时间预算，删除超时后的无限制复制重试；分区替换保持原子化，失败或超时时保留旧有效目录。
- 根据本次真实负载动态收集分区；meta-overlayfs 遇到未声明支持的厂商分区时明确失败，不再静默跳过。
- 为 system、product、system_ext 等每个实际负载分区生成独立探针，完整重启后逐分区验证，避免仅 /system 成功便误报整体已验证。
- Magic Mount 配置更新增加独立锁、一次性备份和提交前校验。
- 扩展元模块专项测试，覆盖分区同步、陈旧文件清理、逐分区失败、厂商分区支持、Hybrid 后端、Magic Mount、复制超时、旧镜像保留和多元模块冲突诊断。

## 根因

当前兼容层仍存在三类假成功风险：残留目录可能被当作活动元模块；复制超时后会进入不受限重试；挂载验证只检查 /system 探针，无法发现 product 或 system_ext 单独失效。部分设备因此会出现“已识别/已应用，但重启后字体不生效”。

## 用户影响

- 元模块识别更可信，环境冲突会直接暴露。
- 超时不会继续后台复制，也不会破坏上一套可用字体负载。
- 首页可信状态所依赖的挂载结果能够反映具体失败分区，而不是整体假成功。
- ColorOS、HyperOS 等多分区负载在元模块能力不足时会给出明确原因。

## 验证

- `sh -n common/mount_compat.sh`
- `sh -n scripts/mount_compat_test.sh`
- `sh scripts/mount_compat_test.sh`
- 专项测试结果：`LuoShu metamodule compatibility checks passed.`

完整仓库构建和 Android 测试交由该 PR 的 GitHub Actions 继续验证。