### PR TITLE
fix: restore Mountify and Magic Mount compatibility

### DIFF
--- a/common/font_config_partitions.sh
+++ b/common/font_config_partitions.sh
@@ -89,4 +89,5 @@ fi
 [ -f "$_luoshufp_module/common/device_font_cache.sh" ] && . "$_luoshufp_module/common/device_font_cache.sh"
 [ -f "$_luoshufp_module/common/mount_fast_sync.sh" ] && . "$_luoshufp_module/common/mount_fast_sync.sh"
 [ -f "$_luoshufp_module/common/device_font_payload_policy.sh" ] && . "$_luoshufp_module/common/device_font_payload_policy.sh"
+[ -f "$_luoshufp_module/common/mount_compat_hotfix.sh" ] && . "$_luoshufp_module/common/mount_compat_hotfix.sh"
 unset _luoshufp_module

--- a/common/mount_compat_hotfix.sh
+++ b/common/mount_compat_hotfix.sh
@@ -1,0 +1,293 @@
+#!/system/bin/sh
+# LuoShu v2.2.x meta-module compatibility hotfix.
+#
+# Mountify, Hybrid Mount and Magic Mount consume the canonical module tree
+# directly. Only dual-directory overlay engines need a mirrored content tree.
+# Runtime probe visibility is diagnostic and must not roll back a payload that
+# already passed LuoShu's atomic font validation.
+set +e
+
+_luoshu_magic_mount_present() {
+    for _lmmh_path in /data/adb/modules/*; do
+        [ -d "$_lmmh_path" ] || continue
+        _luoshu_module_metadata_matches "$_lmmh_path" \
+            magic_mount magic-mount 'magic mount' id=meta-mm meta-mm-rs && return 0
+    done
+    [ -f /data/adb/magic_mount/config.toml ] && {
+        [ -x /data/adb/metamodule/meta-mm ] ||
+        [ -x /data/adb/metamodule/meta-mm-rs ] ||
+        [ -x /data/adb/modules/magic_mount_rs/meta-mm ] ||
+        [ -x /data/adb/modules/meta-mm/meta-mm ] ||
+        [ -x /data/adb/modules/meta_mm/meta-mm ]
+    }
+}
+
+luoshu_mountify_ensure_selected() {
+    luoshu_mountify_module_selected && return 0
+    _lmhes_id=$(luoshu_module_id)
+    for _lmhes_file in \
+        /data/adb/mountify/modules.txt \
+        /data/adb/modules/mountify/modules.txt \
+        /data/adb/modules/Mountify/modules.txt; do
+        [ -f "$_lmhes_file" ] || continue
+        if printf '%s\n' "$_lmhes_id" >> "$_lmhes_file" 2>/dev/null; then
+            luoshu_mount_log "已将 $_lmhes_id 加入 Mountify 选择列表"
+            return 0
+        fi
+    done
+    LUOSHU_MOUNT_DETECTION_WARNING='Mountify 使用选择模式，但未找到可写的模块列表'
+    luoshu_mount_log "$LUOSHU_MOUNT_DETECTION_WARNING"
+    return 0
+}
+
+# Never rewrite another meta-module's config.toml. Magic Mount RC and later
+# builds have changed config paths and partition semantics more than once.
+luoshu_magic_mount_ensure_partitions() {
+    return 0
+}
+
+luoshu_mount_preflight() {
+    _lmhp_active="${1:-unknown}"
+    _lmhp_engine=$(luoshu_detect_mount_engine)
+    LUOSHU_MOUNT_PREFLIGHT_ERROR=''
+
+    [ ! -e "$LUOSHU_MOUNT_MODDIR/remove" ] || {
+        LUOSHU_MOUNT_PREFLIGHT_ERROR='模块存在 remove 标记'
+        return 1
+    }
+
+    if [ "$_lmhp_active" != default ]; then
+        luoshu_recover_explicit_disable || return 1
+        case "$_lmhp_engine" in
+            mountify|hybrid-mount|magic-mount|magic-mount-rs|native-module-mount)
+                for _lmhp_marker in skip_mount skip_mountify mount_error; do
+                    [ -e "$LUOSHU_MOUNT_MODDIR/$_lmhp_marker" ] || continue
+                    rm -f "$LUOSHU_MOUNT_MODDIR/$_lmhp_marker" 2>/dev/null || {
+                        LUOSHU_MOUNT_PREFLIGHT_ERROR="无法清理洛书挂载遗留标记：$_lmhp_marker"
+                        return 1
+                    }
+                done
+                ;;
+        esac
+    fi
+
+    case "$_lmhp_engine" in
+        mountify)
+            [ "$_lmhp_active" = default ] || luoshu_mountify_ensure_selected || return 1
+            ;;
+        meta-overlayfs|dual-dir-metamodule)
+            _lmhp_base=$(luoshu_dual_content_base)
+            mkdir -p "$_lmhp_base" 2>/dev/null || {
+                LUOSHU_MOUNT_PREFLIGHT_ERROR="无法创建元模块内容目录：$_lmhp_base"
+                return 1
+            }
+            [ -w "$_lmhp_base" ] || {
+                LUOSHU_MOUNT_PREFLIGHT_ERROR="元模块内容目录不可写：$_lmhp_base"
+                return 1
+            }
+            ;;
+    esac
+    return 0
+}
+
+# v2.2.5 wrote one probe into every optional partition. Some engines cache a
+# mount plan before those files appear, so one harmless missing probe caused the
+# whole font transaction to be marked failed. Keep one primary diagnostic only.
+luoshu_write_mount_probes() {
+    _lmhwp_active="${1:-unknown}"
+    _lmhwp_engine=$(luoshu_detect_mount_engine)
+    _lmhwp_id=$(luoshu_module_id)
+    _lmhwp_nonce="$(date +%s 2>/dev/null || echo 0)-$$-system"
+    _lmhwp_dir="$LUOSHU_MOUNT_MODDIR/system/etc/luoshu"
+    _lmhwp_manifest="$LUOSHU_MOUNT_MODDIR/config/mount-probes-expected.conf"
+
+    mkdir -p "$_lmhwp_dir" "$LUOSHU_MOUNT_MODDIR/config" 2>/dev/null || return 1
+    {
+        printf 'id=%s\n' "$_lmhwp_id"
+        printf 'font=%s\n' "$_lmhwp_active"
+        printf 'engine=%s\n' "$_lmhwp_engine"
+        printf 'partition=system\n'
+        printf 'nonce=%s\n' "$_lmhwp_nonce"
+    } > "$_lmhwp_dir/mount-probe.conf.tmp.$$" 2>/dev/null || return 1
+    mv -f "$_lmhwp_dir/mount-probe.conf.tmp.$$" "$_lmhwp_dir/mount-probe.conf" 2>/dev/null || return 1
+    chmod 0644 "$_lmhwp_dir/mount-probe.conf" 2>/dev/null || true
+    printf 'system|%s|/system/etc/luoshu/mount-probe.conf\n' "$_lmhwp_nonce" \
+        > "$_lmhwp_manifest.tmp.$$" 2>/dev/null || return 1
+    mv -f "$_lmhwp_manifest.tmp.$$" "$_lmhwp_manifest" 2>/dev/null || return 1
+    chmod 0644 "$_lmhwp_manifest" 2>/dev/null || true
+    cp -f "$_lmhwp_dir/mount-probe.conf" \
+        "$LUOSHU_MOUNT_MODDIR/config/mount-probe-expected.conf" 2>/dev/null || true
+}
+
+luoshu_write_mount_probe() {
+    luoshu_write_mount_probes "$@"
+}
+
+luoshu_sync_mount_payload() {
+    _lmhs_active="${1:-$(head -n1 "$LUOSHU_MOUNT_MODDIR/config/active_font.conf" 2>/dev/null)}"
+    [ -n "$_lmhs_active" ] || _lmhs_active=default
+    _lmhs_engine=$(luoshu_detect_mount_engine)
+    _lmhs_synced=0
+    _lmhs_failed=0
+    _lmhs_root=''
+    _lmhs_partitions=''
+    _lmhs_failed_partitions=''
+
+    luoshu_mount_budget_begin
+    luoshu_mount_lock_acquire || return 1
+    trap 'luoshu_mount_lock_release' EXIT HUP INT TERM
+
+    if ! luoshu_mount_preflight "$_lmhs_active"; then
+        luoshu_mount_record failed "$LUOSHU_MOUNT_PREFLIGHT_ERROR" '' 0 1
+        luoshu_mount_lock_release
+        trap - EXIT HUP INT TERM
+        return 1
+    fi
+
+    luoshu_write_mount_probes "$_lmhs_active" || \
+        luoshu_mount_log '挂载诊断探针生成失败，已继续保留标准模块负载'
+
+    for _lmhs_partition in $(luoshu_used_partitions); do
+        _lmhs_partitions="${_lmhs_partitions}${_lmhs_partitions:+,}$_lmhs_partition"
+    done
+
+    case "$_lmhs_engine" in
+        meta-overlayfs|dual-dir-metamodule)
+            _lmhs_root=$(luoshu_meta_content_roots | head -n1)
+            [ -n "$_lmhs_root" ] && mkdir -p "$_lmhs_root" 2>/dev/null || _lmhs_failed=1
+            if [ "$_lmhs_failed" -eq 0 ]; then
+                for _lmhs_partition in $(luoshu_used_partitions "$_lmhs_root"); do
+                    _lmhs_source="$LUOSHU_MOUNT_MODDIR/$_lmhs_partition"
+                    _lmhs_destination="$_lmhs_root/$_lmhs_partition"
+                    if [ -d "$_lmhs_source" ]; then
+                        if luoshu_copy_partition_atomic "$_lmhs_source" "$_lmhs_destination"; then
+                            _lmhs_synced=$((_lmhs_synced + 1))
+                        else
+                            _lmhs_result=$?
+                            _lmhs_failed=$((_lmhs_failed + 1))
+                            _lmhs_failed_partitions="${_lmhs_failed_partitions}${_lmhs_failed_partitions:+,}$_lmhs_partition"
+                            [ "$_lmhs_result" -ne 124 ] || \
+                                LUOSHU_MOUNT_PREFLIGHT_ERROR="元模块同步超过 ${LUOSHU_MOUNT_TIMEOUT} 秒总时限"
+                            break
+                        fi
+                    elif ! rm -rf "$_lmhs_destination" 2>/dev/null; then
+                        _lmhs_failed=$((_lmhs_failed + 1))
+                        _lmhs_failed_partitions="${_lmhs_failed_partitions}${_lmhs_failed_partitions:+,}$_lmhs_partition"
+                        break
+                    fi
+                done
+            fi
+            ;;
+        *)
+            # Mountify, Hybrid Mount, Magic Mount and native managers read the
+            # canonical /data/adb/modules/LuoShu tree. No guessed mirror and no
+            # external config mutation are necessary.
+            ;;
+    esac
+
+    luoshu_mount_lock_release
+    trap - EXIT HUP INT TERM
+
+    if [ "$_lmhs_failed" -gt 0 ]; then
+        luoshu_mount_record failed \
+            "${LUOSHU_MOUNT_PREFLIGHT_ERROR:-元模块内容更新失败，已保留旧分区目录}" \
+            "$_lmhs_root" "$_lmhs_synced" "$_lmhs_failed" \
+            "$_lmhs_partitions" '' "$_lmhs_failed_partitions"
+        return 1
+    fi
+
+    case "$_lmhs_engine" in
+        meta-overlayfs|dual-dir-metamodule)
+            luoshu_mount_record prepared \
+                '已同步双目录元模块内容；启动后使用主字体可见性进行兼容验证' \
+                "$_lmhs_root" "$_lmhs_synced" 0 "$_lmhs_partitions"
+            ;;
+        *)
+            luoshu_mount_record prepared \
+                '已保留标准模块目录；当前元模块直接读取 /data/adb/modules/LuoShu' \
+                '' 0 0 "$_lmhs_partitions"
+            ;;
+    esac
+    luoshu_mount_log \
+        "engine=$_lmhs_engine backend=$(luoshu_mount_backend "$_lmhs_engine") synced=$_lmhs_synced partitions=$_lmhs_partitions"
+    return 0
+}
+
+_luoshu_hotfix_verify_probe() {
+    _lmhvp_manifest="$LUOSHU_MOUNT_MODDIR/config/mount-probes-expected.conf"
+    [ -s "$_lmhvp_manifest" ] || return 1
+    IFS='|' read -r _lmhvp_partition _lmhvp_expected _lmhvp_path < "$_lmhvp_manifest"
+    [ -n "$_lmhvp_expected" ] || return 1
+    if [ -n "${LUOSHU_VISIBLE_PROBE:-}" ]; then
+        _lmhvp_visible="$LUOSHU_VISIBLE_PROBE"
+    elif [ -n "${LUOSHU_VISIBLE_PROBE_ROOT:-}" ]; then
+        _lmhvp_visible="${LUOSHU_VISIBLE_PROBE_ROOT%/}$_lmhvp_path"
+    else
+        _lmhvp_visible="$_lmhvp_path"
+    fi
+    _lmhvp_seen=$(sed -n 's/^nonce=//p' "$_lmhvp_visible" 2>/dev/null | head -n1)
+    [ "$_lmhvp_expected" = "$_lmhvp_seen" ]
+}
+
+_luoshu_hotfix_verify_font() {
+    _lmhvf_source=''
+    for _lmhvf_candidate in "$LUOSHU_MOUNT_MODDIR/system/fonts"/*; do
+        [ -f "$_lmhvf_candidate" ] || continue
+        [ -s "$_lmhvf_candidate" ] || continue
+        _lmhvf_source="$_lmhvf_candidate"
+        break
+    done
+    [ -n "$_lmhvf_source" ] || return 1
+    _lmhvf_visible="${LUOSHU_VISIBLE_SYSTEM_ROOT:-/system}/fonts/${_lmhvf_source##*/}"
+    [ -s "$_lmhvf_visible" ] || return 1
+    if command -v cmp >/dev/null 2>&1; then
+        cmp -s "$_lmhvf_source" "$_lmhvf_visible" 2>/dev/null
+        return $?
+    fi
+    _lmhvf_a=$(wc -c < "$_lmhvf_source" 2>/dev/null | tr -d '[:space:]')
+    _lmhvf_b=$(wc -c < "$_lmhvf_visible" 2>/dev/null | tr -d '[:space:]')
+    [ -n "$_lmhvf_a" ] && [ "$_lmhvf_a" = "$_lmhvf_b" ]
+}
+
+luoshu_mount_verify_active() {
+    _lmhv_active="${1:-$(head -n1 "$LUOSHU_MOUNT_MODDIR/config/active_font.conf" 2>/dev/null)}"
+    [ -n "$_lmhv_active" ] || _lmhv_active=default
+    if [ "$_lmhv_active" = default ]; then
+        luoshu_mount_record verified '系统默认字体无需挂载验证' '' 0 0
+        return 0
+    fi
+    if _luoshu_hotfix_verify_probe; then
+        luoshu_mount_record verified '主系统挂载探针可见，元模块已读取洛书标准目录' '' 0 0 system system
+        return 0
+    fi
+    if _luoshu_hotfix_verify_font; then
+        luoshu_mount_record verified '主字体文件已从系统路径读取，元模块挂载有效' '' 0 0 system system
+        return 0
+    fi
+    luoshu_mount_record unverified \
+        '暂未从固定路径读取到诊断探针；已保留字体负载，不再因元模块差异自动回滚' \
+        '' 0 0 system '' system
+    return 0
+}
+
+font_config_mark_boot_success() {
+    _lmhbs_config="${CONFIG_DIR:-$LUOSHU_MOUNT_MODDIR/config}"
+    _lmhbs_state=$(sed -n 's/^state=//p' "$_lmhbs_config/font-payload-boot.conf" 2>/dev/null | head -n1)
+    [ "$_lmhbs_state" = booting ] || return 0
+    _lmhbs_font=$(sed -n 's/^font=//p' "$_lmhbs_config/font-payload-boot.conf" 2>/dev/null | head -n1)
+    luoshu_mount_verify_active "${_lmhbs_font:-unknown}" || true
+    printf 'state=confirmed\nfont=%s\ntime=%s\n' \
+        "${_lmhbs_font:-unknown}" "$(date +%s 2>/dev/null || echo 0)" \
+        > "$_lmhbs_config/font-payload-boot.conf.tmp.$$" 2>/dev/null || return 1
+    mv -f "$_lmhbs_config/font-payload-boot.conf.tmp.$$" \
+        "$_lmhbs_config/font-payload-boot.conf" 2>/dev/null || return 1
+    rm -f \
+        "$_lmhbs_config/font-boot-failures" \
+        "$_lmhbs_config/font-payload-quarantine.conf" 2>/dev/null || true
+    printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)" \
+        > "$_lmhbs_config/font-last-boot-success.conf" 2>/dev/null || true
+    chmod 0644 \
+        "$_lmhbs_config/font-payload-boot.conf" \
+        "$_lmhbs_config/font-last-boot-success.conf" 2>/dev/null || true
+    return 0
+}

