### PR TITLE
hotfix: rollback v2.3.7 font activation regression

### DIFF
--- a/common/device_font_dynamic_guard.sh
+++ b/common/device_font_dynamic_guard.sh
@@ -3,35 +3,6 @@
 # Loaded after device_font_payload_runtime.sh and overrides only the dynamic view stage.
 set +e
 
-_dfpr_dynamic_boot_id() {
-    if [ -n "${LUOSHU_BOOT_ID:-}" ]; then
-        printf '%s\n' "$LUOSHU_BOOT_ID"
-        return 0
-    fi
-    _dfpr_boot=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n')
-    if [ -z "$_dfpr_boot" ] && command -v getprop >/dev/null 2>&1; then
-        _dfpr_boot=$(getprop ro.runtime.firstboot 2>/dev/null | tr -d '\r\n')
-    fi
-    [ -n "$_dfpr_boot" ] || _dfpr_boot=unknown
-    printf '%s\n' "$_dfpr_boot"
-}
-
-_dfpr_dynamic_runtime_write() {
-    _dfpr_runtime_state="$1"
-    _dfpr_runtime_reason="$2"
-    _dfpr_runtime_module="$(_dfpr_module)"
-    _dfpr_runtime_file="$_dfpr_runtime_module/config/device-font-dynamic-runtime.conf"
-    mkdir -p "${_dfpr_runtime_file%/*}" 2>/dev/null || return 1
-    {
-        printf 'state=%s\n' "$_dfpr_runtime_state"
-        printf 'reason=%s\n' "$_dfpr_runtime_reason"
-        printf 'bootId=%s\n' "$(_dfpr_dynamic_boot_id)"
-        printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
-    } > "${_dfpr_runtime_file}.tmp.$$" 2>/dev/null || return 1
-    mv -f "${_dfpr_runtime_file}.tmp.$$" "$_dfpr_runtime_file" 2>/dev/null || return 1
-    chmod 0600 "$_dfpr_runtime_file" 2>/dev/null || true
-}
-
 _dfpr_mark_dynamic_rebuild() {
     _dfpr_reason="${1:-dynamic-config-changed}"
     _dfpr_module_dir="$(_dfpr_module)"
@@ -87,10 +58,8 @@ _dfpr_template_ensure_after_release() {
             *) _dfpr_log WARN "原厂字体模板校验失败：code=$_dfpr_template_rc" ;;
         esac
     fi
-    # device_font_load_verify remains manual-only; boot release refreshes only the
-    # constant-time status and never launches FontManager dumps, hashing or Python.
-    if type device_font_load_status >/dev/null 2>&1; then
-        device_font_load_status >/dev/null 2>&1 || true
+    if type device_font_load_verify >/dev/null 2>&1; then
+        device_font_load_verify >/dev/null 2>&1 || true
     fi
     [ "$_dfpr_template_rc" -eq 0 ] && _dfpr_launch_pending_cache
     return 0
@@ -105,8 +74,7 @@ _dfpr_prepare_dynamic_state() {
     _dfpr_dynamic_state="$_dfpr_module_dir/config/device-font-dynamic-mount.conf"
     _dfpr_dynamic_target="${LUOSHU_DATA_FONTS_CONFIG_TARGET:-/data/fonts/config/config.xml}"
     if [ ! -s "$_dfpr_dynamic_source" ] || [ ! -s "$_dfpr_dynamic_target" ]; then
-        rm -f "$_dfpr_dynamic_dest" "$_dfpr_dynamic_state" \
-            "$_dfpr_module_dir/config/device-font-dynamic-runtime.conf" 2>/dev/null || true
+        rm -f "$_dfpr_dynamic_dest" "$_dfpr_dynamic_state" 2>/dev/null || true
         return 2
     fi
     _dfpr_link_or_copy "$_dfpr_dynamic_source" "$_dfpr_dynamic_dest" || return 1
@@ -163,111 +131,66 @@ device_font_dynamic_mount_apply() {
     _dfpr_target=$(sed -n 's/^target=//p' "$_dfpr_state" 2>/dev/null | head -n1)
     _dfpr_target_hash=$(sed -n 's/^targetSha256=//p' "$_dfpr_state" 2>/dev/null | head -n1)
     _dfpr_source_hash=$(sed -n 's/^sourceSha256=//p' "$_dfpr_state" 2>/dev/null | head -n1)
-    case "$_dfpr_source_rel" in
-        system/etc/.luoshu-data-fonts-config.xml) ;;
-        *) _dfpr_dynamic_runtime_write failed invalid-source; return 1 ;;
-    esac
-    if [ "$_dfpr_target" != "${LUOSHU_DATA_FONTS_CONFIG_TARGET:-/data/fonts/config/config.xml}" ]; then
-        _dfpr_dynamic_runtime_write failed invalid-target
-        return 1
-    fi
+    case "$_dfpr_source_rel" in system/etc/.luoshu-data-fonts-config.xml) ;; *) return 1 ;; esac
+    [ "$_dfpr_target" = "${LUOSHU_DATA_FONTS_CONFIG_TARGET:-/data/fonts/config/config.xml}" ] || return 1
     _dfpr_source="$_dfpr_module_dir/$_dfpr_source_rel"
