### PR TITLE
fix: stop boot-time font task resurrection

### DIFF
--- a/common/background_task.sh
+++ b/common/background_task.sh
@@ -1,6 +1,13 @@
 #!/system/bin/sh
 # Root 后台任务启动器：脱离 App 的 su 会话、终端与进程组。
 
+luoshu_current_boot_id() {
+    _lcbi_value=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n')
+    [ -n "$_lcbi_value" ] || _lcbi_value=$(getprop ro.runtime.firstboot 2>/dev/null | tr -d '\r\n')
+    [ -n "$_lcbi_value" ] || _lcbi_value=unknown
+    printf '%s\n' "$_lcbi_value"
+}
+
 luoshu_pid_value() {
     _lpv_file="$1"
     sed -n '1{s/[^0-9].*$//;p;}' "$_lpv_file" 2>/dev/null
@@ -11,6 +18,14 @@ luoshu_task_pid_alive() {
     _ltpa_task="${2:-}"
     _ltpa_pid=$(luoshu_pid_value "$_ltpa_pid_file")
     [ -n "$_ltpa_pid" ] || return 1
+
+    # PID 在完整重启后可能被复用。带 boot sidecar 的任务必须属于当前启动周期。
+    if [ -s "${_ltpa_pid_file}.boot" ]; then
+        _ltpa_expected_boot=$(cat "${_ltpa_pid_file}.boot" 2>/dev/null | tr -d '\r\n')
+        _ltpa_current_boot=$(luoshu_current_boot_id)
+        [ -n "$_ltpa_expected_boot" ] && [ "$_ltpa_expected_boot" = "$_ltpa_current_boot" ] || return 1
+    fi
+
     kill -0 "$_ltpa_pid" 2>/dev/null || return 1
     if [ -n "$_ltpa_task" ]; then
         # A numeric PID can be recycled by Android. The task sidecar and, when available,
@@ -31,7 +46,7 @@ luoshu_clear_task_pid() {
     if [ -n "$_lctp_task" ] && [ -s "${_lctp_pid_file}.task" ] && [ "$(cat "${_lctp_pid_file}.task" 2>/dev/null)" != "$_lctp_task" ]; then
         return 0
     fi
-    rm -f "$_lctp_pid_file" "${_lctp_pid_file}.task" 2>/dev/null || true
+    rm -f "$_lctp_pid_file" "${_lctp_pid_file}.task" "${_lctp_pid_file}.boot" 2>/dev/null || true
 }
 
 luoshu_stop_task_pid() {
@@ -70,6 +85,7 @@ luoshu_start_detached() {
     case "$_lsd_pid" in ''|*[!0-9]*) return 1 ;; esac
     printf '%s\n' "$_lsd_pid" >"$_lsd_pid_file" 2>/dev/null || return 1
     printf '%s\n' "$_lsd_task" >"${_lsd_pid_file}.task" 2>/dev/null || true
-    chmod 0644 "$_lsd_pid_file" "${_lsd_pid_file}.task" 2>/dev/null || true
+    luoshu_current_boot_id >"${_lsd_pid_file}.boot" 2>/dev/null || true
+    chmod 0644 "$_lsd_pid_file" "${_lsd_pid_file}.task" "${_lsd_pid_file}.boot" 2>/dev/null || true
     return 0
 }

--- a/common/device_font_slot_plan.sh
+++ b/common/device_font_slot_plan.sh
@@ -14,18 +14,48 @@ OUT="$MODDIR/config/active-font-slot-plan.json"
 KEY="$MODDIR/config/active-font-slot-plan.key"
 LOG="$MODDIR/logs/device-font-slot-plan.log"
 LOCK="$MODDIR/.device-font-slot-plan.lock"
+PLAN_TIMEOUT_SECONDS="${LUOSHU_SLOT_PLAN_TIMEOUT_SECONDS:-180}"
+PLAN_NICE_LEVEL="${LUOSHU_SLOT_PLAN_NICE_LEVEL:-10}"
+case "$PLAN_TIMEOUT_SECONDS" in ''|*[!0-9]*) PLAN_TIMEOUT_SECONDS=180 ;; esac
+[ "$PLAN_TIMEOUT_SECONDS" -ge 30 ] 2>/dev/null || PLAN_TIMEOUT_SECONDS=30
+[ "$PLAN_TIMEOUT_SECONDS" -le 600 ] 2>/dev/null || PLAN_TIMEOUT_SECONDS=600
+case "$PLAN_NICE_LEVEL" in ''|*[!0-9-]*) PLAN_NICE_LEVEL=10 ;; esac
+[ "$PLAN_NICE_LEVEL" -ge 0 ] 2>/dev/null || PLAN_NICE_LEVEL=0
+[ "$PLAN_NICE_LEVEL" -le 19 ] 2>/dev/null || PLAN_NICE_LEVEL=19
 
 log_plan() {
     mkdir -p "$MODDIR/logs" 2>/dev/null || true
     printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" "$*" >> "$LOG" 2>/dev/null || true
 }
 