--- a/scripts/mount_compat_test.sh
+++ b/scripts/mount_compat_test.sh
@@ -8,180 +8,89 @@ trap 'rm -rf "$TMP"' EXIT HUP INT TERM
 MODULE="$TMP/modules/LuoShu"
 META="$TMP/meta"
 VISIBLE="$TMP/visible"
-mkdir -p "$MODULE/common" "$MODULE/system/fonts" "$MODULE/product/fonts" "$MODULE/config" "$MODULE/logs" "$META" "$VISIBLE"
+mkdir -p \
+    "$MODULE/common" "$MODULE/system/fonts" "$MODULE/product/fonts" \
+    "$MODULE/my_product/fonts" "$MODULE/config" "$MODULE/logs" \
+    "$META" "$VISIBLE/system/fonts"
 cp "$ROOT/common/mount_compat.sh" "$MODULE/common/mount_compat.sh"
-printf 'id=LuoShu\nversion=v2.2.5\nversionCode=20205\n' > "$MODULE/module.prop"
+cp "$ROOT/common/font_config_partitions.sh" "$MODULE/common/font_config_partitions.sh"
+cp "$ROOT/common/mount_compat_hotfix.sh" "$MODULE/common/mount_compat_hotfix.sh"
+printf 'id=LuoShu\nversion=v2.2.8\nversionCode=20208\n' > "$MODULE/module.prop"
 printf 'font-a' > "$MODULE/system/fonts/Roboto-Regular.ttf"
 printf 'product-a' > "$MODULE/product/fonts/Test.ttf"
