### PR TITLE
fix: remove automatic deep font load verification

### DIFF
--- a/.luoshu-runtime/post-fs-data-v227.sh
+++ b/.luoshu-runtime/post-fs-data-v227.sh
@@ -36,6 +36,8 @@ rm -f "$MODDIR/config/active_emoji.conf" "$MODDIR/config/emoji_task.conf" "$MODD
 
 # 升级时清理实验版本遗留任务，避免原生 App 接管错误状态。
 rm -f "$MODDIR/config"/v*_axes_task.conf "$MODDIR/config"/v*_axes_mix.conf "$MODDIR/config"/v*_axes_worker.pid 2>/dev/null || true
+rm -f "$MODDIR/config/device-font-boot-verify.pid" "$MODDIR/config/device-font-boot-verify.pid.task" \
+      "$MODDIR/config/device-font-boot-verify.pid.boot" 2>/dev/null || true
 chmod 0755 "$MODDIR/common/python/bin/luoshu-python" 2>/dev/null || true
 
 # 通过统一桥恢复中断的原子负载，并清理独立字重暂存任务。
@@ -92,11 +94,8 @@ done
 rm -f "$MODDIR/config/text_reboot_required.conf" "$MODDIR/config/font_weight_reboot_required.conf" \
       "$MODDIR/.font_switch.lock" 2>/dev/null || true
 
-# 加载验证必须发生在 Android 完成启动后；这里只提交独立任务，不阻塞 post-fs-data。
-if [ -f "$MODDIR/common/device_font_boot_verify.sh" ]; then
-    MODDIR="$MODDIR" sh "$MODDIR/common/device_font_boot_verify.sh" schedule >/dev/null 2>&1 || true
-fi
-
+# 不再提交开机深度字体加载验证。切换事务和启动守卫已经完成必要安全校验；
+# Android 启动完成后只由 service.sh 写入轻量应用状态。
 log_message "INFO" "当前文字=$ACTIVE_TEXT | 重启保护已复位"
 log_message "INFO" "===== post-fs-data 完成 ====="
 exit 0

--- a/common/device_font_load_verify.sh
+++ b/common/device_font_load_verify.sh
@@ -1,7 +1,6 @@
 #!/system/bin/sh
-# Verify the active aligned payload after Android has completed boot.
-# Only state=verified may be described as device-aligned. Visible files use bounded
-# first/last-block fingerprints so verification never rereads every full CJK font.
+# Record the active font after Android boot without rescanning the complete payload.
+# The expensive FontManager/hash verifier is retained only behind the explicit `verify` command.
 set +e
 
 _dfload_module() {
@@ -61,6 +60,39 @@ _dfload_write_simple() {
     mv -f "${_dfload_conf}.tmp.$$" "$_dfload_conf" 2>/dev/null || return 1
     chmod 0600 "$_dfload_conf" 2>/dev/null || true
     return 0
+}
+
+# Normal boot path: switching already completed transaction, payload and mount checks.
+# Do not traverse or hash the font tree again. A confirmed boot transaction or mounted
+# self-mount is sufficient for the App's applied state; explicit deep verification remains
+# available for diagnostics.
+device_font_load_status() {
+    _dfload_module_dir="$(_dfload_module)"
+    _dfload_config="$_dfload_module_dir/config"
+    _dfload_active=$(head -n1 "$_dfload_config/active_font.conf" 2>/dev/null | tr -d '\r\n')
+    [ -n "$_dfload_active" ] || _dfload_active=default
+    if [ "$_dfload_active" = default ]; then
+        _dfload_write_simple not-applicable default-font "$_dfload_active" system
+        return 0
+    fi
+
+    _dfload_mount_state=$(sed -n 's/^state=//p' "$_dfload_config/self-mount.conf" 2>/dev/null | head -n1)
+    _dfload_boot_state=$(sed -n 's/^state=//p' "$_dfload_config/font-payload-boot.conf" 2>/dev/null | head -n1)
+    if [ "$_dfload_mount_state" = failed ]; then
+        _dfload_write_simple failed self-mount-failed "$_dfload_active" compatibility
+        _dfload_log "字体自挂载状态失败：$_dfload_active"
+        return 1
+    fi
+    case "$_dfload_mount_state:$_dfload_boot_state" in
+        mounted:*|*:confirmed)
+            _dfload_write_simple verified boot-transaction-confirmed "$_dfload_active" mount-verified
+            _dfload_log "字体已按正常切换流程生效：$_dfload_active"
+            return 0
+            ;;
+    esac
+
+    _dfload_write_simple pending awaiting-boot-transaction "$_dfload_active" compatibility
+    return 2
 }
 
 _dfload_python() {
@@ -187,11 +219,6 @@ device_font_load_verify() {
     fi
     _dfload_engine_state="$_dfload_config/device-font-engine.conf"
     if ! grep -q '^state=installed$' "$_dfload_engine_state" 2>/dev/null; then
-        # Compatibility payloads do not have aligned manifests, but the strict mount
-        # guard above already compared every required font/config file with the view
-        # visible from PID 1. That is the same runtime evidence used by the aligned
-        # verifier's mount-only fallback, so expose it as mount-verified instead of
-        # leaving a visibly active font permanently stuck at "pending".
         _dfload_write_simple verified verified-by-visible-mounts "$_dfload_active" mount-verified
         _dfload_log "兼容字体负载已通过系统主命名空间挂载验证：$_dfload_active"
         return 0
@@ -235,5 +262,9 @@ device_font_load_verify() {
 }
 
 if [ "${0##*/}" = device_font_load_verify.sh ]; then
-    device_font_load_verify
+    case "${1:-status}" in
+        status|auto) device_font_load_status ;;
+        verify|deep) device_font_load_verify ;;
+        *) printf 'usage: %s {status|verify}\n' "$0" >&2; exit 2 ;;
+    esac
 fi

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -1,7 +1,6 @@
 #!/system/bin/sh
 # LuoShu early-boot wrapper around the verified v2.2.7 initializer.
 # Delegated core consumes font-payload-rebuild-pending.conf before the payload is hidden.