-    if [ ! -s "$_dfpr_source" ] || [ ! -s "$_dfpr_target" ]; then
-        _dfpr_dynamic_runtime_write failed source-or-target-missing
-        return 1
-    fi
-    if [ "$(_dfpr_hash "$_dfpr_source")" != "$_dfpr_source_hash" ]; then
-        _dfpr_dynamic_runtime_write failed source-hash-mismatch
-        return 1
-    fi
-    if _dfpr_dynamic_mount_is_readonly "$_dfpr_target"; then
-        if [ "$(_dfpr_hash "$_dfpr_target")" = "$_dfpr_source_hash" ]; then
-            _dfpr_dynamic_runtime_write mounted readonly-view-present
-            return 0
-        fi
-        _dfpr_dynamic_runtime_write overridden readonly-view-mismatch
-        return 2
-    fi
+    [ -s "$_dfpr_source" ] && [ -s "$_dfpr_target" ] || return 2
+    [ "$(_dfpr_hash "$_dfpr_source")" = "$_dfpr_source_hash" ] || return 1
     if [ "$(_dfpr_hash "$_dfpr_target")" != "$_dfpr_target_hash" ]; then
         _dfpr_mark_dynamic_rebuild dynamic-config-changed >/dev/null 2>&1 || true
-        _dfpr_dynamic_runtime_write overridden dynamic-config-changed
         _dfpr_log WARN '动态字体配置已被系统更新，已登记后台重建并保留 ROM 原配置'
         return 2
     fi
+    _dfpr_dynamic_mount_is_readonly "$_dfpr_target" && return 0
     mount -o bind "$_dfpr_source" "$_dfpr_target" 2>/dev/null || \
         mount --bind "$_dfpr_source" "$_dfpr_target" 2>/dev/null || {
-            _dfpr_dynamic_runtime_write failed bind-failed
             _dfpr_log WARN '动态字体配置只读视图挂载失败，保留 ROM 原配置'
-            return 1
+            return 2
         }
     if ! mount -o remount,bind,ro "$_dfpr_target" 2>/dev/null && \
        ! mount -o bind,remount,ro "$_dfpr_target" 2>/dev/null && \
        ! mount -o remount,ro,bind "$_dfpr_target" 2>/dev/null; then
         umount "$_dfpr_target" 2>/dev/null || true
-        _dfpr_dynamic_runtime_write failed readonly-remount-failed
         _dfpr_log WARN '动态字体配置无法切换为只读 bind，已撤销挂载'
-        return 1
+        return 2
     fi
-    if _dfpr_dynamic_mount_is_readonly "$_dfpr_target" && \
-       [ "$(_dfpr_hash "$_dfpr_target")" = "$_dfpr_source_hash" ]; then
-        _dfpr_dynamic_runtime_write mounted readonly-view-confirmed
+    if _dfpr_dynamic_mount_is_readonly "$_dfpr_target"; then
         _dfpr_log INFO '动态字体配置只读视图已在 FontManagerService 初始化前挂载'
         return 0
     fi
     umount "$_dfpr_target" 2>/dev/null || true
-    _dfpr_dynamic_runtime_write failed readonly-verification-failed
     _dfpr_log WARN '动态字体配置只读验证失败，已撤销并保留 ROM 原配置'
-    return 1
+    return 2
 }
 
 device_font_dynamic_mount_release() {
     _dfpr_module_dir="$(_dfpr_module)"
     _dfpr_state="$_dfpr_module_dir/config/device-font-dynamic-mount.conf"
     if [ ! -s "$_dfpr_state" ]; then
-        rm -f "$_dfpr_module_dir/config/device-font-dynamic-runtime.conf" 2>/dev/null || true
         _dfpr_template_ensure_after_release
         return 2
     fi
     _dfpr_source_rel=$(sed -n 's/^source=//p' "$_dfpr_state" 2>/dev/null | head -n1)
     _dfpr_target=$(sed -n 's/^target=//p' "$_dfpr_state" 2>/dev/null | head -n1)
     _dfpr_source_hash=$(sed -n 's/^sourceSha256=//p' "$_dfpr_state" 2>/dev/null | head -n1)
-    case "$_dfpr_source_rel" in
-        system/etc/.luoshu-data-fonts-config.xml) ;;
-        *) _dfpr_dynamic_runtime_write failed invalid-source; return 1 ;;
-    esac
-    if [ "$_dfpr_target" != "${LUOSHU_DATA_FONTS_CONFIG_TARGET:-/data/fonts/config/config.xml}" ]; then
-        _dfpr_dynamic_runtime_write failed invalid-target
-        return 1
-    fi
+    case "$_dfpr_source_rel" in system/etc/.luoshu-data-fonts-config.xml) ;; *) return 1 ;; esac
+    [ "$_dfpr_target" = "${LUOSHU_DATA_FONTS_CONFIG_TARGET:-/data/fonts/config/config.xml}" ] || return 1
     _dfpr_source="$_dfpr_module_dir/$_dfpr_source_rel"