+printf 'vendor-a' > "$MODULE/my_product/fonts/Oem.ttf"
 
-# Dual-directory engines copy all used supported partitions and write one probe per partition.
+# Dual-directory engines still receive every used partition, including OEM ones.
 MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" sh -c '
     . "$MODDIR/common/mount_compat.sh"
     luoshu_sync_mount_payload Demo
 '
 test -f "$META/LuoShu/system/fonts/Roboto-Regular.ttf"
 test -f "$META/LuoShu/product/fonts/Test.ttf"
-test -f "$META/LuoShu/system/etc/luoshu/mount-probe.conf"
-test -f "$META/LuoShu/product/etc/luoshu/mount-probe.conf"
-grep -q '^engine=meta-overlayfs$' "$MODULE/config/mount_compat.conf"
+test -f "$META/LuoShu/my_product/fonts/Oem.ttf"
 grep -q '^state=prepared$' "$MODULE/config/mount_compat.conf"
-grep -q '^partitions=system,product$' "$MODULE/config/mount_compat.conf"
 
-# Replacing a partition must remove stale files instead of merging trees.
-rm -f "$MODULE/system/fonts/Roboto-Regular.ttf"
-printf stale > "$META/LuoShu/system/fonts/Old.ttf"
-MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" sh -c '
+# Direct-source engines read the canonical module directory and never create guessed mirrors.
+rm -rf "$META/LuoShu"
+for ENGINE in mountify hybrid-mount magic-mount native-module-mount; do
+    MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE="$ENGINE" LUOSHU_META_TEST_ROOT="$META" sh -c '
+        . "$MODDIR/common/mount_compat.sh"
+        luoshu_sync_mount_payload Demo
+    '
+    test ! -e "$META/LuoShu"
+    grep -q "^engine=$ENGINE$" "$MODULE/config/mount_compat.conf"
+done
+
+# LuoShu must not rewrite Magic Mount RC configuration.
+MAGIC_CONFIG="$TMP/magic-mount-config.toml"
+printf 'mountsource = "KSU"\npartitions = ["vendor"]\n' > "$MAGIC_CONFIG"
+cp "$MAGIC_CONFIG" "$MAGIC_CONFIG.before"
+touch "$MODULE/skip_mount" "$MODULE/skip_mountify" "$MODULE/mount_error"
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG" sh -c '
     . "$MODDIR/common/mount_compat.sh"
     luoshu_sync_mount_payload Demo
 '
