### PR TITLE
fix: harden font tasks and App recovery

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuViewModel.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuViewModel.kt
@@ -618,7 +618,7 @@ internal class LuoShuViewModel(application: Application) : AndroidViewModel(appl
         watchedTaskId = taskId
         operationBusy = true
         try {
-            val result = waitForTask("switch_status", taskId, timeoutSeconds = 120) { data ->
+            val result = waitForTask("switch_status", taskId, timeoutSeconds = 390) { data ->
                 operationMessage = data.optString("message", "正在处理字体…")
                 snapshot = snapshot.copy(
                     taskType = "switch",
@@ -717,7 +717,8 @@ internal class LuoShuViewModel(application: Application) : AndroidViewModel(appl
     ): JSONObject {
         var elapsed = 0
         var failures = 0
-        while (elapsed < timeoutSeconds) {
+        var deadlineSeconds = timeoutSeconds
+        while (elapsed < deadlineSeconds) {
             val interval = if (elapsed < 30) 1 else 2
             delay(interval * 1_000L)
             elapsed += interval
@@ -738,6 +739,8 @@ internal class LuoShuViewModel(application: Application) : AndroidViewModel(appl
                 continue
             }
             failures = 0
+            val advertisedTimeout = data.optInt("timeout", 0)
+            if (advertisedTimeout > 0) deadlineSeconds = maxOf(deadlineSeconds, advertisedTimeout + 30)
             onProgress(data)
             when (data.optString("state")) {
                 "success", "failed" -> return data

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/DiagnosticExportUi.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/DiagnosticExportUi.kt
@@ -1,6 +1,5 @@
 package io.github.xgl34222220.luoshu.ui.logs
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +15,7 @@ import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -66,6 +66,12 @@ internal suspend fun exportSanitizedDiagnostic(): DiagnosticExportState {
         selfMountState="${'$'}(read_value "${'$'}CFG/self-mount.conf" state)"
         selfMountBackend="${'$'}(read_value "${'$'}CFG/self-mount.conf" backend)"
         selfMountFailed="${'$'}(read_value "${'$'}CFG/self-mount.conf" failed)"
+        moduleDirectory=missing
+        [ -d "${'$'}MOD" ] && moduleDirectory=present
+        pendingModuleDirectory=missing
+        [ -d /data/adb/modules_update/LuoShu ] && pendingModuleDirectory=present
+        postMountScript=missing
+        [ -f "${'$'}MOD/post-mount.sh" ] && postMountScript=present
         cachePending=no
         [ -s "${'$'}CFG/device-font-cache-pending.conf" ] && cachePending=yes
         rootManager=Root
@@ -102,6 +108,9 @@ internal suspend fun exportSanitizedDiagnostic(): DiagnosticExportState {
             printf 'selfMountState=%s\n' "${'$'}{selfMountState:-missing}"
             printf 'selfMountBackend=%s\n' "${'$'}{selfMountBackend:-missing}"
             printf 'selfMountFailed=%s\n' "${'$'}{selfMountFailed:-none}"
+            printf 'moduleDirectory=%s\n' "${'$'}moduleDirectory"
+            printf 'pendingModuleDirectory=%s\n' "${'$'}pendingModuleDirectory"
+            printf 'postMountScript=%s\n' "${'$'}postMountScript"
             printf 'cachePending=%s\n' "${'$'}cachePending"
             printf 'rootManager=%s\n' "${'$'}rootManager"
             printf 'mountEngine=%s\n' "${'$'}mountEngine"
@@ -133,19 +142,26 @@ internal fun DiagnosticExportButton(
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        onClick = onClick,
-        enabled = !state.busy,
         modifier = modifier.size(50.dp),
         shape = RoundedCornerShape(17.dp),
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
         contentColor = MaterialTheme.colorScheme.primary,
-        shadowElevation = 6.dp,
+        tonalElevation = 2.dp,
+        shadowElevation = 3.dp,
     ) {
-        Box(contentAlignment = Alignment.Center) {
+        IconButton(
+            onClick = onClick,
+            enabled = !state.busy,
+            modifier = Modifier.size(50.dp),
+        ) {
             if (state.busy) {
                 CircularProgressIndicator(Modifier.size(21.dp), strokeWidth = 2.dp)
             } else {
-                Icon(Icons.Rounded.Description, contentDescription = "生成脱敏诊断报告")
+                Icon(
+                    Icons.Rounded.Description,
+                    contentDescription = "生成脱敏诊断报告",
+                    modifier = Modifier.size(24.dp),
+                )
             }
         }
     }

--- a/common/app_installer.sh
+++ b/common/app_installer.sh
@@ -8,6 +8,7 @@ APK="$MODDIR/bundled/LuoShu-App.apk"
 META="$MODDIR/bundled/app.prop"
 PENDING="$MODDIR/config/app_install_pending"
 STATE="$MODDIR/config/app_install_state.conf"
+RETRY_STATE="$MODDIR/config/app_install_retry_count"
 LOG="${APP_INSTALL_LOG:-$MODDIR/logs/app-install.log}"
 MODE="${1:-auto}"
 
@@ -115,7 +116,7 @@ INSTALLED_VERSION=$(installed_version_code)
 if [ "$INSTALLED_VERSION" = "$APP_VERSION_CODE" ]; then
     PREVIOUS_APK_SHA256=$(read_prop apkSha256 "$STATE")
     if [ "$APK_SHA256" = unknown ] || [ "$PREVIOUS_APK_SHA256" = "$APK_SHA256" ]; then
-        rm -f "$PENDING" 2>/dev/null || true
+        rm -f "$PENDING" "$RETRY_STATE" 2>/dev/null || true
         write_state up_to_date "已安装版本与模块内置 App 一致"
         log_app INFO "$APP_PACKAGE 已是目标版本 $APP_VERSION_CODE，跳过覆盖安装"
         printf 'already-current\n'
@@ -143,7 +144,7 @@ fi
 
 printf '%s\n' "$INSTALL_RESULT" >> "$LOG" 2>/dev/null || true
 if [ "$INSTALL_CODE" -eq 0 ] && printf '%s' "$INSTALL_RESULT" | grep -q 'Success'; then
-    rm -f "$PENDING" 2>/dev/null || true
+    rm -f "$PENDING" "$RETRY_STATE" 2>/dev/null || true
     write_state installed "覆盖安装成功"
     log_app INFO "洛书 App 已安装或更新到 $APP_VERSION_CODE"
     printf 'installed\n'
@@ -151,7 +152,21 @@ if [ "$INSTALL_CODE" -eq 0 ] && printf '%s' "$INSTALL_RESULT" | grep -q 'Success
 fi
 
 touch "$PENDING" 2>/dev/null || true
+if [ "$INSTALL_CODE" -eq 124 ] || [ "$INSTALL_CODE" -eq 137 ]; then
+    write_state deferred "App 安装命令超时，等待下次开机重试"
+    log_app INFO "App 安装超时，保留自动重试标记"
+    printf 'deferred\n'
+    exit 10
+fi
+case "$INSTALL_RESULT" in
+    *INSTALL_FAILED_UPDATE_INCOMPATIBLE*|*INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES*|*INSTALL_FAILED_SHARED_USER_INCOMPATIBLE*|*INSTALL_FAILED_INVALID_APK*|*INSTALL_PARSE_FAILED_*)
+        write_state blocked "${INSTALL_RESULT:-安装包或签名不兼容}"
+        log_app ERROR "App 安装存在永久阻断，需要用户手动处理旧签名或损坏安装包"
+        printf 'permanent-failure\n'
+        exit 12
+        ;;
+esac
 write_state failed "${INSTALL_RESULT:-安装命令失败}"
-log_app ERROR "App 安装失败，保留首次开机重试标记"
+log_app ERROR "App 安装暂时失败，保留首次开机重试标记"
 printf 'failed\n'
 exit 11

--- a/common/font_switch_task.sh
+++ b/common/font_switch_task.sh
@@ -22,12 +22,16 @@ WORKER_PID_FILE="${LUOSHU_SWITCH_WORKER_PID_FILE:-$MODDIR/config/switch_task_wor
 LOAD_VERIFY_STATE="$MODDIR/config/device-font-load-verification.conf"
 [ -f "$BACKGROUND_TASK" ] && . "$BACKGROUND_TASK"
 
-# 大型 CJK 字体在部分低速存储设备上会超过旧版 45 秒。任务已脱离 App 会话，
-# 因此给完整验证、事务快照、槽位映射和挂载同步共 110 秒，同时仍早于 App 的 120 秒观察上限结束。
-TIMEOUT_SECONDS="${LUOSHU_SWITCH_TIMEOUT_SECONDS:-110}"
-case "$TIMEOUT_SECONDS" in ''|*[!0-9]*) TIMEOUT_SECONDS=110 ;; esac
+# 大型 CJK、TTC、可变字体和复合槽位在低速存储或多 OEM 分区设备上可能超过两分钟。
+# 后台任务与 App 都读取同一超时字段；默认给完整验证、事务快照、槽位映射和挂载同步 360 秒。
+TIMEOUT_SECONDS="${LUOSHU_SWITCH_TIMEOUT_SECONDS:-360}"
+case "$TIMEOUT_SECONDS" in ''|*[!0-9]*) TIMEOUT_SECONDS=360 ;; esac
 [ "$TIMEOUT_SECONDS" -ge 5 ] 2>/dev/null || TIMEOUT_SECONDS=5
-[ "$TIMEOUT_SECONDS" -le 600 ] 2>/dev/null || TIMEOUT_SECONDS=600
+[ "$TIMEOUT_SECONDS" -le 900 ] 2>/dev/null || TIMEOUT_SECONDS=900
+HEARTBEAT_INTERVAL="${LUOSHU_SWITCH_HEARTBEAT_INTERVAL:-5}"
+case "$HEARTBEAT_INTERVAL" in ''|*[!0-9]*) HEARTBEAT_INTERVAL=5 ;; esac
+[ "$HEARTBEAT_INTERVAL" -ge 1 ] 2>/dev/null || HEARTBEAT_INTERVAL=1
+[ "$HEARTBEAT_INTERVAL" -le 30 ] 2>/dev/null || HEARTBEAT_INTERVAL=30
 
 json_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '
@@ -46,6 +50,9 @@ write_task() {
     _started="$5"
     _finished="$6"
     _pid="$7"
+    _heartbeat="${8:-$(date +%s 2>/dev/null || echo 0)}"
+    _timeout="${9:-$TIMEOUT_SECONDS}"
+    _elapsed="${10:-0}"
     mkdir -p "${TASK_FILE%/*}" 2>/dev/null || return 1
     _tmp="${TASK_FILE}.tmp.$$"
     {
@@ -56,6 +63,9 @@ write_task() {
         printf 'started=%s\n' "$_started"
         printf 'finished=%s\n' "$_finished"
         printf 'pid=%s\n' "$_pid"
+        printf 'heartbeat=%s\n' "$_heartbeat"
+        printf 'timeout=%s\n' "$_timeout"
+        printf 'elapsed=%s\n' "$_elapsed"
     } > "$_tmp" 2>/dev/null || return 1
     mv -f "$_tmp" "$TASK_FILE" 2>/dev/null || return 1
     chmod 0644 "$TASK_FILE" 2>/dev/null || true
@@ -117,27 +127,28 @@ terminate_child_tree() {
 run_bounded() {
     _font="$1"
     _output="$2"
-    if command -v timeout >/dev/null 2>&1; then
-        timeout "$TIMEOUT_SECONDS" sh "$MANAGER" action switch "$_font" > "$_output" 2>&1
-        return $?
-    fi
-    if command -v toybox >/dev/null 2>&1 && toybox timeout --help >/dev/null 2>&1; then
-        toybox timeout "$TIMEOUT_SECONDS" sh "$MANAGER" action switch "$_font" > "$_output" 2>&1
-        return $?
-    fi
+    _task="$3"
+    _started="$4"
 
     sh "$MANAGER" action switch "$_font" > "$_output" 2>&1 &
     _child=$!
     _elapsed=0
-    while task_pid_alive "$_child" && [ "$_elapsed" -lt "$TIMEOUT_SECONDS" ]; do
+    _next_heartbeat=0
+    while task_pid_alive "$_child"; do
+        if [ "$_elapsed" -ge "$TIMEOUT_SECONDS" ]; then
+            terminate_child_tree "$_child"
+            wait "$_child" 2>/dev/null || true
+            return 124
+        fi
+        if [ "$_elapsed" -ge "$_next_heartbeat" ]; then
+            _heartbeat=$(date +%s 2>/dev/null || echo 0)
+            write_task "$_task" running "$_font" "正在验证并应用字体（已用 ${_elapsed} 秒）" \
+                "$_started" '' "$$" "$_heartbeat" "$TIMEOUT_SECONDS" "$_elapsed" || true
+            _next_heartbeat=$((_elapsed + HEARTBEAT_INTERVAL))
+        fi
         sleep 1
         _elapsed=$((_elapsed + 1))
     done
-    if task_pid_alive "$_child"; then
-        terminate_child_tree "$_child"
-        wait "$_child" 2>/dev/null || true
-        return 124
-    fi
     wait "$_child"
 }
 
@@ -152,7 +163,7 @@ run_worker() {
     printf '[%s] bounded switch start: %s task=%s timeout=%ss\n' \
         "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" "$_font" "$_task" "$TIMEOUT_SECONDS" >> "$LOG_FILE" 2>/dev/null || true
 
-    run_bounded "$_font" "$_output"
+    run_bounded "$_font" "$_output" "$_task" "$_started"
     _rc=$?
     _finished="$(date +%s 2>/dev/null || echo 0)"
     if [ "$_rc" -eq 0 ] && grep -q '"status":"ok"' "$_output" 2>/dev/null; then
@@ -192,7 +203,7 @@ start_task() {
 
     export MODDIR LUOSHU_FONT_MANAGER="$MANAGER" LUOSHU_SWITCH_TASK_FILE="$TASK_FILE" \
         LUOSHU_SWITCH_LOG="$LOG_FILE" LUOSHU_SWITCH_TIMEOUT_SECONDS="$TIMEOUT_SECONDS" \
-        LUOSHU_SWITCH_WORKER_PID_FILE="$WORKER_PID_FILE"
+        LUOSHU_SWITCH_HEARTBEAT_INTERVAL="$HEARTBEAT_INTERVAL" LUOSHU_SWITCH_WORKER_PID_FILE="$WORKER_PID_FILE"
 
     if type luoshu_start_detached >/dev/null 2>&1; then
         luoshu_start_detached "$WORKER_PID_FILE" "$_task" "$LOG_FILE" sh "$0" run "$_task" "$_font" "$_started"
@@ -227,12 +238,15 @@ status_task() {
     _message="$(read_value message)"
     _started="$(read_value started)"
     _finished="$(read_value finished)"
+    _heartbeat="$(read_value heartbeat)"
+    _timeout="$(read_value timeout)"
+    _elapsed="$(read_value elapsed)"
     if [ "$_state" = success ] && [ -f "$STATUS_SCRIPT" ]; then
         MODDIR="$MODDIR" sh "$STATUS_SCRIPT" "$_font" >/dev/null 2>&1 || true
     fi
-    printf '{"status":"ok","data":{"task":"%s","state":"%s","font":"%s","message":"%s","started":%s,"finished":%s}}\n' \
+    printf '{"status":"ok","data":{"task":"%s","state":"%s","font":"%s","message":"%s","started":%s,"finished":%s,"heartbeat":%s,"timeout":%s,"elapsed":%s}}\n' \
         "$(json_escape "$_task")" "$(json_escape "$_state")" "$(json_escape "$_font")" "$(json_escape "$_message")" \
-        "${_started:-0}" "${_finished:-0}"
+        "${_started:-0}" "${_finished:-0}" "${_heartbeat:-0}" "${_timeout:-$TIMEOUT_SECONDS}" "${_elapsed:-0}"
 }
 
 case "${1:-status}" in

--- a/scripts/app_installer_test.sh
+++ b/scripts/app_installer_test.sh
@@ -35,10 +35,16 @@ case "$1" in
     ;;
   install)
     printf '%s\n' "$*" >> "$MOCK_PM_CALLS"
-    if [ "${MOCK_PM_FAIL:-0}" = 1 ]; then
-      echo 'Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]'
-      exit 1
-    fi
+    case "${MOCK_PM_FAIL:-0}" in
+      1)
+        echo 'Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]'
+        exit 1
+        ;;
+      2)
+        echo 'Failure [INSTALL_FAILED_INTERNAL_ERROR]'
+        exit 1
+        ;;
+    esac
     echo 'Success'
     ;;
   *) exit 1 ;;
@@ -96,15 +102,27 @@ grep -q '^status=deferred$' "$MOD/config/app_install_state.conf"
 
 rm -f "$MOD/config/app_install_pending"
 set +e
-MOCK_VERSION=1431901 MOCK_PM_FAIL=1 MOCK_PM_CALLS="$CALLS" \
+MOCK_VERSION=1431901 MOCK_PM_FAIL=2 MOCK_PM_CALLS="$CALLS" \
 APP_INSTALL_PM_BIN="$BIN/pm" APP_INSTALL_DUMPSYS_BIN="$BIN/dumpsys" \
-MODDIR="$MOD" sh "$MOD/common/app_installer.sh" test-failure > "$TMP/failure.out"
-FAIL_CODE=$?
+MODDIR="$MOD" sh "$MOD/common/app_installer.sh" test-transient-failure > "$TMP/transient.out"
+TRANSIENT_CODE=$?
 set -e
-test "$FAIL_CODE" -eq 11
-grep -qx 'failed' "$TMP/failure.out"
+test "$TRANSIENT_CODE" -eq 11
+grep -qx 'failed' "$TMP/transient.out"
 test -f "$MOD/config/app_install_pending"
 grep -q '^status=failed$' "$MOD/config/app_install_state.conf"
+
+rm -f "$MOD/config/app_install_pending"
+set +e
+MOCK_VERSION=1431901 MOCK_PM_FAIL=1 MOCK_PM_CALLS="$CALLS" \
+APP_INSTALL_PM_BIN="$BIN/pm" APP_INSTALL_DUMPSYS_BIN="$BIN/dumpsys" \
+MODDIR="$MOD" sh "$MOD/common/app_installer.sh" test-permanent-failure > "$TMP/permanent.out"
+PERMANENT_CODE=$?
+set -e
+test "$PERMANENT_CODE" -eq 12
+grep -qx 'permanent-failure' "$TMP/permanent.out"
+test -f "$MOD/config/app_install_pending"
+grep -q '^status=blocked$' "$MOD/config/app_install_state.conf"
 grep -q 'INSTALL_FAILED_UPDATE_INCOMPATIBLE' "$MOD/logs/app-install.log"
 
 printf 'Bundled App installer tests passed.\n'

--- a/scripts/font_switch_performance_test.sh
+++ b/scripts/font_switch_performance_test.sh
@@ -11,9 +11,11 @@ payload_body="$(awk '/^luoshu_payload_validate_current\(\)/,/^}/' "$ROOT/common/
 dynamic_body="$(awk '/^luoshu_dynamic_targets_apply\(\)/,/^}/' "$ROOT/common/font_safety.sh")"
 ! printf '%s\n' "$dynamic_body" | grep -q 'wc -c'
 
-grep -q 'LUOSHU_SWITCH_TIMEOUT_SECONDS:-110' "$ROOT/common/font_switch_task.sh"
+grep -q 'LUOSHU_SWITCH_TIMEOUT_SECONDS:-360' "$ROOT/common/font_switch_task.sh"
 grep -q 'luoshu_start_detached' "$ROOT/common/font_switch_task.sh"
 grep -q 'mark_load_verification_pending' "$ROOT/common/font_switch_task.sh"
+grep -q 'heartbeat=%s' "$ROOT/common/font_switch_task.sh"
+grep -q 'timeout=%s' "$ROOT/common/font_switch_task.sh"
 grep -q 'luoshu_switch_perf_mark complete' "$ROOT/common/font_manager.sh"
 grep -q 'MiuixTaskCenterHeader(' \
     "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsScreenMiuix.kt"
@@ -26,8 +28,12 @@ grep -q 'horizontalArrangement = Arrangement.spacedBy(10.dp)' \
 # Compact task-center header actions intentionally share one 50 dp visual box.
 grep -q 'modifier = modifier.size(50.dp)' \
     "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/DiagnosticExportUi.kt"
-grep -q 'IconButton(onClick = actions.refresh, modifier = Modifier.size(50.dp))' \
-    "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsScreenCompact.kt"
+grep -q 'modifier = Modifier.size(50.dp)' \
+    "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/DiagnosticExportUi.kt"
+grep -q 'timeoutSeconds = 390' \
+    "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuViewModel.kt"
+grep -q 'advertisedTimeout' \
+    "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuViewModel.kt"
 grep -q 'DeviceTrustLevel.SYSTEM' \
     "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/DeviceTrustUi.kt"
 grep -q 'DeviceTrustLevel.COMPATIBILITY' \

--- a/scripts/font_switch_task_test.sh
+++ b/scripts/font_switch_task_test.sh
@@ -52,6 +52,9 @@ wait_state success
 grep -q '^message=字体已准备完成' "$LUOSHU_SWITCH_TASK_FILE"
 grep -q '^state=pending$' "$MODDIR/config/device-font-load-verification.conf"
 grep -q '^reason=awaiting-full-reboot$' "$MODDIR/config/device-font-load-verification.conf"
+grep -q '^heartbeat=[0-9][0-9]*$' "$LUOSHU_SWITCH_TASK_FILE"
+grep -q '^timeout=5$' "$LUOSHU_SWITCH_TASK_FILE"
+grep -q '^elapsed=[0-9][0-9]*$' "$LUOSHU_SWITCH_TASK_FILE"
 
 start_output="$(sh "$ROOT/common/font_switch_task.sh" start bad)"
 printf '%s\n' "$start_output" | grep -q '"status":"ok"'

--- a/service.sh
+++ b/service.sh
@@ -97,27 +97,42 @@ MODULE_DIR="$MODDIR"
         fi
     fi
 
-    # 刷写阶段无法调用 pm 时，只在首次完整开机后自动重试一次。
-    # 成功覆盖安装会保留 App 数据、字体索引和外观设置。
+    # 刷写阶段无法调用 pm，或系统包管理器在开机初期尚未稳定时，最多跨三次完整开机重试。
+    # 签名冲突、损坏 APK 等永久错误立即转为手动处理，避免每次开机重复失败。
     if [ -s "$MODDIR/bundled/LuoShu-App.apk" ] && [ -f "$MODDIR/common/app_installer.sh" ]; then
         if [ -f "$MODDIR/config/app_install_pending" ] || [ ! -f "$MODDIR/config/app_install_state.conf" ]; then
+            _app_retry_file="$MODDIR/config/app_install_retry_count"
+            _app_retry_limit="${LUOSHU_APP_INSTALL_RETRY_LIMIT:-3}"
+            case "$_app_retry_limit" in ''|*[!0-9]*) _app_retry_limit=3 ;; esac
+            [ "$_app_retry_limit" -ge 1 ] 2>/dev/null || _app_retry_limit=1
             _app_result=$(MODDIR="$MODDIR" APP_INSTALL_LOG="$MODDIR/logs/app-install.log" sh "$MODDIR/common/app_installer.sh" first-boot 2>/dev/null)
             _app_code=$?
             case "$_app_result" in
-                installed)
-                    rm -f "$MODDIR/config/app_install_manual" 2>/dev/null || true
-                    log_service "INFO" "已在首次开机自动安装或更新洛书 App"
-                    ;;
-                already-current)
-                    rm -f "$MODDIR/config/app_install_manual" 2>/dev/null || true
-                    log_service "INFO" "洛书 App 已是模块内置版本"
-                    ;;
-                *)
-                    # 首次开机只自动尝试一次，避免签名冲突时每次开机重复失败。
-                    rm -f "$MODDIR/config/app_install_pending" 2>/dev/null || true
-                    touch "$MODDIR/config/app_install_manual" 2>/dev/null || true
-                    log_service "INFO" "App 自动更新未完成（code=$_app_code），请使用模块操作按钮重试；详情见 app-install.log"
-                    ;;
+  installed|already-current)
+      rm -f "$MODDIR/config/app_install_manual" "$_app_retry_file" 2>/dev/null || true
+      log_service "INFO" "洛书 App 已安装并与模块内置版本一致"
+      ;;
+  permanent-failure|invalid-package|invalid-apk)
+      rm -f "$MODDIR/config/app_install_pending" "$_app_retry_file" 2>/dev/null || true
+      touch "$MODDIR/config/app_install_manual" 2>/dev/null || true
+      log_service "ERROR" "App 自动更新被永久错误阻断（result=$_app_result, code=$_app_code），请使用模块操作按钮处理；详情见 app-install.log"
+      ;;
+  *)
+      _app_retry_count=$(cat "$_app_retry_file" 2>/dev/null)
+      case "$_app_retry_count" in ''|*[!0-9]*) _app_retry_count=0 ;; esac
+      _app_retry_count=$((_app_retry_count + 1))
+      printf '%s
+' "$_app_retry_count" > "$_app_retry_file" 2>/dev/null || true
+      if [ "$_app_retry_count" -lt "$_app_retry_limit" ]; then
+          touch "$MODDIR/config/app_install_pending" 2>/dev/null || true
+          rm -f "$MODDIR/config/app_install_manual" 2>/dev/null || true
+          log_service "INFO" "App 自动更新暂未完成（第 $_app_retry_count/$_app_retry_limit 次，result=$_app_result, code=$_app_code），下次完整开机继续重试"
+      else
+          rm -f "$MODDIR/config/app_install_pending" 2>/dev/null || true
+          touch "$MODDIR/config/app_install_manual" 2>/dev/null || true
+          log_service "ERROR" "App 自动更新连续 $_app_retry_count 次未完成，已停止自动重试；请使用模块操作按钮重试"
+      fi
+      ;;
             esac
         fi
     fi


### PR DESCRIPTION
## 变更内容

- 将字体切换默认硬超时从 110 秒提升到 360 秒，最高允许 900 秒。
- 字体任务每 5 秒写入心跳、已用时间和实际超时，App 使用模块返回的截止时间，不再在后台仍正常处理时提前报失败。
- 超时时继续终止字体管理器及其子进程，并保留原有事务回滚。
- App 内置安装区分临时失败与签名/安装包永久错误；临时失败最多跨 3 次完整开机自动重试，永久错误转为手动处理。
- 任务中心右侧诊断按钮与刷新按钮统一为 50 dp IconButton 布局，修复视觉中心不一致。
- 脱敏诊断新增模块目录、待安装目录和 post-mount 脚本状态，便于排查 APatch 重启后模块消失问题。
- 更新字体任务和 App 安装器回归测试。

## 验证

- `sh -n common/font_switch_task.sh`
- `sh -n common/app_installer.sh`
- `sh -n service.sh`
- `sh scripts/font_switch_task_test.sh`
- `sh scripts/app_installer_test.sh`
- `sh scripts/font_switch_performance_test.sh`
- `sh scripts/check.sh`
- `gradle --no-daemon --stacktrace :app:testDebugUnitTest :app:lintDebug`

上述检查已在 Ubuntu 24.04、Java 17、Gradle 9.5.0 环境通过。

本 PR 暂不提升版本号，也不直接发布；合并后再准备 v2.3.6 Alpha1 候选包进行 APatch、KernelSU、Magisk 真机验证。