-    if [ ! -s "$_dfpr_source" ] || [ ! -s "$_dfpr_target" ]; then
-        _dfpr_dynamic_runtime_write failed source-or-target-missing
-        return 1
-    fi
+    [ -s "$_dfpr_source" ] && [ -s "$_dfpr_target" ] || return 2
     if ! _dfpr_dynamic_mount_exists "$_dfpr_target"; then
-        _dfpr_dynamic_runtime_write unconfirmed dynamic-view-not-mounted
         _dfpr_template_ensure_after_release
         return 2
     fi
-    if [ "$(_dfpr_hash "$_dfpr_source")" != "$_dfpr_source_hash" ]; then
-        _dfpr_dynamic_runtime_write failed source-hash-mismatch
-        return 1
-    fi
-    if [ "$(_dfpr_hash "$_dfpr_target")" != "$_dfpr_source_hash" ]; then
-        _dfpr_dynamic_runtime_write overridden mounted-view-mismatch
-        return 2
-    fi
+    [ "$(_dfpr_hash "$_dfpr_source")" = "$_dfpr_source_hash" ] || return 1
+    [ "$(_dfpr_hash "$_dfpr_target")" = "$_dfpr_source_hash" ] || return 1
     umount "$_dfpr_target" 2>/dev/null || {
-        _dfpr_dynamic_runtime_write failed release-unmount-failed
         _dfpr_log WARN '启动完成后无法撤销动态字体临时视图'
         return 1
     }
     if _dfpr_dynamic_mount_exists "$_dfpr_target"; then
-        _dfpr_dynamic_runtime_write failed release-still-mounted
         _dfpr_log WARN '动态字体临时视图仍处于挂载状态'
         return 1
     fi
-    _dfpr_dynamic_runtime_write released font-manager-initialized
     _dfpr_log INFO 'FontManagerService 初始化完成，已释放动态字体临时视图'
     _dfpr_template_ensure_after_release
     return 0

--- a/common/device_font_load_verify.sh
+++ b/common/device_font_load_verify.sh
@@ -7,23 +7,6 @@ _dfload_module() {
     printf '%s\n' "${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
 }
 