-test ! -e "$META/LuoShu/system/fonts/Old.ttf"
-test ! -e "$META/LuoShu/system/fonts/Roboto-Regular.ttf"
-test -s "$META/LuoShu/system/etc/luoshu/mount-probe.conf"
+cmp -s "$MAGIC_CONFIG" "$MAGIC_CONFIG.before"
+test ! -e "$MODULE/skip_mount"
+test ! -e "$MODULE/skip_mountify"
+test ! -e "$MODULE/mount_error"
 
-# Verify every used partition, not merely /system.
-mkdir -p "$VISIBLE/system/etc/luoshu" "$VISIBLE/product/etc/luoshu"
-cp "$MODULE/system/etc/luoshu/mount-probe.conf" "$VISIBLE/system/etc/luoshu/mount-probe.conf"
-cp "$MODULE/product/etc/luoshu/mount-probe.conf" "$VISIBLE/product/etc/luoshu/mount-probe.conf"
-MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" LUOSHU_VISIBLE_PROBE_ROOT="$VISIBLE" sh -c '
+# Missing diagnostic probes are advisory and may not roll back a validated payload.
+printf 'state=booting\nfont=Demo\n' > "$MODULE/config/font-payload-boot.conf"
+MODDIR="$MODULE" MODULE_DIR="$MODULE" CONFIG_DIR="$MODULE/config" \
+LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_VISIBLE_PROBE_ROOT="$VISIBLE" \
+LUOSHU_VISIBLE_SYSTEM_ROOT="$VISIBLE/system" sh -c '
+    . "$MODDIR/common/mount_compat.sh"
+    font_config_mark_boot_success
+'
+grep -q '^state=confirmed$' "$MODULE/config/font-payload-boot.conf"
+grep -q '^state=unverified$' "$MODULE/config/mount_compat.conf"
+
+# A real visible font verifies the mount even if a synthetic probe is absent.
+cp "$MODULE/system/fonts/Roboto-Regular.ttf" "$VISIBLE/system/fonts/Roboto-Regular.ttf"
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=mountify \
+LUOSHU_VISIBLE_PROBE_ROOT="$VISIBLE" LUOSHU_VISIBLE_SYSTEM_ROOT="$VISIBLE/system" sh -c '
     . "$MODDIR/common/mount_compat.sh"
     luoshu_mount_verify_active Demo
 '
 grep -q '^state=verified$' "$MODULE/config/mount_compat.conf"