-# Delegated boot verifier invocation: device_font_boot_verify.sh" schedule
 # Delegated recovery contract: font_mix_controller.sh recover
 # Delegated dynamic view contract: device_font_dynamic_mount_apply
 set +e

--- a/scripts/device_font_trust_test.sh
+++ b/scripts/device_font_trust_test.sh
@@ -30,9 +30,20 @@ assert "verified-by-visible-mounts" in payload["reasons"], payload
 assert "dynamic-family-unconfirmed" in payload["reasons"], payload
 PY
 
-# A compatibility payload has no aligned engine manifest. Once the strict mount
-# guard proves every required file is visible from PID 1, it is nevertheless a
-# verified active font and must not remain permanently stuck at "pending".
+# Normal boot status must not invoke mount traversal or Python. A confirmed transaction
+# is enough to expose the active font after the reboot requested by the switch task.
+AUTO_MOD="$TMP/auto-module"
+mkdir -p "$AUTO_MOD/common" "$AUTO_MOD/config" "$AUTO_MOD/logs"
+cp "$ROOT/common/device_font_load_verify.sh" "$AUTO_MOD/common/"
+printf 'Composite Font\n' > "$AUTO_MOD/config/active_font.conf"
+printf 'state=confirmed\nfont=Composite Font\n' > "$AUTO_MOD/config/font-payload-boot.conf"
+MODDIR="$AUTO_MOD" MODULE_DIR="$AUTO_MOD" \
+    sh "$AUTO_MOD/common/device_font_load_verify.sh"
+grep -q '^state=verified$' "$AUTO_MOD/config/device-font-load-verification.conf"
+grep -q '^mode=mount-verified$' "$AUTO_MOD/config/device-font-load-verification.conf"
+grep -q '^reason=boot-transaction-confirmed$' "$AUTO_MOD/config/device-font-load-verification.conf"
+
+# The expensive verifier remains available only as an explicit diagnostic command.
 COMPAT_MOD="$TMP/compat-module"
 mkdir -p "$COMPAT_MOD/common" "$COMPAT_MOD/config" "$COMPAT_MOD/logs"
 cp "$ROOT/common/device_font_load_verify.sh" "$COMPAT_MOD/common/"
@@ -41,19 +52,18 @@ luoshu_mount_verify_active() { return 0; }
 EOF_MOUNT_OK
 printf 'Composite Font\n' > "$COMPAT_MOD/config/active_font.conf"
 MODDIR="$COMPAT_MOD" MODULE_DIR="$COMPAT_MOD" \
-    sh "$COMPAT_MOD/common/device_font_load_verify.sh"
+    sh "$COMPAT_MOD/common/device_font_load_verify.sh" verify
 grep -q '^state=verified$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 grep -q '^mode=mount-verified$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 grep -q '^reason=verified-by-visible-mounts$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 