+current_boot_id() {
+    _cbi=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n')
+    [ -n "$_cbi" ] || _cbi=$(getprop ro.runtime.firstboot 2>/dev/null | tr -d '\r\n')
+    [ -n "$_cbi" ] || _cbi=unknown
+    printf '%s\n' "$_cbi"
+}
+
 python_run() {
     [ -x "$PYTHON" ] && [ -f "$PLANNER" ] || return 1
-    PYTHONHOME="$PYROOT" \
-    PYTHONPATH="$MODDIR/common:$PYROOT/lib/python3.14:$PYROOT/lib/python3.14/site-packages" \
-    LD_LIBRARY_PATH="$PYROOT/lib:$PYROOT/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-        "$PYTHON" "$PLANNER" "$@"
+    if command -v timeout >/dev/null 2>&1; then
+        set -- timeout "$PLAN_TIMEOUT_SECONDS" "$PYTHON" "$PLANNER" "$@"
+    elif command -v toybox >/dev/null 2>&1 && toybox timeout --help >/dev/null 2>&1; then
+        set -- toybox timeout "$PLAN_TIMEOUT_SECONDS" "$PYTHON" "$PLANNER" "$@"
+    else
+        # Android normally provides toybox timeout. The fallback still lowers priority,
+        # but reports the missing hard guard in the log for diagnostics.
+        log_plan "系统缺少 timeout，槽位规划无法启用硬超时"
+        set -- "$PYTHON" "$PLANNER" "$@"
+    fi
+    if command -v nice >/dev/null 2>&1; then
+        set -- nice -n "$PLAN_NICE_LEVEL" "$@"
+    fi
+    (
+        export PYTHONHOME="$PYROOT"
+        export PYTHONPATH="$MODDIR/common:$PYROOT/lib/python3.14:$PYROOT/lib/python3.14/site-packages"
+        export LD_LIBRARY_PATH="$PYROOT/lib:$PYROOT/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        exec "$@"
+    )
 }
 
 file_digest() {
@@ -39,11 +69,44 @@ file_digest() {
     fi
 }
 
+source_identity() {
+    _si_path="$1"
+    _si_stat=$(stat -c '%d:%i:%s:%Y:%Z' "$_si_path" 2>/dev/null)
+    [ -n "$_si_stat" ] || _si_stat=$(stat -c '%s:%Y' "$_si_path" 2>/dev/null)
+    [ -n "$_si_stat" ] || _si_stat=$(ls -ln "$_si_path" 2>/dev/null)
+    printf '%s\n' "$_si_stat"
+}
+
 plan_key() {
     _pk_source="$1"
-    _pk_source_hash=$(file_digest "$_pk_source")
+    _pk_source_identity=$(source_identity "$_pk_source")
     _pk_template_hash=$(file_digest "$TEMPLATE")
-    printf '%s|%s\n' "$_pk_source_hash" "$_pk_template_hash"
+    printf 'slot-plan-v2|%s|%s|%s\n' "$_pk_source" "$_pk_source_identity" "$_pk_template_hash"
+}
+
+release_lock() {
+    rm -rf "$LOCK" 2>/dev/null || true
+}
+
+acquire_lock() {
+    _al_boot=$(current_boot_id)
+    if [ -d "$LOCK" ]; then
+        _al_old_boot=$(cat "$LOCK/boot_id" 2>/dev/null | tr -d '\r\n')
+        _al_old_pid=$(cat "$LOCK/pid" 2>/dev/null | tr -d '\r\n')
+        if [ -z "$_al_old_boot" ] || [ "$_al_old_boot" != "$_al_boot" ] || \
+           [ -z "$_al_old_pid" ] || ! kill -0 "$_al_old_pid" 2>/dev/null; then
+            log_plan "清理上一启动周期遗留的槽位规划锁"
+            rm -rf "$LOCK" 2>/dev/null || true
+        else
+            log_plan "已有槽位规划任务在运行"
+            return 1
+        fi
+    fi
+    mkdir "$LOCK" 2>/dev/null || return 1
+    printf '%s\n' "$_al_boot" > "$LOCK/boot_id" 2>/dev/null || true
+    printf '%s\n' "$$" > "$LOCK/pid" 2>/dev/null || true
+    chmod 0600 "$LOCK/boot_id" "$LOCK/pid" 2>/dev/null || true
+    return 0
 }
 
 build_plan() {
@@ -55,11 +118,6 @@ build_plan() {
         return 1
     }
     mkdir -p "$MODDIR/config" "$MODDIR/logs" 2>/dev/null || return 1
-    if ! mkdir "$LOCK" 2>/dev/null; then
-        log_plan "已有槽位规划任务在运行"
-        return 0
-    fi
-    trap 'rmdir "$LOCK" 2>/dev/null || true' EXIT HUP INT TERM
 
     if [ ! -s "$TEMPLATE" ] && [ -f "$TEMPLATE_HELPER" ]; then
         MODDIR="$MODDIR" sh "$TEMPLATE_HELPER" ensure >/dev/null 2>&1 || true
@@ -76,6 +134,18 @@ build_plan() {
         return 0
     fi
 
+    if ! acquire_lock; then
+        return 0
+    fi
+    trap release_lock EXIT HUP INT TERM
+
+    # 获取锁后再次检查，避免两个近同时启动的请求重复解析同一字体。
+    _bp_old=$(head -n1 "$KEY" 2>/dev/null | tr -d '\r\n')
+    if [ "$_bp_force" != 1 ] && [ -n "$_bp_key" ] && [ "$_bp_key" = "$_bp_old" ] && [ -s "$OUT" ]; then
+        log_plan "字体 $_bp_font_id 的槽位计划已由另一任务更新，跳过"
+        return 0
+    fi
+
     _bp_tmp="$OUT.tmp.$$"
     rm -f "$_bp_tmp" 2>/dev/null || true
     _bp_result=$(python_run \
@@ -85,7 +155,10 @@ build_plan() {
     _bp_rc=$?
     if [ "$_bp_rc" -ne 0 ] || [ ! -s "$_bp_tmp" ]; then
         rm -f "$_bp_tmp" 2>/dev/null || true
-        log_plan "字体 $_bp_font_id 的逐槽位计划失败：code=$_bp_rc result=$_bp_result"
+        case "$_bp_rc" in
+            124|137) log_plan "字体 $_bp_font_id 的逐槽位计划超过 ${PLAN_TIMEOUT_SECONDS} 秒，已终止" ;;
+            *) log_plan "字体 $_bp_font_id 的逐槽位计划失败：code=$_bp_rc result=$_bp_result" ;;
+        esac
         return 1
     fi
 
@@ -95,6 +168,7 @@ build_plan() {
         printf '%s\n' "$_bp_key"
         printf 'font=%s\n' "$_bp_font_id"
         printf 'source=%s\n' "$_bp_source"
+        printf 'bootId=%s\n' "$(current_boot_id)"
         printf 'time=%s\n' "$(date +%s)"
     } > "$KEY" 2>/dev/null || true
     chmod 0600 "$KEY" 2>/dev/null || true
@@ -104,7 +178,7 @@ build_plan() {
 
 clear_plan() {
     rm -f "$OUT" "$OUT.tmp" "$OUT".tmp.* "$KEY" 2>/dev/null || true
-    rmdir "$LOCK" 2>/dev/null || true
+    rm -rf "$LOCK" 2>/dev/null || true
     return 0
 }
 

--- a/common/font_library_cache.sh
+++ b/common/font_library_cache.sh
@@ -102,15 +102,12 @@ if [ "${0##*/}" = "font_library_cache.sh" ]; then
         MODDIR="$MODDIR" sh "$_pdfp_planner" build "$_pdfp_source" "$_pdfp_current" >/dev/null 2>&1 || true
     }
 
-    # v2.2 模板和当前字体的逐槽位计划在完整开机后的索引预热阶段异步生成。
-    # 当前阶段只写模块私有 JSON，不阻塞字体列表，也不改写 Android 字体负载。
-    if [ "${1:-fingerprint}" = value ]; then
-        (_prepare_device_font_plan) &
-    fi
-
+    # 指纹查询必须保持纯读取。旧逻辑在 value 后隐式派生 Python 槽位规划任务，
+    # 导致每次完整开机都可能重新出现高 CPU 后台进程。
     case "${1:-fingerprint}" in
         fingerprint) font_library_fingerprint_json ;;
         value) font_library_fingerprint_value ;;
+        prepare-plan) _prepare_device_font_plan ;;
         *) printf '{"status":"error","message":"未知字体索引命令"}\n' ;;
     esac
 fi

