### PR TITLE
release: publish LuoShu v2.2.8

### DIFF
--- a/RELEASE_NOTES_v2.2.8.md
+++ b/RELEASE_NOTES_v2.2.8.md
@@ -1,0 +1,57 @@
+# 洛书 v2.2.8
+
+洛书 v2.2.8 是元模块兼容回退修复版本，重点恢复 Mountify 与 Magic Mount RC 在旧版本中已经可用的标准模块挂载方式，并撤销会误判、误回滚的过度兼容逻辑。
+
+## 问题原因
+
+v2.2.5 起，洛书新增了逐分区挂载探针与元模块配置适配，但把诊断结果错误地作为字体事务是否成功的硬条件：
+
+- 要求所有字体负载分区都必须从固定系统路径读回探针。
+- Magic Mount 的外部 `config.toml` 会被洛书主动改写。
+- 元模块挂载时机、缓存方式或路径布局稍有不同，就会被判定为挂载失败。
+- 已经通过字体文件原子校验的负载，仍可能因探针不可见而被回滚或隔离。
+
+这套逻辑破坏了 Mountify 与 Magic Mount RC 原本可用的标准模块目录契约。
+
+## 本次修复
+
+- Mountify、Hybrid Mount、Magic Mount、Magic Mount RC 与原生 Root 管理器统一直接读取 `/data/adb/modules/LuoShu`。
+- 仅真正采用双目录内容树的 Overlay 元模块继续同步第二份内容镜像。
+- 洛书不再修改 Magic Mount 或 Magic Mount RC 的配置文件。
+- 补充 Magic Mount RC 常见模块 ID 与可执行路径识别。
+- Mountify 处于模块选择模式时，自动尝试把 `LuoShu` 加入已有选择列表。
+- 清理洛书自身遗留的 `skip_mount`、`skip_mountify` 与 `mount_error` 标记，避免一次失败永久影响后续应用。
+- 取消逐分区硬性探针，改为主系统分区诊断，并增加真实字体文件可见性验证。
+- 探针路径或挂载时机不同只记录诊断，不再回滚、隔离或撤销已通过原子校验的字体负载。
+- 保留多元模块同时启用的警告，但不再擅自修改其他元模块状态。
+
+## 回归验证
+
+- Meta Overlay 双目录同步及 OEM 分区同步通过。
+- Mountify、Hybrid Mount、Magic Mount 与原生挂载均不会创建猜测目录。
+- Magic Mount 配置文件在字体事务前后保持字节级不变。
+- Magic Mount RC 路径识别与洛书遗留标记恢复通过。
+- 探针不可见时字体启动事务仍能安全确认，不再触发误回滚。
+- 真实系统字体文件可见时可完成挂载确认。
+- Shell 语法检查与完整仓库发布门禁由正式发布工作流执行。
+
+## 安装与升级
+
+1. 在 Magisk、KernelSU、SukiSU Ultra 或 APatch 中刷入 `LuoShu-v2.2.8.zip`。
+2. 完整重启设备。
+3. 打开洛书重新应用一次字体，再完整重启。
+4. Mountify 使用选择模式时，确认模块列表中存在 `LuoShu`；新版会自动尝试补充。
+
+从 v2.2.7 升级不会清除字体库、App 数据或外观设置。模块 ZIP 内置同版本正式签名 App，也提供独立的 `LuoShu-App-v2.2.8.apk`。
+
+## 版本信息
+
+- 模块版本：`v2.2.8`
+- 模块 versionCode：`20208`
+- App versionCode：`2020801`
+- 最低 Android：Android 9 / API 28
+- 目标 Android：API 36
+
+## 校验
+
+Release 同时提供模块 ZIP、正式签名 APK 及各自的 SHA-256 文件。下载后可使用对应 `.sha256` 文件核验完整性。

--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v2.2.7
-summary=修复模块卸载后主目录与元模块镜像残留
-notes=v2.2.7 修复卸载清理缺陷：卸载脚本不再重新创建 logs 目录或向模块目录写入“已卸载”日志；恢复字体粗细、动态挂载、旧 provider 与 Flyme 持久字体后，安全删除 /data/adb/modules/LuoShu、/data/adb/modules_update/LuoShu 及 meta-overlayfs 双目录中的 LuoShu 内容镜像；清理洛书生成的 Magic Mount 锁、备份与临时文件，但保留用户当前主配置和其他模块。新增卸载回归测试，确认目标目录全部消失且非洛书数据不受影响。模块 versionCode 20207，App versionCode 2020701。
+version=v2.2.8
+summary=恢复 Mountify 与 Magic Mount RC 兼容并取消误回滚
+notes=v2.2.8 修复 v2.2.5 起的元模块兼容回退：Mountify、Hybrid Mount、Magic Mount 与原生管理器重新统一读取 /data/adb/modules/LuoShu 标准模块目录；仅双目录 Overlay 元模块同步内容镜像；洛书不再改写 Magic Mount 配置文件；补充 Magic Mount RC 路径识别；Mountify 选择模式自动尝试加入 LuoShu；挂载探针改为诊断信息，探针路径或挂载时机不同不再导致已通过原子校验的字体负载被回滚或隔离。模块 versionCode 20208，App versionCode 2020801。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v2.2.7
-versionCode=20207
+version=v2.2.8
+versionCode=20208
 author=惜故里丶
 description=Android 无 Hook 全局字体引擎：真机字体清单、快速单字体切换、组合字体与安全事务回滚
 updateJson=https://raw.githubusercontent.com/xgl34222220-ops/LuoShu/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-  "version": "v2.2.7",
-  "versionCode": 20207,
-  "zipUrl": "https://github.com/xgl34222220-ops/LuoShu/releases/download/v2.2.7/LuoShu-v2.2.7.zip",
-  "changelog": "https://raw.githubusercontent.com/xgl34222220-ops/LuoShu/main/RELEASE_NOTES_v2.2.7.md"
+  "version": "v2.2.8",
+  "versionCode": 20208,
+  "zipUrl": "https://github.com/xgl34222220-ops/LuoShu/releases/download/v2.2.8/LuoShu-v2.2.8.zip",
+  "changelog": "https://raw.githubusercontent.com/xgl34222220-ops/LuoShu/main/RELEASE_NOTES_v2.2.8.md"
 }


### PR DESCRIPTION
## 发布内容

发布 v2.2.8 元模块兼容回退修复版。

- 恢复 Mountify、Magic Mount RC、Hybrid Mount 与原生管理器直接读取标准模块目录的契约。
- 仅双目录 Overlay 元模块同步内容镜像。
- 不再改写 Magic Mount 配置。
- 挂载探针改为非破坏性诊断，不再触发已验证字体负载的误回滚或隔离。
- 更新模块版本、App 派生版本、更新通道与正式发布说明。

## 版本

- 模块：v2.2.8 / 20208
- App：2.2.8 / 2020801

合入 main 后由 `Publish signed release` 工作流执行完整源码门禁、App Lint/单元测试、签名 APK 与模块 ZIP 构建，并创建不可覆盖的 v2.2.8 Release。