### PR TITLE
hotfix: restore font switching on real devices

### DIFF
--- a/common/mount_self_atomic.sh
+++ b/common/mount_self_atomic.sh
@@ -121,38 +121,6 @@ _luoshu_atomic_files_equal() {
     [ -n "$_lsafe_left_fingerprint" ] && [ "$_lsafe_left_fingerprint" = "$_lsafe_right_fingerprint" ]
 }
 
-_luoshu_atomic_file_identity() {
-    stat -c '%d:%i' "$1" 2>/dev/null
-}
-
-_luoshu_atomic_same_identity() {
-    _lsasi_left=$(_luoshu_atomic_file_identity "$1")
-    _lsasi_right=$(_luoshu_atomic_file_identity "$2")
-    [ -n "$_lsasi_left" ] && [ "$_lsasi_left" = "$_lsasi_right" ]
-}
-
-_luoshu_atomic_namespace_target() {
-    _lsant_path="$1"
-    _lsant_root="${LUOSHU_SELF_PID1_ROOT:-/proc/1/root}"
-    case "$_lsant_root" in
-        /|'') printf '%s\n' "$_lsant_path" ;;
-        *)
-            case "$_lsant_path" in
-                "$_lsant_root"/*) printf '/%s\n' "${_lsant_path#"$_lsant_root"/}" ;;
-                *) printf '%s\n' "$_lsant_path" ;;
-            esac
-            ;;
-    esac
-}
-
-_luoshu_atomic_mountinfo_has_target() {
-    _lsamht_target=$(_luoshu_atomic_namespace_target "$1")
-    _lsamht_file="${LUOSHU_SELF_MOUNTINFO:-/proc/1/mountinfo}"
-    [ -r "$_lsamht_file" ] || return 1
-    awk -v target="$_lsamht_target" '$5 == target { found=1 } END { exit !found }' \
-        "$_lsamht_file" 2>/dev/null
-}
-
 _luoshu_atomic_pid1_target() {
     _lsapt_target="$1"
     _lsapt_root="${LUOSHU_SELF_PID1_ROOT:-/proc/1/root}"
@@ -224,11 +192,6 @@ _luoshu_atomic_tree_visible() {
                 continue
             fi
             printf '%s\n' "$_lsatv_dst" >> "$_lsatv_seen" 2>/dev/null || {
-                _lsatv_failed=1
-                break
-            }
-            _luoshu_atomic_mountinfo_has_target "$_lsatv_dst" && \
-                _luoshu_atomic_same_identity "$_lsatv_src" "$_lsatv_dst" || {
                 _lsatv_failed=1
                 break
             }
@@ -316,9 +279,6 @@ _luoshu_atomic_verify_manifest() {
     [ -s "$_lsavm_manifest" ] || return 1
     while IFS='|' read -r _lsavm_source _lsavm_target _lsavm_mode; do
         [ -n "$_lsavm_source" ] && [ -n "$_lsavm_target" ] || return 1
-        if [ "${_lsavm_mode:-overlay}" = overlay ]; then
-            _luoshu_atomic_mountinfo_has_target "$_lsavm_target" || return 1
-        fi
         _lsavm_visible=$(_luoshu_atomic_pid1_target "$_lsavm_target")
         _luoshu_atomic_tree_visible "$_lsavm_source" "$_lsavm_visible" "${_lsavm_mode:-overlay}" || return 1
     done < "$_lsavm_manifest"

--- a/scripts/self_mount_atomic_test.sh
+++ b/scripts/self_mount_atomic_test.sh
@@ -19,14 +19,12 @@ setup_case() {
     LUOSHU_SELF_MOUNT_STATE_ROOT="$CASE_ROOT/state"
     LUOSHU_SELF_MOUNT_VISIBLE_ROOT="$CASE_ROOT/root"
     LUOSHU_SELF_PID1_ROOT=/
-    LUOSHU_SELF_MOUNTINFO="$CASE_ROOT/mountinfo"
     export MODULE_DIR LUOSHU_MOUNT_MODDIR LUOSHU_SELF_MOUNT_STATE_ROOT \
-        LUOSHU_SELF_MOUNT_VISIBLE_ROOT LUOSHU_SELF_PID1_ROOT LUOSHU_SELF_MOUNTINFO
+        LUOSHU_SELF_MOUNT_VISIBLE_ROOT LUOSHU_SELF_PID1_ROOT
     mkdir -p "$MODULE_DIR/config" "$MODULE_DIR/logs" "$CASE_ROOT/root/system/fonts" \
         "$CASE_ROOT/root/system/etc" "$CASE_ROOT/state"
     printf 'custom\n' > "$MODULE_DIR/config/active_font.conf"
     : > "$CASE_ROOT/unmount.log"
-    : > "$LUOSHU_SELF_MOUNTINFO"
     FAIL_OVERLAY=''
     FAIL_BIND=''
 }
@@ -61,14 +59,12 @@ _luoshu_partition_root() {
 }
 _luoshu_overlay_mount_dir() {
     test "${FAIL_OVERLAY:-}" != all && test "${FAIL_OVERLAY:-}" != "$3" || return 1
-    cp -R "$1/." "$2/" || return 1
-    printf '1 0 0:1 / %s rw - overlay overlay rw\n' "$2" >> "$LUOSHU_SELF_MOUNTINFO"
+    cp -R "$1/." "$2/"
 }
 _luoshu_mount_cmd() {
     test "$1" = -o && test "$2" = bind || return 1
     test "${FAIL_BIND:-}" != "$4" || return 1
-    ln -f "$3" "$4" || return 1
-    printf '2 0 0:2 / %s rw - bind bind rw\n' "$4" >> "$LUOSHU_SELF_MOUNTINFO"
+    cp -f "$3" "$4"
 }
 _luoshu_umount_cmd() {
     printf '%s\n' "$1" >> "$CASE_ROOT/unmount.log"

--- a/scripts/self_mount_test.sh
+++ b/scripts/self_mount_test.sh
@@ -12,7 +12,6 @@ PRIVATE_STATE="$TMP/private-state"
 FAKE_MOUNT="$TMP/fake-mount.sh"
 FAKE_UMOUNT="$TMP/fake-umount.sh"
 MOUNTINFO="$TMP/mounts"
-ATOMIC_MOUNTINFO="$TMP/atomic-mountinfo"
 mkdir -p \
     "$MODULE/system/fonts" \
     "$MODULE/system/etc/luoshu" \
@@ -30,13 +29,11 @@ printf 'id=LuoShu\nfont=Demo\nengine=self-mount\npartition=system\nnonce=test-sy
 printf 'system|test-system|/system/etc/luoshu/mount-probe.conf\n' \
     > "$MODULE/config/mount-probes-expected.conf"
 : > "$MOUNTINFO"
-: > "$ATOMIC_MOUNTINFO"
 
 cat > "$FAKE_MOUNT" <<'EOF_FAKE_MOUNT'
 #!/bin/sh
 set -eu
 mountinfo=${LUOSHU_TEST_MOUNTINFO:?}
-atomic_mountinfo=${LUOSHU_TEST_ATOMIC_MOUNTINFO:-}
 case "$1" in
     -o)
         [ "$2" = bind ]
@@ -48,8 +45,6 @@ case "$1" in
         mkdir -p "$dst"
         cp -a "$src/." "$dst/"
         printf 'bind %s %s %s\n' "$src" "$dst" "$backup" >> "$mountinfo"
-        [ -z "$atomic_mountinfo" ] || \
-            printf '1 0 0:1 / %s rw - bind bind rw\n' "$dst" >> "$atomic_mountinfo"
         ;;
     -t)
         [ "$2" = overlay ]
@@ -67,8 +62,6 @@ case "$1" in
         cp -a "$stock/." "$target/"
         cp -a "$source/." "$target/"
         printf 'overlay %s %s %s\n' "$source" "$target" "$backup" >> "$mountinfo"
-        [ -z "$atomic_mountinfo" ] || \
-            printf '2 0 0:2 / %s rw - overlay overlay rw\n' "$target" >> "$atomic_mountinfo"
         ;;
     *) exit 2 ;;
 esac
@@ -92,7 +85,6 @@ LUOSHU_PRIVATE_MOUNTINFO="$MOUNTINFO" \
 LUOSHU_PRIVATE_MOUNT_COMMAND="$FAKE_MOUNT" \
 LUOSHU_PRIVATE_UMOUNT_COMMAND="$FAKE_UMOUNT" \
 LUOSHU_TEST_MOUNTINFO="$MOUNTINFO" \
-LUOSHU_TEST_ATOMIC_MOUNTINFO="$ATOMIC_MOUNTINFO" \
 sh -c '
     . "$1/common/private_payload.sh"
     luoshu_private_install_migrate "$MODDIR"
@@ -117,7 +109,6 @@ MODDIR="$MODULE" MODULE_DIR="$MODULE" LUOSHU_MOUNT_MODDIR="$MODULE" \
 LUOSHU_SELF_MOUNT_VISIBLE_ROOT="$VISIBLE" \
 LUOSHU_SELF_MOUNT_STATE_ROOT="$STATE" \
 LUOSHU_SELF_PID1_ROOT=/ \
-LUOSHU_SELF_MOUNTINFO="$ATOMIC_MOUNTINFO" \
 LUOSHU_SELF_MOUNT_COMMAND="$FAKE_MOUNT" \
 LUOSHU_SELF_UMOUNT_COMMAND="$FAKE_UMOUNT" \
 LUOSHU_PRIVATE_STATE_ROOT="$PRIVATE_STATE" \
@@ -125,7 +116,6 @@ LUOSHU_PRIVATE_MOUNTINFO="$MOUNTINFO" \
 LUOSHU_PRIVATE_MOUNT_COMMAND="$FAKE_MOUNT" \
 LUOSHU_PRIVATE_UMOUNT_COMMAND="$FAKE_UMOUNT" \
 LUOSHU_TEST_MOUNTINFO="$MOUNTINFO" \
-LUOSHU_TEST_ATOMIC_MOUNTINFO="$ATOMIC_MOUNTINFO" \
 sh -c '
     luoshu_payload_partitions() { printf "system\n"; }
     luoshu_module_id() { printf "LuoShu\n"; }


### PR DESCRIPTION
## 根因

v2.3.7 在 `common/mount_self_atomic.sh` 中新增了 PID 1 `mountinfo` 目标核对，以及源文件与系统可见目标的设备号/inode 同一性检查。

在部分 ColorOS、KernelSU、SukiSU、APatch 环境中，字体 bind/overlay 已经成功且内容可见，但这些额外身份条件并不成立，于是 `_luoshu_atomic_verify_manifest` 返回失败，整次原子字体事务被逆序回滚。用户表现为：

- 一直停在“正在准备原子替换字体负载”
- 字体组合直接失败
- 单字体和组合字体均无法切换
- 系统字体恢复也可能被旧事务连带判失败

## 修复

- 将原子自挂载实现回退到 v2.3.6 的内容可见性验证：目标存在、大小和快速指纹一致即可确认。
- 删除 PID 1 `mountinfo` 强制目标门禁。
- 删除 bind 源/目标设备号与 inode 必须相同的强制条件。
- 保留原子事务策略：任何真实字体或配置组件失败仍会全部回滚，不允许半挂载。
- 同步回退自挂载回归测试，使测试覆盖与真实设备兼容策略一致。

这是恢复“真正能换字体”的核心热修。