-grep -q '^verifiedPartitions=system,product$' "$MODULE/config/mount_compat.conf"
-rm -f "$VISIBLE/product/etc/luoshu/mount-probe.conf"
-if MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" LUOSHU_VISIBLE_PROBE_ROOT="$VISIBLE" sh -c '
-    . "$MODDIR/common/mount_compat.sh"
-    luoshu_mount_verify_active Demo
-'; then
-    echo 'partition verification unexpectedly passed with product missing' >&2
-    exit 1
-fi
-grep -q '^state=unverified$' "$MODULE/config/mount_compat.conf"
-grep -q '^failedPartitions=product$' "$MODULE/config/mount_compat.conf"
 
-# Unsupported vendor partitions are rejected explicitly rather than silently ignored.
-mkdir -p "$MODULE/my_product/fonts"
-printf vendor-font > "$MODULE/my_product/fonts/Oem.ttf"
-if MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" sh -c '
-    . "$MODDIR/common/mount_compat.sh"
-    luoshu_sync_mount_payload Demo
-'; then
-    echo 'unsupported meta-overlayfs partition unexpectedly succeeded' >&2
-    exit 1
-fi
-grep -q 'my_product' "$MODULE/config/mount_compat.conf"
-MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=meta-overlayfs LUOSHU_META_TEST_ROOT="$META" LUOSHU_META_EXTRA_PARTITIONS=my_product sh -c '
-    . "$MODDIR/common/mount_compat.sh"
-    luoshu_sync_mount_payload Demo
-'
-test -f "$META/LuoShu/my_product/fonts/Oem.ttf"
-rm -rf "$MODULE/my_product" "$META/LuoShu/my_product"
-
-# Direct-source engines never create a guessed second module tree.
-rm -rf "$META/LuoShu"
-MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=mountify LUOSHU_META_TEST_ROOT="$META" sh -c '
-    . "$MODDIR/common/mount_compat.sh"
-    luoshu_sync_mount_payload Demo
-'
-test ! -e "$META/LuoShu"
-grep -q '^engine=mountify$' "$MODULE/config/mount_compat.conf"
-
-# Hybrid Mount records the selected backend for diagnostics.
-MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=hybrid-mount LUOSHU_META_TEST_BACKEND=kasumi sh -c '
-    . "$MODDIR/common/mount_compat.sh"
-    luoshu_sync_mount_payload Demo
-'
-grep -q '^engine=hybrid-mount$' "$MODULE/config/mount_compat.conf"
-grep -q '^backend=kasumi$' "$MODULE/config/mount_compat.conf"
-
-# Magic Mount retries clear recoverable markers and update partitions under a config lock.
-touch "$MODULE/skip_mount" "$MODULE/mount_error"
-MAGIC_CONFIG="$TMP/magic-mount-config.toml"
-printf 'mountsource = "KSU"\numount = false\npartitions = [\n  "vendor", # keep existing\n]\n' > "$MAGIC_CONFIG"
-MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG" sh -c '
-    . "$MODDIR/common/mount_compat.sh"
-    luoshu_sync_mount_payload Demo
-'
-test ! -e "$MODULE/skip_mount"
-test ! -e "$MODULE/mount_error"
-grep -q '"vendor"' "$MAGIC_CONFIG"
-grep -q '"product"' "$MAGIC_CONFIG"
-test "$(grep -c '^[[:space:]]*partitions[[:space:]]*=' "$MAGIC_CONFIG")" -eq 1
-test -s "$MAGIC_CONFIG.luoshu.bak"
-test ! -e "$MAGIC_CONFIG.luoshu.lock"
-
-# Explicit font transactions recover an old LuoShu disable marker, but never remove remove.
-touch "$MODULE/disable"
-printf '2\n' > "$MODULE/config/font-boot-failures"
-MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG" sh -c '
-    . "$MODDIR/common/mount_compat.sh"
-    luoshu_sync_mount_payload FontA
-'
-test ! -e "$MODULE/disable"
-test ! -e "$MODULE/config/font-boot-failures"
-touch "$MODULE/remove"
-if MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=magic-mount LUOSHU_MAGIC_MOUNT_CONFIG="$MAGIC_CONFIG" sh -c '
-    . "$MODDIR/common/mount_compat.sh"
-    luoshu_sync_mount_payload FontA
-'; then
-    echo 'remove marker was unexpectedly cleared' >&2
-    exit 1
-fi
-test -e "$MODULE/remove"
-rm -f "$MODULE/remove"
-
-# A copy timeout has one bounded attempt only and preserves the old destination tree.
-SLOWBIN="$TMP/slowbin"
-mkdir -p "$SLOWBIN" "$TMP/source/system" "$TMP/dest/system"
-printf new > "$TMP/source/system/new.ttf"
-printf old > "$TMP/dest/system/old.ttf"
-cat > "$SLOWBIN/cp" <<'EOS'
-#!/bin/sh
-sleep 10
-exit 1
-EOS
-chmod 0755 "$SLOWBIN/cp"
-if PATH="$SLOWBIN:$PATH" MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_MOUNT_TIMEOUT=2 LUOSHU_META_TEST_ENGINE=native-module-mount sh -c '
-    . "$MODDIR/common/mount_compat.sh"
-    luoshu_mount_budget_begin
-    luoshu_copy_partition_atomic "$1" "$2"
-' sh "$TMP/source/system" "$TMP/dest/system"; then
-    echo 'slow copy unexpectedly succeeded' >&2
-    exit 1
-fi
-test -f "$TMP/dest/system/old.ttf"
-test ! -e "$TMP/dest/system/new.ttf"
-
-# Conflicting enabled mount modules are surfaced in diagnostics instead of being silently guessed.
-MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=mountify LUOSHU_META_TEST_CANDIDATES="mountify magic-mount" sh -c '
+# Multiple enabled engines remain a warning instead of changing the direct-source contract.
+MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_META_TEST_ENGINE=mountify \
+LUOSHU_META_TEST_CANDIDATES='mountify magic-mount' sh -c '
     . "$MODDIR/common/mount_compat.sh"
     luoshu_sync_mount_payload Demo
     luoshu_mount_status_json > "$MODDIR/config/mount_status.json"
 '
 grep -q '^warning=检测到多个已启用挂载模块：mountify、magic-mount$' "$MODULE/config/mount_compat.conf"
 grep -q '"backend":"mountify"' "$MODULE/config/mount_status.json"
