### PR TITLE
release: 发布洛书 v2.2.7

### DIFF
--- a/RELEASE_NOTES_v2.2.7.md
+++ b/RELEASE_NOTES_v2.2.7.md
@@ -1,0 +1,40 @@
+# 洛书 v2.2.7
+
+洛书 v2.2.7 是卸载清理修复版本，解决模块卸载后 `/data/adb/modules/LuoShu`、待安装副本或 meta-overlayfs 内容镜像仍可能保留文件的问题。
+
+## 卸载清理
+
+- 移除卸载阶段重新创建 `logs` 目录和写入“已卸载”持久日志的行为。
+- 卸载事件只写入 Android 系统日志，不会在模块目录重新产生文件。
+- 恢复字体粗细设置、动态字体 bind、旧 provider 备份与 Flyme 持久字体后，删除当前洛书模块目录。
+- 同时清理 `/data/adb/modules_update/LuoShu` 待安装副本。
+- 清理 meta-overlayfs／双目录元模块保存的 `LuoShu` 内容镜像。
+- 删除洛书生成的 Magic Mount 配置锁、备份及临时文件，但保留用户当前的 Magic Mount 主配置。
+- 删除路径增加 basename 安全检查，只允许清理名称明确为 `LuoShu` 的目标树，避免误删其他模块。
+
+## 回归验证
+
+- 新增真实临时目录卸载测试，模拟主模块、待安装副本和两份元模块镜像。
+- 测试确认卸载后洛书目标目录全部消失。
+- 测试确认其他模块目录和 Magic Mount 主配置保持不变。
+- 完整源码门禁、字体引擎测试、App Lint／单元测试、候选 APK 和模块成品校验均需通过后才发布。
+
+## 安装与升级
+
+1. 在 Magisk、KernelSU、SukiSU Ultra 或 APatch 中刷入 `LuoShu-v2.2.7.zip`。
+2. 完整重启设备。
+3. 此版本不修改现有字体配置或 UI，已正常使用的字体无需重新应用。
+
+模块 ZIP 内置同版本正式签名 App。独立的 `LuoShu-App-v2.2.7.apk` 可用于覆盖升级，但卸载清理逻辑位于模块脚本中，仅安装 APK 不会更新该修复。
+
+## 版本信息
+
+- 模块版本：`v2.2.7`
+- 模块 versionCode：`20207`
+- App versionCode：`2020701`
+- 最低 Android：Android 9 / API 28
+- 目标 Android：API 36
+
+## 校验
+
+Release 同时提供模块 ZIP、正式签名 APK 及各自的 SHA-256 文件。下载后可使用对应 `.sha256` 文件核验完整性。

--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v2.2.6
-summary=修正验收状态、清理重复 ROM 日志并补齐后台对齐同步
-notes=v2.2.6 修复 v2.2.5 真机反馈：兼容字体映射不再被验收向导长期标记为红色失败，字体任务、待重启和设备对齐缓存统一显示为信息状态，只有明确的加载验证失败或状态读取异常才阻断；HyperOS 与 ColorOS 版本仅在首次识别或版本变化时记录一次，并自动压缩已有重复检测日志；后台设备对齐缓存独立运行时加载事务守卫与 mount_compat.sh，生成后同步到 Magic Mount、meta-overlayfs、Hybrid Mount 或 Mountify。模块 versionCode 20206，App versionCode 2020601。
+version=v2.2.7
+summary=修复模块卸载后主目录与元模块镜像残留
+notes=v2.2.7 修复卸载清理缺陷：卸载脚本不再重新创建 logs 目录或向模块目录写入“已卸载”日志；恢复字体粗细、动态挂载、旧 provider 与 Flyme 持久字体后，安全删除 /data/adb/modules/LuoShu、/data/adb/modules_update/LuoShu 及 meta-overlayfs 双目录中的 LuoShu 内容镜像；清理洛书生成的 Magic Mount 锁、备份与临时文件，但保留用户当前主配置和其他模块。新增卸载回归测试，确认目标目录全部消失且非洛书数据不受影响。模块 versionCode 20207，App versionCode 2020701。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v2.2.6
-versionCode=20206
+version=v2.2.7
+versionCode=20207
 author=惜故里丶
 description=Android 无 Hook 全局字体引擎：真机字体清单、快速单字体切换、组合字体与安全事务回滚
 updateJson=https://raw.githubusercontent.com/xgl34222220-ops/LuoShu/main/update.json