-# A missing/partial PID 1 mount remains a hard failure and must never inherit
-# the compatibility success state.
+# A missing/partial PID 1 mount remains a hard failure in explicit diagnostics.
 cat > "$COMPAT_MOD/common/mount_compat.sh" <<'EOF_MOUNT_FAIL'
 luoshu_mount_verify_active() { return 1; }
 EOF_MOUNT_FAIL
 set +e
 MODDIR="$COMPAT_MOD" MODULE_DIR="$COMPAT_MOD" \
-    sh "$COMPAT_MOD/common/device_font_load_verify.sh"
+    sh "$COMPAT_MOD/common/device_font_load_verify.sh" verify
 VERIFY_RC=$?
 set -e
 test "$VERIFY_RC" -eq 1
@@ -61,14 +71,14 @@ grep -q '^state=failed$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 grep -q '^mode=compatibility$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 grep -q '^reason=self-mount-not-visible$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 
-# The post-fs scheduler must run the verifier only after boot and must not block startup.
+# The post-fs scheduler now receives the lightweight default path after boot.
 MOD="$TMP/module"
 mkdir -p "$MOD/common" "$MOD/config" "$MOD/logs" "$TMP/bin"
 cp "$ROOT/common/device_font_boot_verify.sh" "$MOD/common/"
 cp "$ROOT/common/background_task.sh" "$MOD/common/"
 cat > "$MOD/common/device_font_load_verify.sh" <<'EOF_VERIFY'
 #!/bin/sh
-printf 'state=verified\nmode=aligned\nactiveFont=test\n' > "$MODDIR/config/device-font-load-verification.conf"
+printf 'state=verified\nmode=mount-verified\nactiveFont=test\n' > "$MODDIR/config/device-font-load-verification.conf"
 exit 0
 EOF_VERIFY
 chmod +x "$MOD/common/"*.sh

--- a/scripts/device_font_trust_test.sh
+++ b/scripts/device_font_trust_test.sh
@@ -71,7 +71,7 @@ grep -q '^state=failed$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 grep -q '^mode=compatibility$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 grep -q '^reason=self-mount-not-visible$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 
-# The post-fs scheduler now receives the lightweight default path after boot.
+# The legacy worker remains callable for manual diagnostics, but boot scripts must not schedule it.
 MOD="$TMP/module"
 mkdir -p "$MOD/common" "$MOD/config" "$MOD/logs" "$TMP/bin"
 cp "$ROOT/common/device_font_boot_verify.sh" "$MOD/common/"
@@ -93,6 +93,6 @@ PATH="$TMP/bin:$PATH" MODDIR="$MOD" \
     LUOSHU_BOOT_VERIFY_POLL_SECONDS=1 \
     sh "$MOD/common/device_font_boot_verify.sh" run trust-test
 grep -q '^state=verified$' "$MOD/config/device-font-load-verification.conf"
-grep -q 'device_font_boot_verify.sh" schedule' "$ROOT/post-fs-data.sh"
+! grep -q 'device_font_boot_verify.sh.*schedule' "$ROOT/post-fs-data.sh" "$ROOT/.luoshu-runtime/post-fs-data-v227.sh"
 
 echo 'device_font_trust_test: PASS'


### PR DESCRIPTION
## What changed

- stop scheduling the post-fs-data boot verification worker
- make no-argument `device_font_load_verify.sh` calls perform only a lightweight status update
- treat a confirmed font transaction or mounted self-mount as the normal applied state
- keep the old FontManager dump, visible-font hashing and Python verifier only behind the explicit `verify` command
- clean stale boot-verifier PID sidecars during early boot
- update trust regression tests to require that boot scripts do not auto-schedule deep verification

## Root cause

The normal switch path already validates the payload transaction and self-mount. After reboot, LuoShu ran the same safety work again: one detached verifier from post-fs-data and another invocation from late-start service. The deep verifier traversed the mounted font tree, fingerprinted visible fonts and launched Python, causing sustained CPU usage under `sh .../device_font_load_verify.sh` even though the font had already switched successfully.

## New behavior

- normal boot: read active font, transaction state and self-mount state only
- manual diagnostics: `sh /data/adb/modules/LuoShu/common/device_font_load_verify.sh verify`

## Validation

CI should cover shell syntax, trust states, no-Hook boot paths, App build and module candidate packaging.