-grep -q '"warning":"检测到多个已启用挂载模块：mountify、magic-mount"' "$MODULE/config/mount_status.json"
 
-# The flash installer must recover both the staging tree and the currently active module tree.
-grep -q 'for _enable_dir in "$MODPATH" "$OLD_MOD"' "$ROOT/customize.sh"
-grep -q 'rm -f "$_enable_dir/disable"' "$ROOT/customize.sh"
-
-# Runtime syncing remains transaction-only. Never mirror blindly from early boot scripts.
-grep -q 'common/mount_compat.sh' "$ROOT/common/font_mix.sh"
-grep -q 'luoshu_sync_mount_payload' "$ROOT/common/font_mix.sh"
-! grep -q 'luoshu_sync_mount_payload' "$ROOT/post-fs-data.sh"
-! grep -q 'luoshu_sync_mount_payload' "$ROOT/service.sh"
-! grep -q 'prepare_mount_compat.sh' "$ROOT/scripts/build.sh"
-
-# Release packages must not contain markers that exclude LuoShu from mount planning.
-STAGE="$TMP/stage"
-mkdir -p "$STAGE"
-cp -R "$ROOT/." "$STAGE/"
-rm -rf "$STAGE/.git" "$STAGE/dist" "$STAGE/common/python" 2>/dev/null || true
-! find "$STAGE" -type f \( -name skip_mount -o -name skip_mountify \) | grep -q .
+# The compatibility override must always be loaded after the original implementation.
+grep -q 'common/mount_compat_hotfix.sh' "$ROOT/common/font_config_partitions.sh"
 sh -n "$ROOT/common/mount_compat.sh"