--- a/scripts/uninstall_cleanup_test.sh
+++ b/scripts/uninstall_cleanup_test.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+MODULES="$TMP/modules"
+MODULES_UPDATE="$TMP/modules_update"
+META_MNT="$TMP/metamodule/mnt"
+CONTENT_BASE="$TMP/content"
+MAGIC_CONFIG="$TMP/magic_mount/config.toml"
+MODDIR="$MODULES/LuoShu"
+
+mkdir -p \
+  "$MODDIR/logs" \
+  "$MODDIR/config" \
+  "$MODULES/OtherModule" \
+  "$MODULES_UPDATE/LuoShu/system/fonts" \
+  "$META_MNT/LuoShu/product/fonts" \
+  "$CONTENT_BASE/LuoShu/system/fonts" \
+  "${MAGIC_CONFIG%/*}"
+
+cp "$ROOT/uninstall.sh" "$MODDIR/uninstall.sh"
+printf '%s\n' 'version=v-test' > "$MODDIR/module.prop"
+printf '%s\n' 'old log' > "$MODDIR/logs/fontswitch.log"
+printf '%s\n' 'keep sibling' > "$MODULES/OtherModule/module.prop"
+printf '%s\n' 'partitions = ["system", "product"]' > "$MAGIC_CONFIG"
+printf '%s\n' 'backup' > "$MAGIC_CONFIG.luoshu.bak"
+printf '%s\n' '999999' > "$MAGIC_CONFIG.luoshu.lock"
+printf '%s\n' 'temp' > "$MAGIC_CONFIG.luoshu.123"
+
+LUOSHU_MODULES_DIR="$MODULES" \
+LUOSHU_MODULES_UPDATE_DIR="$MODULES_UPDATE" \
+LUOSHU_METAMODULE_MNT="$META_MNT" \
+LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG" \
+MODULE_CONTENT_DIR="$CONTENT_BASE" \
+sh "$MODDIR/uninstall.sh"
+
+[ ! -e "$MODDIR" ]
+[ ! -e "$MODULES_UPDATE/LuoShu" ]
+[ ! -e "$META_MNT/LuoShu" ]
+[ ! -e "$CONTENT_BASE/LuoShu" ]
+[ -f "$MODULES/OtherModule/module.prop" ]
+[ -f "$MAGIC_CONFIG" ]
+[ ! -e "$MAGIC_CONFIG.luoshu.bak" ]
+[ ! -e "$MAGIC_CONFIG.luoshu.lock" ]
+[ ! -e "$MAGIC_CONFIG.luoshu.123" ]
+grep -q 'partitions = \["system", "product"\]' "$MAGIC_CONFIG"
+
+# 卸载脚本不得再次在模块目录中创建 logs 或任何文件。
+[ ! -d "$MODULES/LuoShu/logs" ]
+
+echo 'LuoShu uninstall cleanup checks passed.'

--- a/scripts/v2_source_audit.sh
+++ b/scripts/v2_source_audit.sh
@@ -49,3 +49,8 @@ find "$ROOT/system" -type f -iname '*emoji*' -print -quit 2>/dev/null | grep -q 
 ! grep -q '^webroot=' "$ROOT/module.prop"
 grep -q 'native_font_index.json' "$ROOT/common/font_manager.sh"
 grep -q 'native_font_index.json' "$ROOT/service.sh"
+
+# 卸载脚本不能在删除阶段重新创建模块日志目录或写回持久文件。
+! grep -q 'mkdir -p .*MODDIR.*/logs' "$ROOT/uninstall.sh"
+! grep -q 'MODDIR/logs/.*>>' "$ROOT/uninstall.sh"
+sh "$ROOT/scripts/uninstall_cleanup_test.sh"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,10 +1,15 @@
 #!/system/bin/sh
-# 洛书安全卸载：恢复模块明确记录的设置与持久字体，不修改 FontManagerService 数据文件。
+# 洛书安全卸载：恢复模块明确记录的设置与持久字体，然后完整清理模块与元模块镜像。
 set +e
 MODDIR="${0%/*}"
 MODULE_DIR="$MODDIR"
 MODULE_VERSION=$(sed -n 's/^version=//p' "$MODDIR/module.prop" 2>/dev/null | head -n1)
 [ -n "$MODULE_VERSION" ] || MODULE_VERSION="unknown"
+
+LUOSHU_MODULES_DIR="${LUOSHU_MODULES_DIR:-/data/adb/modules}"
+LUOSHU_MODULES_UPDATE_DIR="${LUOSHU_MODULES_UPDATE_DIR:-/data/adb/modules_update}"
+LUOSHU_METAMODULE_MNT="${LUOSHU_METAMODULE_MNT:-/data/adb/metamodule/mnt}"
+LUOSHU_MAGIC_MOUNT_CONFIG="${LUOSHU_MAGIC_MOUNT_CONFIG:-/data/adb/magic_mount/config.toml}"
 
 _luoshu_uninstall_hash() {
     _luh_file="$1"
@@ -15,6 +20,23 @@ _luoshu_uninstall_hash() {
     else
         cksum "$_luh_file" 2>/dev/null | awk '{print $1 ":" $2}'
     fi
+}
+
+_luoshu_content_root() {
+    _lucr_base="${MODULE_CONTENT_DIR:-$LUOSHU_METAMODULE_MNT}"
+    _lucr_base=${_lucr_base%/}
+    case "$_lucr_base" in
+        */LuoShu) printf '%s\n' "$_lucr_base" ;;
+        *) printf '%s/LuoShu\n' "$_lucr_base" ;;
+    esac
+}
+
+_luoshu_remove_tree() {
+    _lurt_path=${1%/}
+    [ -n "$_lurt_path" ] || return 1
+    [ "$_lurt_path" != / ] || return 1
+    [ "${_lurt_path##*/}" = LuoShu ] || return 1
+    rm -rf "$_lurt_path" 2>/dev/null || true
 }
 
 # 恢复安装洛书前记录的 Android 全局字体粗细设置。