--- a/common/font_switch_task.sh
+++ b/common/font_switch_task.sh
@@ -22,8 +22,6 @@ WORKER_PID_FILE="${LUOSHU_SWITCH_WORKER_PID_FILE:-$MODDIR/config/switch_task_wor
 LOAD_VERIFY_STATE="$MODDIR/config/device-font-load-verification.conf"
 [ -f "$BACKGROUND_TASK" ] && . "$BACKGROUND_TASK"
 
-# 大型 CJK、TTC、可变字体和复合槽位在低速存储或多 OEM 分区设备上可能超过两分钟。
-# 后台任务与 App 都读取同一超时字段；默认给完整验证、事务快照、槽位映射和挂载同步 360 秒。
 TIMEOUT_SECONDS="${LUOSHU_SWITCH_TIMEOUT_SECONDS:-360}"
 case "$TIMEOUT_SECONDS" in ''|*[!0-9]*) TIMEOUT_SECONDS=360 ;; esac
 [ "$TIMEOUT_SECONDS" -ge 5 ] 2>/dev/null || TIMEOUT_SECONDS=5
@@ -35,6 +33,17 @@ case "$HEARTBEAT_INTERVAL" in ''|*[!0-9]*) HEARTBEAT_INTERVAL=5 ;; esac
 
 json_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '
+}
+
+current_boot_id() {
+    if type luoshu_current_boot_id >/dev/null 2>&1; then
+        luoshu_current_boot_id
+        return
+    fi
+    _cbi=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n')
+    [ -n "$_cbi" ] || _cbi=$(getprop ro.runtime.firstboot 2>/dev/null | tr -d '\r\n')
+    [ -n "$_cbi" ] || _cbi=unknown
+    printf '%s\n' "$_cbi"
 }
 
 read_value() {
@@ -53,6 +62,7 @@ write_task() {
     _heartbeat="${8:-$(date +%s 2>/dev/null || echo 0)}"
     _timeout="${9:-$TIMEOUT_SECONDS}"
     _elapsed="${10:-0}"
+    _boot_id="${11:-$(current_boot_id)}"
     mkdir -p "${TASK_FILE%/*}" 2>/dev/null || return 1
     _tmp="${TASK_FILE}.tmp.$$"
     {
@@ -66,6 +76,7 @@ write_task() {
         printf 'heartbeat=%s\n' "$_heartbeat"
         printf 'timeout=%s\n' "$_timeout"
         printf 'elapsed=%s\n' "$_elapsed"
+        printf 'bootId=%s\n' "$_boot_id"
     } > "$_tmp" 2>/dev/null || return 1
     mv -f "$_tmp" "$TASK_FILE" 2>/dev/null || return 1
     chmod 0644 "$TASK_FILE" 2>/dev/null || true
@@ -96,11 +107,19 @@ reconcile_task() {
     [ -s "$TASK_FILE" ] || return 0
     _state="$(read_value state)"
     case "$_state" in queued|running) ;; *) return 0 ;; esac
-    _pid="$(read_value pid)"
-    task_pid_alive "$_pid" && return 0
     _task="$(read_value task)"
     _font="$(read_value font)"
     _started="$(read_value started)"
+    _task_boot="$(read_value bootId)"
+    _now_boot="$(current_boot_id)"
+    if [ -n "$_task_boot" ] && [ -n "$_now_boot" ] && [ "$_task_boot" != "$_now_boot" ]; then
+        write_task "$_task" failed "$_font" '设备已重启，上一字体切换任务已结束' \
+            "$_started" "$(date +%s 2>/dev/null || echo 0)" '' '' '' 0 "$_now_boot"
+        type luoshu_clear_task_pid >/dev/null 2>&1 && luoshu_clear_task_pid "$WORKER_PID_FILE" "$_task"
+        return 0
+    fi
+    _pid="$(read_value pid)"
+    task_pid_alive "$_pid" && return 0
     write_task "$_task" failed "$_font" '字体切换进程异常结束，已保留上一套字体' "$_started" "$(date +%s 2>/dev/null || echo 0)" ''
     type luoshu_clear_task_pid >/dev/null 2>&1 && luoshu_clear_task_pid "$WORKER_PID_FILE" "$_task"
 }
@@ -241,12 +260,13 @@ status_task() {
     _heartbeat="$(read_value heartbeat)"
     _timeout="$(read_value timeout)"
     _elapsed="$(read_value elapsed)"
+    _boot_id="$(read_value bootId)"
     if [ "$_state" = success ] && [ -f "$STATUS_SCRIPT" ]; then
         MODDIR="$MODDIR" sh "$STATUS_SCRIPT" "$_font" >/dev/null 2>&1 || true
     fi
-    printf '{"status":"ok","data":{"task":"%s","state":"%s","font":"%s","message":"%s","started":%s,"finished":%s,"heartbeat":%s,"timeout":%s,"elapsed":%s}}\n' \
+    printf '{"status":"ok","data":{"task":"%s","state":"%s","font":"%s","message":"%s","started":%s,"finished":%s,"heartbeat":%s,"timeout":%s,"elapsed":%s,"bootId":"%s"}}\n' \
         "$(json_escape "$_task")" "$(json_escape "$_state")" "$(json_escape "$_font")" "$(json_escape "$_message")" \
-        "${_started:-0}" "${_finished:-0}" "${_heartbeat:-0}" "${_timeout:-$TIMEOUT_SECONDS}" "${_elapsed:-0}"
+        "${_started:-0}" "${_finished:-0}" "${_heartbeat:-0}" "${_timeout:-$TIMEOUT_SECONDS}" "${_elapsed:-0}" "$(json_escape "$_boot_id")"
 }
 
 case "${1:-status}" in

--- a/scripts/background_task_test.sh
+++ b/scripts/background_task_test.sh
@@ -28,11 +28,22 @@ luoshu_start_detached "$PID_FILE" "$TASK" "$LOG_FILE" sh "$WORKER" worker "$TASK
 
 test -s "$PID_FILE"
 test -s "${PID_FILE}.task"
+test -s "${PID_FILE}.boot"
 test "$(cat "${PID_FILE}.task")" = "$TASK"
+test "$(cat "${PID_FILE}.boot")" = "$(luoshu_current_boot_id)"
+luoshu_task_pid_alive "$PID_FILE" "$TASK"
+
+printf 'different-boot\n' > "${PID_FILE}.boot"
+if luoshu_task_pid_alive "$PID_FILE" "$TASK"; then
+    echo 'boot-id mismatch must invalidate detached task' >&2
+    exit 1
+fi
+luoshu_current_boot_id > "${PID_FILE}.boot"
 luoshu_task_pid_alive "$PID_FILE" "$TASK"
 
 luoshu_stop_task_pid "$PID_FILE"
 test ! -e "$PID_FILE"
 test ! -e "${PID_FILE}.task"
+test ! -e "${PID_FILE}.boot"
 
 echo 'background_task_test: PASS'

--- a/scripts/device_font_slot_plan_runtime_test.sh
+++ b/scripts/device_font_slot_plan_runtime_test.sh
@@ -25,24 +25,23 @@ chmod 0755 "$MODULE/common"/*.sh
 
 printf 'Alpha\n' > "$MODULE/config/active_font.conf"
 printf 'fixture-font\n' > "$PUBLIC/fonts/Alpha-Regular.ttf"
-MODDIR="$MODULE" LUOSHU_PUBLIC_DIR="$PUBLIC" sh "$MODULE/common/font_library_cache.sh" value >/dev/null
 
-_count=0
-while [ "$_count" -lt 50 ] && ! grep -q '^plan:build|' "$CALLS" 2>/dev/null; do
-    sleep 0.02
-    _count=$((_count + 1))
-done
+# 指纹查询必须是纯读取，不能在开机服务中隐式启动规划进程。
+MODDIR="$MODULE" LUOSHU_PUBLIC_DIR="$PUBLIC" sh "$MODULE/common/font_library_cache.sh" value >/dev/null
+sleep 0.1
+test ! -e "$CALLS"
+
+MODDIR="$MODULE" LUOSHU_PUBLIC_DIR="$PUBLIC" sh "$MODULE/common/font_library_cache.sh" prepare-plan >/dev/null
 grep -q '^template:ensure$' "$CALLS"
 grep -Fq "plan:build|$PUBLIC/fonts/Alpha-Regular.ttf|Alpha" "$CALLS"
 
 : > "$CALLS"
 printf 'default\n' > "$MODULE/config/active_font.conf"
 MODDIR="$MODULE" LUOSHU_PUBLIC_DIR="$PUBLIC" sh "$MODULE/common/font_library_cache.sh" value >/dev/null
-_count=0
-while [ "$_count" -lt 50 ] && ! grep -q '^plan:clear|' "$CALLS" 2>/dev/null; do
-    sleep 0.02
-    _count=$((_count + 1))
-done
+sleep 0.1
+test ! -s "$CALLS"
+
+MODDIR="$MODULE" LUOSHU_PUBLIC_DIR="$PUBLIC" sh "$MODULE/common/font_library_cache.sh" prepare-plan >/dev/null
 grep -q '^template:ensure$' "$CALLS"
 grep -q '^plan:clear||$' "$CALLS"
 

--- a/scripts/device_font_slot_plan_test.sh
+++ b/scripts/device_font_slot_plan_test.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+MOD="$TMP/module"
+PY="$MOD/common/python/bin/luoshu-python"
+PLANNER="$MOD/common/device_font_slot_plan.py"
+SOURCE="$TMP/font.ttf"
+COUNT="$TMP/run-count"
+mkdir -p "$MOD/common/python/bin" "$MOD/config" "$MOD/logs"
+cp "$ROOT/common/device_font_slot_plan.sh" "$MOD/common/device_font_slot_plan.sh"
+printf '{"slots":[]}\n' > "$MOD/config/device-font-template.json"
+printf '# fake planner\n' > "$PLANNER"
+printf 'font-v1\n' > "$SOURCE"
+
+cat > "$PY" <<EOF_PY
+#!/bin/sh
+shift
+output=''
+while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+        --output) output="\$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+count=\$(cat "$COUNT" 2>/dev/null || echo 0)
+count=\$((count + 1))
+printf '%s\n' "\$count" > "$COUNT"
+if [ -f "$TMP/slow" ]; then
+    sleep 5
+fi
+printf '{"ok":true}\n' > "\$output"
+printf 'planned\n'
+EOF_PY
+chmod +x "$PY" "$MOD/common/device_font_slot_plan.sh"
+
+MODDIR="$MOD" LUOSHU_SLOT_PLAN_TIMEOUT_SECONDS=30 sh "$MOD/common/device_font_slot_plan.sh" build "$SOURCE" Demo
+test "$(cat "$COUNT")" = 1
+test -s "$MOD/config/active-font-slot-plan.json"
+grep -q '^slot-plan-v2|' "$MOD/config/active-font-slot-plan.key"
+
+MODDIR="$MOD" sh "$MOD/common/device_font_slot_plan.sh" build "$SOURCE" Demo
+test "$(cat "$COUNT")" = 1
+
+sleep 1
+printf 'font-v2\n' > "$SOURCE"
+MODDIR="$MOD" sh "$MOD/common/device_font_slot_plan.sh" build "$SOURCE" Demo
+test "$(cat "$COUNT")" = 2
+
+mkdir -p "$MOD/.device-font-slot-plan.lock"
+printf 'different-boot\n' > "$MOD/.device-font-slot-plan.lock/boot_id"
+printf '1\n' > "$MOD/.device-font-slot-plan.lock/pid"
+rm -f "$MOD/config/active-font-slot-plan.json"
+MODDIR="$MOD" sh "$MOD/common/device_font_slot_plan.sh" build "$SOURCE" Demo
+test "$(cat "$COUNT")" = 3
+test ! -d "$MOD/.device-font-slot-plan.lock"
+
+echo 'device_font_slot_plan_test: PASS'

--- a/scripts/font_library_cache_test.sh
+++ b/scripts/font_library_cache_test.sh
@@ -45,9 +45,35 @@ REMOVED=$(font_library_fingerprint_value)
 test "$REMOVED" != "$ADDED"
 printf '%s' "$REMOVED" | grep -q ':2:'
 
-# ROM 内部映射字体不属于用户字体库索引。
 printf 'internal' > "$USER_FONTS_DIR/SysFont-Regular.ttf"
 INTERNAL=$(font_library_fingerprint_value)
 test "$INTERNAL" = "$REMOVED"
+
+DIRECT_MOD="$TMP/direct-module"
+DIRECT_PUBLIC="$TMP/direct-public"
+PLAN_MARKER="$TMP/plan-called"
+mkdir -p "$DIRECT_MOD/common" "$DIRECT_MOD/config" "$DIRECT_PUBLIC/fonts"
+cp "$ROOT/common/font_library_cache.sh" "$DIRECT_MOD/common/font_library_cache.sh"
+printf 'One\n' > "$DIRECT_MOD/config/active_font.conf"
+printf 'font-one' > "$DIRECT_PUBLIC/fonts/One-Regular.ttf"
+cat > "$DIRECT_MOD/common/device_font_template.sh" <<'EOF_TEMPLATE'
+#!/bin/sh
+exit 0
+EOF_TEMPLATE
+cat > "$DIRECT_MOD/common/device_font_slot_plan.sh" <<EOF_PLANNER
+#!/bin/sh
+printf 'called\n' > "$PLAN_MARKER"
+exit 0
+EOF_PLANNER
+chmod +x "$DIRECT_MOD/common/device_font_template.sh" "$DIRECT_MOD/common/device_font_slot_plan.sh"
+
+MODDIR="$DIRECT_MOD" LUOSHU_PUBLIC_DIR="$DIRECT_PUBLIC" sh "$DIRECT_MOD/common/font_library_cache.sh" value >/dev/null
+sleep 0.2
+test ! -e "$PLAN_MARKER"
+MODDIR="$DIRECT_MOD" LUOSHU_PUBLIC_DIR="$DIRECT_PUBLIC" sh "$DIRECT_MOD/common/font_library_cache.sh" fingerprint >/dev/null
+sleep 0.2
+test ! -e "$PLAN_MARKER"
+MODDIR="$DIRECT_MOD" LUOSHU_PUBLIC_DIR="$DIRECT_PUBLIC" sh "$DIRECT_MOD/common/font_library_cache.sh" prepare-plan >/dev/null
+test -e "$PLAN_MARKER"
 
 printf 'Font library fingerprint tests passed.\n'

--- a/scripts/font_switch_task_test.sh
+++ b/scripts/font_switch_task_test.sh
@@ -55,6 +55,7 @@ grep -q '^reason=awaiting-full-reboot$' "$MODDIR/config/device-font-load-verific
 grep -q '^heartbeat=[0-9][0-9]*$' "$LUOSHU_SWITCH_TASK_FILE"
 grep -q '^timeout=5$' "$LUOSHU_SWITCH_TASK_FILE"
 grep -q '^elapsed=[0-9][0-9]*$' "$LUOSHU_SWITCH_TASK_FILE"
+grep -q '^bootId=.' "$LUOSHU_SWITCH_TASK_FILE"
 
 start_output="$(sh "$ROOT/common/font_switch_task.sh" start bad)"
 printf '%s\n' "$start_output" | grep -q '"status":"ok"'
@@ -66,8 +67,26 @@ printf '%s\n' "$start_output" | grep -q '"status":"ok"'
 wait_state failed
 grep -q '超过 5 秒' "$LUOSHU_SWITCH_TASK_FILE"
 
+cat > "$LUOSHU_SWITCH_TASK_FILE" <<'EOF_STALE'
+task=old-boot-task
+state=running
+font=stale-font
+message=running
+started=1
+finished=
+pid=1
+heartbeat=1
+timeout=360
+elapsed=1
+bootId=different-boot-id
+EOF_STALE
+sh "$ROOT/common/font_switch_task.sh" reconcile
+grep -q '^state=failed$' "$LUOSHU_SWITCH_TASK_FILE"
+grep -q '^message=设备已重启，上一字体切换任务已结束$' "$LUOSHU_SWITCH_TASK_FILE"
+
 status_output="$(sh "$ROOT/common/font_switch_task.sh" status)"
 printf '%s\n' "$status_output" | grep -q '"state":"failed"'
+printf '%s\n' "$status_output" | grep -q '"bootId":"'
 grep -q 'luoshu_start_detached' "$ROOT/common/font_switch_task.sh"
 
 echo 'font_switch_task_test: PASS'


### PR DESCRIPTION
## What changed

- make font-library fingerprint queries pure reads so `value` and `fingerprint` never spawn hidden slot-planning/Python workers
- add an explicit `prepare-plan` command for controlled maintenance paths
- guard detached tasks and font-switch state with the current Android boot ID to prevent PID reuse after reboot
- make device slot planning use a lightweight source identity cache key instead of hashing the entire CJK/TTC font on every check
- add a 180-second configurable hard timeout, low CPU priority, double-checked locking, and stale-lock recovery for slot planning
- add regression coverage for boot-ID mismatch, query side effects, cache hits, source changes, and stale lock recovery

## Root cause

The late-start service calls `font_library_cache.sh value` during every complete boot. That command also launched `_prepare_device_font_plan` in the background. As a result, a new `luoshu-python` slot-planning process could appear after reboot even though the original font-switch process had already ended. Large CJK/TTC fonts made that new worker look like a resurrected high-CPU process. Persistent PID/lock files also had no boot-cycle identity, so a recycled Android PID could be mistaken for an existing task.

## Validation

Locally executed:

- `scripts/background_task_test.sh`
- `scripts/font_library_cache_test.sh`
- `scripts/font_switch_task_test.sh`
- `scripts/device_font_slot_plan_test.sh`
- `sh -n` for all changed shell scripts