-_dfload_boot_id() {
-    if [ -n "${LUOSHU_BOOT_ID:-}" ]; then
-        printf '%s\n' "$LUOSHU_BOOT_ID"
-        return 0
-    fi
-    _dfload_boot=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n')
-    if [ -z "$_dfload_boot" ] && command -v getprop >/dev/null 2>&1; then
-        _dfload_boot=$(getprop ro.runtime.firstboot 2>/dev/null | tr -d '\r\n')
-    fi
-    [ -n "$_dfload_boot" ] || _dfload_boot=unknown
-    printf '%s\n' "$_dfload_boot"
-}
-
-_dfload_value() {
-    sed -n "s/^${2}=//p" "$1" 2>/dev/null | head -n1 | tr -d '\r\n'
-}
-
 _dfload_hash_stream() {
     if command -v sha256sum >/dev/null 2>&1; then
         sha256sum 2>/dev/null | awk '{print $1}'
@@ -72,7 +55,6 @@ _dfload_write_simple() {
         printf 'mode=%s\n' "$_dfload_mode"
         printf 'activeFont=%s\n' "$_dfload_active"
         printf 'reason=%s\n' "$_dfload_reason"
-        printf 'bootId=%s\n' "$(_dfload_boot_id)"
         printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
     } > "${_dfload_conf}.tmp.$$" 2>/dev/null || return 1
     mv -f "${_dfload_conf}.tmp.$$" "$_dfload_conf" 2>/dev/null || return 1
@@ -81,8 +63,9 @@ _dfload_write_simple() {
 }
 
 # Normal boot path: switching already completed transaction, payload and mount checks.
-# Do not traverse or hash the font tree again. Only current-boot atomic mount evidence,
-# a matching boot transaction and any required dynamic-font view may mark the font applied.
+# Do not traverse or hash the font tree again. A confirmed boot transaction or mounted
+# self-mount is sufficient for the App's applied state; explicit deep verification remains
+# available for diagnostics.
 device_font_load_status() {
     _dfload_module_dir="$(_dfload_module)"
     _dfload_config="$_dfload_module_dir/config"
@@ -93,82 +76,23 @@ device_font_load_status() {
         return 0
     fi
 
-    _dfload_current_boot=$(_dfload_boot_id)
-    _dfload_mount_file="$_dfload_config/self-mount.conf"
-    _dfload_mount_state=$(_dfload_value "$_dfload_mount_file" state)
-    _dfload_mount_backend=$(_dfload_value "$_dfload_mount_file" backend)
-    _dfload_mount_failed=$(_dfload_value "$_dfload_mount_file" failed)
-    _dfload_mount_boot=$(_dfload_value "$_dfload_mount_file" bootId)
-    _dfload_required="$_dfload_config/self-mount-required.conf"
-    _dfload_boot_file="$_dfload_config/font-payload-boot.conf"
-    _dfload_boot_state=$(_dfload_value "$_dfload_boot_file" state)
-    _dfload_boot_font=$(_dfload_value "$_dfload_boot_file" font)
-
-    if [ "$_dfload_mount_state" = failed ] || [ -n "$_dfload_mount_failed" ]; then
+    _dfload_mount_state=$(sed -n 's/^state=//p' "$_dfload_config/self-mount.conf" 2>/dev/null | head -n1)
+    _dfload_boot_state=$(sed -n 's/^state=//p' "$_dfload_config/font-payload-boot.conf" 2>/dev/null | head -n1)
+    if [ "$_dfload_mount_state" = failed ]; then
         _dfload_write_simple failed self-mount-failed "$_dfload_active" compatibility
-        _dfload_log "字体自挂载状态失败：$_dfload_active (${_dfload_mount_failed:-unknown})"
+        _dfload_log "字体自挂载状态失败：$_dfload_active"
         return 1
     fi
-    if [ "$_dfload_mount_state" != mounted ]; then
-        _dfload_write_simple pending self-mount-not-confirmed "$_dfload_active" compatibility
-        return 2
-    fi
-    case "$_dfload_mount_backend" in ''|none|rollback|verification)
-        _dfload_write_simple failed self-mount-invalid-backend "$_dfload_active" compatibility
-        return 1
-        ;;
+    case "$_dfload_mount_state:$_dfload_boot_state" in
+        mounted:*|*:confirmed)
+            _dfload_write_simple verified boot-transaction-confirmed "$_dfload_active" mount-verified
+            _dfload_log "字体已按正常切换流程生效：$_dfload_active"
+            return 0
+            ;;
     esac
-    if [ "$_dfload_current_boot" = unknown ] || [ -z "$_dfload_mount_boot" ] || \
-       [ "$_dfload_mount_boot" != "$_dfload_current_boot" ]; then
-        _dfload_write_simple pending stale-self-mount "$_dfload_active" compatibility
-        return 2
-    fi
-    if [ ! -s "$_dfload_required" ]; then
-        _dfload_write_simple failed self-mount-manifest-missing "$_dfload_active" compatibility
-        _dfload_log '自挂载状态为 mounted，但本次启动缺少必需挂载清单'
-        return 1
-    fi
-    if [ "$_dfload_boot_state" != confirmed ]; then
-        _dfload_write_simple pending awaiting-boot-transaction "$_dfload_active" compatibility
-        return 2
-    fi
-    if [ -n "$_dfload_boot_font" ] && [ "$_dfload_boot_font" != "$_dfload_active" ]; then
-        _dfload_write_simple pending stale-boot-transaction "$_dfload_active" compatibility
-        return 2
-    fi
 
-    _dfload_dynamic_contract="$_dfload_config/device-font-dynamic-mount.conf"
-    if [ -s "$_dfload_dynamic_contract" ]; then
-        _dfload_dynamic_runtime="$_dfload_config/device-font-dynamic-runtime.conf"
-        _dfload_dynamic_state=$(_dfload_value "$_dfload_dynamic_runtime" state)
-        _dfload_dynamic_reason=$(_dfload_value "$_dfload_dynamic_runtime" reason)
-        _dfload_dynamic_boot=$(_dfload_value "$_dfload_dynamic_runtime" bootId)
-        if [ -z "$_dfload_dynamic_boot" ] || [ "$_dfload_dynamic_boot" != "$_dfload_current_boot" ]; then
-            _dfload_write_simple pending dynamic-config-unconfirmed "$_dfload_active" compatibility
-            return 2
-        fi
-        case "$_dfload_dynamic_state" in
-            mounted|released) ;;
-            overridden)
-                _dfload_write_simple failed dynamic-config-overridden "$_dfload_active" compatibility
-                _dfload_log "OEM 动态字体配置覆盖了洛书启动视图：${_dfload_dynamic_reason:-unknown}"
-                return 1
-                ;;
-            failed)
-                _dfload_write_simple failed dynamic-config-mount-failed "$_dfload_active" compatibility
-                _dfload_log "动态字体配置挂载失败：${_dfload_dynamic_reason:-unknown}"
-                return 1
-                ;;
-            *)
-                _dfload_write_simple pending dynamic-config-unconfirmed "$_dfload_active" compatibility
-                return 2
-                ;;
-        esac
-    fi
-
-    _dfload_write_simple verified current-boot-mount-confirmed "$_dfload_active" mount-verified
-    _dfload_log "本次启动字体事务与完整自挂载均已确认：$_dfload_active"
-    return 0
+    _dfload_write_simple pending awaiting-boot-transaction "$_dfload_active" compatibility
+    return 2
 }
 
 _dfload_python() {

--- a/common/device_font_runtime_report.sh
+++ b/common/device_font_runtime_report.sh
@@ -71,11 +71,6 @@ device_font_runtime_report_collect() {
     _dfr_template=$(sed -n 's/^state=//p' "$_dfr_config/device-font-template.state" 2>/dev/null | head -n1)
     _dfr_alignment=$(sed -n 's/^state=//p' "$_dfr_config/device-font-load-verification.conf" 2>/dev/null | head -n1)
     _dfr_mode=$(sed -n 's/^mode=//p' "$_dfr_config/device-font-load-verification.conf" 2>/dev/null | head -n1)
-    _dfr_self_mount=$(sed -n 's/^state=//p' "$_dfr_config/self-mount.conf" 2>/dev/null | head -n1)
-    _dfr_self_backend=$(sed -n 's/^backend=//p' "$_dfr_config/self-mount.conf" 2>/dev/null | head -n1)
-    _dfr_self_failed=$(sed -n 's/^failed=//p' "$_dfr_config/self-mount.conf" 2>/dev/null | head -n1)
-    _dfr_post_mount=$(sed -n 's/^state=//p' "$_dfr_config/post-mount-hook.conf" 2>/dev/null | head -n1)
-    _dfr_dynamic_runtime=$(sed -n 's/^state=//p' "$_dfr_config/device-font-dynamic-runtime.conf" 2>/dev/null | head -n1)
     _dfr_cache_pending=no
     [ -s "$_dfr_config/device-font-cache-pending.conf" ] && _dfr_cache_pending=yes
 
@@ -96,11 +91,6 @@ device_font_runtime_report_collect() {
         printf 'templateState=%s\n' "${_dfr_template:-missing}"
         printf 'alignmentState=%s\n' "${_dfr_alignment:-missing}"
         printf 'alignmentMode=%s\n' "${_dfr_mode:-compatibility}"
-        printf 'selfMountState=%s\n' "${_dfr_self_mount:-missing}"
-        printf 'selfMountBackend=%s\n' "${_dfr_self_backend:-missing}"
-        printf 'selfMountFailure=%s\n' "${_dfr_self_failed:-none}"
-        printf 'postMountHook=%s\n' "${_dfr_post_mount:-missing}"
-        printf 'dynamicRuntime=%s\n' "${_dfr_dynamic_runtime:-not-applicable}"
         printf 'cachePending=%s\n' "$_dfr_cache_pending"
         printf 'fingerprint=%s\n' "$(getprop ro.build.fingerprint 2>/dev/null)"
         printf 'incremental=%s\n' "$(getprop ro.build.version.incremental 2>/dev/null)"
@@ -121,10 +111,6 @@ device_font_runtime_report_collect() {
         "device-font-engine.conf|device-font-engine.conf" \
         "device-font-installed.conf|device-font-installed.conf" \
         "device-font-dynamic-mount.conf|device-font-dynamic-mount.conf" \
-        "device-font-dynamic-runtime.conf|device-font-dynamic-runtime.conf" \
-        "self-mount.conf|self-mount.conf" \
-        "self-mount-required.conf|self-mount-required.conf" \
-        "post-mount-hook.conf|post-mount-hook.conf" \
         "device-font-cache-pending.conf|device-font-cache-pending.conf" \
         "device-font-load-verification.conf|device-font-load-verification.conf" \
         "device-font-load-verification.json|device-font-load-verification.json" \

--- a/common/module_update_state.sh
+++ b/common/module_update_state.sh
@@ -35,10 +35,9 @@ luoshu_update_config_is_volatile() {
         composite_progress.json|mix_last_error.txt|app_install_pending|app_install_state.conf|\
         app_install_manual|font-payload-rebuild-pending.conf|font-boot-failures|\
         font-payload-quarantine.conf|mount_compat.conf|self-mount.conf|\
-        self-mount-required.conf|post-mount-hook.conf|device-font-dynamic-runtime.conf|\
-        device-font-load-verification.conf|device-font-load-verification.json|\
-        device-font-manager-dump.txt|device-font-mount-evidence.txt|\
-        *.pid|*.pid.task|*.tmp|*.tmp.*)
+        self-mount-required.conf|device-font-load-verification.conf|\
+        device-font-load-verification.json|device-font-manager-dump.txt|\
+        device-font-mount-evidence.txt|*.pid|*.pid.task|*.tmp|*.tmp.*)
             return 0
             ;;
     esac
@@ -91,8 +90,6 @@ luoshu_clear_update_volatile() {
         "$_module/config/mount_compat.conf" \
         "$_module/config/self-mount.conf" \
         "$_module/config/self-mount-required.conf" \
-        "$_module/config/post-mount-hook.conf" \
-        "$_module/config/device-font-dynamic-runtime.conf" \
         "$_module/config/device-font-load-verification.conf" \
         "$_module/config/device-font-load-verification.json" \
         "$_module/config/device-font-manager-dump.txt" \

--- a/common/mount_self_fallback.sh
+++ b/common/mount_self_fallback.sh
@@ -17,19 +17,6 @@ _luoshu_self_visible_root() {
     printf '%s\n' "${LUOSHU_SELF_MOUNT_VISIBLE_ROOT:-}"
 }
 
-_luoshu_self_boot_id() {
-    if [ -n "${LUOSHU_BOOT_ID:-}" ]; then
-        printf '%s\n' "$LUOSHU_BOOT_ID"
-        return 0
-    fi
-    _lsbi_value=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n')
-    if [ -z "$_lsbi_value" ] && command -v getprop >/dev/null 2>&1; then
-        _lsbi_value=$(getprop ro.runtime.firstboot 2>/dev/null | tr -d '\r\n')
-    fi
-    [ -n "$_lsbi_value" ] || _lsbi_value=unknown
-    printf '%s\n' "$_lsbi_value"
-}
-
 _luoshu_self_log() {
     _lsml_module=$(_luoshu_self_module)
     mkdir -p "$_lsml_module/logs" 2>/dev/null || true
@@ -403,7 +390,6 @@ _luoshu_self_state_write() {
         printf 'backend=%s\n' "$_lssw_backend"
         printf 'mounted=%s\n' "$_lssw_mounted"
         printf 'failed=%s\n' "$_lssw_failed"
-        printf 'bootId=%s\n' "$(_luoshu_self_boot_id)"
         printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
     } > "$_lssw_module/config/self-mount.conf.tmp.$$" 2>/dev/null && \
         mv -f "$_lssw_module/config/self-mount.conf.tmp.$$" \

--- a/post-mount.sh
+++ b/post-mount.sh
@@ -1,63 +1,15 @@
 #!/system/bin/sh
 # LuoShu private payload mount. External metamodules are intentionally ignored.
-# Fail open for boot safety, but always leave an explicit current-boot hook result.
 set +e
 MODDIR="${0%/*}"
 MODULE_DIR="$MODDIR"
-
-_post_mount_boot_id() {
-    if [ -n "${LUOSHU_BOOT_ID:-}" ]; then
-        printf '%s\n' "$LUOSHU_BOOT_ID"
-        return 0
-    fi
-    _pm_boot=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n')
-    if [ -z "$_pm_boot" ] && command -v getprop >/dev/null 2>&1; then
-        _pm_boot=$(getprop ro.runtime.firstboot 2>/dev/null | tr -d '\r\n')
-    fi
-    [ -n "$_pm_boot" ] || _pm_boot=unknown
-    printf '%s\n' "$_pm_boot"
-}
-
-_post_mount_state() {
-    _pm_state="$1"
-    _pm_reason="$2"
-    _pm_code="$3"
-    mkdir -p "$MODDIR/config" "$MODDIR/logs" 2>/dev/null || true
-    {
-        printf 'state=%s\n' "$_pm_state"
-        printf 'reason=%s\n' "$_pm_reason"
-        printf 'code=%s\n' "$_pm_code"
-        printf 'bootId=%s\n' "$(_post_mount_boot_id)"
-        printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
-    } > "$MODDIR/config/post-mount-hook.conf.tmp.$$" 2>/dev/null && \
-        mv -f "$MODDIR/config/post-mount-hook.conf.tmp.$$" \
-            "$MODDIR/config/post-mount-hook.conf" 2>/dev/null || true
-    printf '[%s] [POST-MOUNT] state=%s reason=%s code=%s\n' \
-        "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" \
-        "$_pm_state" "$_pm_reason" "$_pm_code" \
-        >> "$MODDIR/logs/self-mount.log" 2>/dev/null || true
-}
-
 [ -f "$MODDIR/common/private_payload.sh" ] && . "$MODDIR/common/private_payload.sh"
-if ! type luoshu_private_mount_module_view >/dev/null 2>&1 || \
-   ! luoshu_private_mount_module_view "$MODDIR" >/dev/null 2>&1; then
-    _post_mount_state failed module-view-failed 1
-    exit 0
-fi
+luoshu_private_mount_module_view "$MODDIR" >/dev/null 2>&1 || true
 [ -f "$MODDIR/common/util_functions.sh" ] && . "$MODDIR/common/util_functions.sh"
 [ -f "$MODDIR/common/font_config_runtime.sh" ] && . "$MODDIR/common/font_config_runtime.sh"
 [ -f "$MODDIR/common/font_config_partitions.sh" ] && . "$MODDIR/common/font_config_partitions.sh"
 [ -f "$MODDIR/common/mount_compat.sh" ] && . "$MODDIR/common/mount_compat.sh"
 [ -f "$MODDIR/common/mount_self_backend.sh" ] && . "$MODDIR/common/mount_self_backend.sh"
-if ! type luoshu_private_self_mount_ensure >/dev/null 2>&1; then
-    _post_mount_state failed mount-entry-missing 127
-    exit 0
-fi
-luoshu_private_self_mount_ensure >/dev/null 2>&1
-_pm_rc=$?
-if [ "$_pm_rc" -eq 0 ]; then
-    _post_mount_state completed self-mount-complete 0
-else
-    _post_mount_state failed self-mount-failed "$_pm_rc"
-fi
+type luoshu_private_self_mount_ensure >/dev/null 2>&1 || exit 0
+luoshu_private_self_mount_ensure >/dev/null 2>&1 || true
 exit 0

--- a/scripts/device_font_trust_test.sh
+++ b/scripts/device_font_trust_test.sh
@@ -30,127 +30,18 @@ assert "verified-by-visible-mounts" in payload["reasons"], payload
 assert "dynamic-family-unconfirmed" in payload["reasons"], payload
 PY
 
-# Normal boot status is constant-time but must be strict: a completed payload transaction
-# alone is not proof that this boot mounted the payload into Android's root namespace.
+# Normal boot status must not invoke mount traversal or Python. A confirmed transaction
+# is enough to expose the active font after the reboot requested by the switch task.
 AUTO_MOD="$TMP/auto-module"
 mkdir -p "$AUTO_MOD/common" "$AUTO_MOD/config" "$AUTO_MOD/logs"
 cp "$ROOT/common/device_font_load_verify.sh" "$AUTO_MOD/common/"
 printf 'Composite Font\n' > "$AUTO_MOD/config/active_font.conf"
 printf 'state=confirmed\nfont=Composite Font\n' > "$AUTO_MOD/config/font-payload-boot.conf"
-set +e
-LUOSHU_BOOT_ID=test-boot MODDIR="$AUTO_MOD" MODULE_DIR="$AUTO_MOD" \
-    sh "$AUTO_MOD/common/device_font_load_verify.sh"
-AUTO_RC=$?
-set -e
-test "$AUTO_RC" -eq 2
-grep -q '^state=pending$' "$AUTO_MOD/config/device-font-load-verification.conf"
-grep -q '^reason=self-mount-not-confirmed$' "$AUTO_MOD/config/device-font-load-verification.conf"
-
-# Only a current-boot atomic mount with its required manifest may become verified.
-printf 'state=mounted\nbackend=self-overlay\nmounted=system/fonts:overlay\nfailed=\nbootId=test-boot\n' \
-    > "$AUTO_MOD/config/self-mount.conf"
-printf '%s\n' '/module/system/fonts|/system/fonts|overlay' \
-    > "$AUTO_MOD/config/self-mount-required.conf"
-LUOSHU_BOOT_ID=test-boot MODDIR="$AUTO_MOD" MODULE_DIR="$AUTO_MOD" \
+MODDIR="$AUTO_MOD" MODULE_DIR="$AUTO_MOD" \
     sh "$AUTO_MOD/common/device_font_load_verify.sh"
 grep -q '^state=verified$' "$AUTO_MOD/config/device-font-load-verification.conf"
 grep -q '^mode=mount-verified$' "$AUTO_MOD/config/device-font-load-verification.conf"
-grep -q '^reason=current-boot-mount-confirmed$' "$AUTO_MOD/config/device-font-load-verification.conf"
-
-# A mount record from a previous boot must never survive as an applied-font claim.
-sed -i 's/^bootId=.*/bootId=old-boot/' "$AUTO_MOD/config/self-mount.conf"
-set +e
-LUOSHU_BOOT_ID=test-boot MODDIR="$AUTO_MOD" MODULE_DIR="$AUTO_MOD" \
-    sh "$AUTO_MOD/common/device_font_load_verify.sh"
-STALE_RC=$?
-set -e
-test "$STALE_RC" -eq 2
-grep -q '^state=pending$' "$AUTO_MOD/config/device-font-load-verification.conf"
-grep -q '^reason=stale-self-mount$' "$AUTO_MOD/config/device-font-load-verification.conf"
-sed -i 's/^bootId=.*/bootId=test-boot/' "$AUTO_MOD/config/self-mount.conf"
-
-# Dynamic /data/fonts contracts are part of activation. OEM replacement is a real failure,
-# while a released view from this boot is accepted without running the deep verifier.
-printf 'state=prepared\n' > "$AUTO_MOD/config/device-font-dynamic-mount.conf"
-printf 'state=overridden\nreason=dynamic-config-changed\nbootId=test-boot\n' \
-    > "$AUTO_MOD/config/device-font-dynamic-runtime.conf"
-set +e
-LUOSHU_BOOT_ID=test-boot MODDIR="$AUTO_MOD" MODULE_DIR="$AUTO_MOD" \
-    sh "$AUTO_MOD/common/device_font_load_verify.sh"
-DYNAMIC_RC=$?
-set -e
-test "$DYNAMIC_RC" -eq 1
-grep -q '^state=failed$' "$AUTO_MOD/config/device-font-load-verification.conf"
-grep -q '^reason=dynamic-config-overridden$' "$AUTO_MOD/config/device-font-load-verification.conf"
-printf 'state=released\nreason=font-manager-initialized\nbootId=test-boot\n' \
-    > "$AUTO_MOD/config/device-font-dynamic-runtime.conf"
-LUOSHU_BOOT_ID=test-boot MODDIR="$AUTO_MOD" MODULE_DIR="$AUTO_MOD" \
-    sh "$AUTO_MOD/common/device_font_load_verify.sh"
-grep -q '^state=verified$' "$AUTO_MOD/config/device-font-load-verification.conf"
-
-# The dynamic guard must publish the reason when the OEM rewrites its config, and must not
-# resurrect the expensive deep verifier after the temporary view is released.
-DYN_MOD="$TMP/dynamic-module"
-DYN_TARGET="$TMP/data-fonts-config.xml"
-mkdir -p "$DYN_MOD/common" "$DYN_MOD/config" "$DYN_MOD/logs" "$DYN_MOD/system/etc"
-printf 'Composite Font\n' > "$DYN_MOD/config/active_font.conf"
-printf 'luoshu-view\n' > "$DYN_MOD/system/etc/.luoshu-data-fonts-config.xml"
-printf 'oem-new-view\n' > "$DYN_TARGET"
-_dfpr_module() { printf '%s\n' "$DYN_MOD"; }
-_dfpr_hash() { sha256sum "$1" | awk '{print $1}'; }
-_dfpr_log() { :; }
-_dfpr_launch_pending_cache() { :; }
-. "$ROOT/common/device_font_dynamic_guard.sh"
-DYN_SOURCE_HASH=$(_dfpr_hash "$DYN_MOD/system/etc/.luoshu-data-fonts-config.xml")
-{
-    printf 'state=prepared\n'
-    printf 'source=system/etc/.luoshu-data-fonts-config.xml\n'
-    printf 'target=%s\n' "$DYN_TARGET"
-    printf 'targetSha256=old-target-hash\n'
-    printf 'sourceSha256=%s\n' "$DYN_SOURCE_HASH"
-} > "$DYN_MOD/config/device-font-dynamic-mount.conf"
-set +e
-LUOSHU_BOOT_ID=test-boot LUOSHU_DATA_FONTS_CONFIG_TARGET="$DYN_TARGET" \
-    device_font_dynamic_mount_apply
-DYN_RC=$?
-set -e
-test "$DYN_RC" -eq 2
-grep -q '^state=overridden$' "$DYN_MOD/config/device-font-dynamic-runtime.conf"
-grep -q '^reason=dynamic-config-changed$' "$DYN_MOD/config/device-font-dynamic-runtime.conf"
-grep -q '^bootId=test-boot$' "$DYN_MOD/config/device-font-dynamic-runtime.conf"
-DEEP_MARK="$TMP/deep-called"
-STATUS_MARK="$TMP/status-called"
-device_font_load_verify() { : > "$DEEP_MARK"; }
-device_font_load_status() { : > "$STATUS_MARK"; }
-_dfpr_template_ensure_after_release
-test -f "$STATUS_MARK"
-test ! -e "$DEEP_MARK"
-
-# post-mount stays fail-open for boot safety, but it must never hide a missing module view
-# or self-mount entry from diagnostics.
-PM_MOD="$TMP/post-mount-module"
-mkdir -p "$PM_MOD/common" "$PM_MOD/config" "$PM_MOD/logs"
-cp "$ROOT/post-mount.sh" "$PM_MOD/post-mount.sh"
-cat > "$PM_MOD/common/private_payload.sh" <<'EOF_PM_FAIL'
-luoshu_private_mount_module_view() { return 1; }
-EOF_PM_FAIL
-LUOSHU_BOOT_ID=test-boot sh "$PM_MOD/post-mount.sh"
-grep -q '^state=failed$' "$PM_MOD/config/post-mount-hook.conf"
-grep -q '^reason=module-view-failed$' "$PM_MOD/config/post-mount-hook.conf"
-grep -q '^bootId=test-boot$' "$PM_MOD/config/post-mount-hook.conf"
-cat > "$PM_MOD/common/private_payload.sh" <<'EOF_PM_OK'
-luoshu_private_mount_module_view() { return 0; }
-EOF_PM_OK
-: > "$PM_MOD/common/util_functions.sh"
-: > "$PM_MOD/common/font_config_runtime.sh"
-: > "$PM_MOD/common/font_config_partitions.sh"
-cat > "$PM_MOD/common/mount_compat.sh" <<'EOF_PM_MOUNT'
-luoshu_private_self_mount_ensure() { return 0; }
-EOF_PM_MOUNT
-: > "$PM_MOD/common/mount_self_backend.sh"
-LUOSHU_BOOT_ID=test-boot sh "$PM_MOD/post-mount.sh"
-grep -q '^state=completed$' "$PM_MOD/config/post-mount-hook.conf"
-grep -q '^reason=self-mount-complete$' "$PM_MOD/config/post-mount-hook.conf"
+grep -q '^reason=boot-transaction-confirmed$' "$AUTO_MOD/config/device-font-load-verification.conf"
 
 # The expensive verifier remains available only as an explicit diagnostic command.
 COMPAT_MOD="$TMP/compat-module"


### PR DESCRIPTION
## 问题

v2.3.7 的严格启动证据链在部分真实设备上把正常字体组合、系统字体恢复和启动挂载误判为失败，导致：

- 字体组合停在“准备原子替换字体负载”后失败
- 已恢复系统字体仍因旧负载回写失败而标记失败
- 启动守卫准备撤销覆盖
- 任务中心残留失败状态

## 热修

完整回退 PR #125 引入的 7 个严格验证文件到 v2.3.6 稳定实现：

- 恢复轻量启动状态判断，不再强制要求本次启动的完整 bootId/动态视图证据链
- 动态字体配置不支持或被 ROM 更新时继续 fail-open，不把正常组合直接判失败
- 恢复 post-mount 的安全兜底行为
- 恢复更新状态迁移和自挂载兼容逻辑
- 同步恢复对应回归测试

这是止血热修，先恢复真实设备可用性。后续严格验证必须在真实设备覆盖完成后再逐项引入。