@@ -63,7 +85,26 @@ if [ -f "$MODDIR/common/origin_flyme_global.sh" ]; then
     fi
 fi
 
-rm -f "$MODDIR/.first_boot" "$MODDIR/.font_switch.lock" 2>/dev/null || true
-mkdir -p "$MODDIR/logs" 2>/dev/null || true
-echo "[$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null)] 洛书 $MODULE_VERSION 已卸载" >> "$MODDIR/logs/fontswitch.log" 2>/dev/null || true
+# 清理洛书写入 Magic Mount 配置旁的锁、备份和临时文件。不会回滚整个
+# Magic Mount 配置，避免覆盖用户卸载前自行完成的其他配置修改。
+rm -f \
+    "$LUOSHU_MAGIC_MOUNT_CONFIG.luoshu.lock" \
+    "$LUOSHU_MAGIC_MOUNT_CONFIG.luoshu.bak" \
+    "$LUOSHU_MAGIC_MOUNT_CONFIG.luoshu."* 2>/dev/null || true
+
+# 元模块可能维护独立于 /data/adb/modules 的第二份内容树。卸载时必须同时
+# 删除这份 LuoShu 镜像，否则 meta-overlayfs 仍会看到旧负载文件。
+_luoshu_remove_tree "$(_luoshu_content_root)"
+_luoshu_remove_tree "$LUOSHU_METAMODULE_MNT/LuoShu"
+
+# 清理待安装副本和当前模块目录。卸载完成后不再在 MODDIR 内创建 logs，
+# 避免 KernelSU、APatch 或部分元模块在卸载脚本结束后留下一个新目录。
+_luoshu_remove_tree "$LUOSHU_MODULES_UPDATE_DIR/LuoShu"
+_luoshu_remove_tree "$LUOSHU_MODULES_DIR/LuoShu"
+_luoshu_remove_tree "$MODDIR"
+
+# 卸载事件只写入系统日志，不再制造任何持久文件。
+if command -v log >/dev/null 2>&1; then
+    log -t LuoShu "洛书 $MODULE_VERSION 已卸载" >/dev/null 2>&1 || true
+fi
 exit 0

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-  "version": "v2.2.6",
-  "versionCode": 20206,
-  "zipUrl": "https://github.com/xgl34222220-ops/LuoShu/releases/download/v2.2.6/LuoShu-v2.2.6.zip",
-  "changelog": "https://raw.githubusercontent.com/xgl34222220-ops/LuoShu/main/RELEASE_NOTES_v2.2.6.md"
+  "version": "v2.2.7",
+  "versionCode": 20207,
+  "zipUrl": "https://github.com/xgl34222220-ops/LuoShu/releases/download/v2.2.7/LuoShu-v2.2.7.zip",
+  "changelog": "https://raw.githubusercontent.com/xgl34222220-ops/LuoShu/main/RELEASE_NOTES_v2.2.7.md"
 }


### PR DESCRIPTION
## 发布内容

洛书 v2.2.7 是卸载清理修复版本，解决模块卸载后主目录、待安装副本和 meta-overlayfs 内容镜像仍可能残留的问题。

### 根因

旧版 `uninstall.sh` 在卸载收尾阶段重新创建 `logs` 目录，并把“已卸载”写回 `fontswitch.log`。部分 Root 管理器不会在卸载脚本结束后再次清除新创建的文件，因此洛书自己把模块目录建立了回来。

### 修复

- 卸载阶段不再向模块目录写任何持久日志；
- 卸载事件只写入 Android 系统日志；
- 恢复字体粗细、动态 bind、旧 provider 与 Flyme 持久字体后，安全删除当前模块目录；
- 删除 `/data/adb/modules_update/LuoShu` 待安装副本；
- 删除 meta-overlayfs／双目录元模块中的 `LuoShu` 内容镜像；
- 清理洛书创建的 Magic Mount 锁、备份和临时文件，但保留用户当前主配置；
- 所有递归删除均校验 basename，只允许删除名为 `LuoShu` 的目标树；
- 新增卸载专项测试，确认洛书目录全部消失，同时其他模块和 Magic Mount 主配置不受影响。

### 正式版本

- 模块：v2.2.7 / versionCode 20207；
- App：versionCode 2020701；
- 在线更新元数据指向不可变 `v2.2.7` Release；
- 新增 `RELEASE_NOTES_v2.2.7.md`。

## 发布门禁

版本正式化后重新运行完整源码检查、字体引擎测试、App Lint／单元测试、候选 APK、模块打包和成品校验。全部通过后合并到 `main`，再由固定签名发布工作流创建不可覆盖的 v2.2.7 GitHub Release。