+sh -n "$ROOT/common/mount_compat_hotfix.sh"
+sh -n "$ROOT/common/font_config_partitions.sh"
 sh -n "$ROOT/common/font_mix.sh"
-sh -n "$ROOT/common/app_bridge.sh"
 sh -n "$ROOT/post-fs-data.sh"
 sh -n "$ROOT/service.sh"
 


### PR DESCRIPTION
## 问题

v2.2.5 起的元模块兼容层把诊断探针当成挂载成败的硬条件，并会主动改写 Magic Mount 的 `config.toml`。Mountify 与 Magic Mount RC 的挂载时机、缓存和配置结构并不完全一致，导致原本可用的标准模块负载被误判失败，随后触发事务回滚或隔离。

## 修复

- Mountify、Hybrid Mount、Magic Mount 与原生管理器统一直接读取 `/data/adb/modules/LuoShu`，不再猜测或复制第二套目录。
- 仅双目录 Overlay 元模块继续同步内容镜像。
- 不再改写 Magic Mount / Magic Mount RC 的外部配置文件。
- 补充 Magic Mount RC 常见可执行路径识别。
- Mountify 选择模式下尝试将 LuoShu 加入现有模块列表，未知路径仅记录警告，不误伤已验证负载。
- 将逐分区硬性探针改为单一主分区诊断，并增加真实字体文件可见性验证。
- 探针不可见时只记录诊断，不再回滚、隔离或撤销已通过原子校验的字体负载。
- 显式字体事务清理 LuoShu 自身遗留的 `skip_mount`、`skip_mountify` 和 `mount_error` 标记。

## 验证

本地元模块回归测试已通过，覆盖：

- Meta Overlay 双目录同步及 OEM 分区。
- Mountify、Hybrid Mount、Magic Mount、原生挂载均不创建猜测镜像。
- Magic Mount 配置保持字节级不变。
- Magic Mount 遗留标记恢复。
- 缺失探针不会导致启动事务失败。
- 真实系统字体可见时可完成挂载确认。
- Shell 语法检查。

GitHub Actions 未为该提交触发工作流。