### PR TITLE
refactor(ui): rebuild home with lightweight reference-video hierarchy

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuAppShell.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/LuoShuAppShell.kt
@@ -213,7 +213,7 @@ internal fun LuoShuAppShell(
         val blurActive = appearance.blurEnabled && appearance.glassEnabled
         val hazeState = rememberHazeState(blurEnabled = blurActive)
         val navigationBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-        val dockClearance = navigationBottom + if (appearance.floatingDock) 84.dp else 68.dp
+        val dockClearance = navigationBottom + if (appearance.floatingDock) 74.dp else 62.dp
         val underlayOffset by animateDpAsState(
             targetValue = if (logsSheetVisible) (-12).dp else 0.dp,
             animationSpec = tween(300, easing = LuoShuStandardEasing),
@@ -404,8 +404,6 @@ private fun AppBackdrop(appearance: AppearanceSettings, dark: Boolean) {
             .background(Brush.verticalGradient(base))
             .drawBehind {
                 if (miuix) {
-                    // A subtle accent field behind the floating dock gives Haze real pixels to
-                    // sample instead of blurring a perfectly flat page background.
                     drawRect(
                         Brush.radialGradient(
                             listOf(
@@ -457,7 +455,7 @@ private fun MaterialAppDock(
     val dark = scheme.background.luminance() < .5f
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val floating = appearance.floatingDock
-    val shape = if (floating) RoundedCornerShape(30.dp) else RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp)
+    val shape = if (floating) RoundedCornerShape(24.dp) else RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
     val activeHaze = appearance.blurEnabled && appearance.glassEnabled
     val hazeModifier = if (activeHaze) {
         Modifier.hazeEffect(state = hazeState, style = HazeMaterials.ultraThin()) {
@@ -470,11 +468,11 @@ private fun MaterialAppDock(
         pages = dockPages,
         current = current,
         onSelect = onSelect,
-        itemHeight = 58.dp,
+        itemHeight = 48.dp,
         modifier = modifier
-            .then(if (floating) Modifier.padding(horizontal = 16.dp).padding(bottom = bottomInset + 10.dp) else Modifier)
+            .then(if (floating) Modifier.padding(horizontal = 18.dp).padding(bottom = bottomInset + 8.dp) else Modifier)
             .fillMaxWidth()
-            .shadow(if (floating) 14.dp else 6.dp, shape, clip = false)
+            .shadow(if (floating) 8.dp else 4.dp, shape, clip = false)
             .clip(shape)
             .then(hazeModifier)
             .background(
@@ -485,8 +483,8 @@ private fun MaterialAppDock(
                 },
             )
             .border(1.dp, if (dark) Color.White.copy(alpha = .12f) else Color.White.copy(alpha = .72f), shape)
-            .padding(start = 6.dp, top = 6.dp, end = 6.dp, bottom = if (floating) 6.dp else bottomInset + 6.dp),
-        indicatorColor = scheme.primaryContainer.copy(alpha = .64f),
+            .padding(start = 4.dp, top = 4.dp, end = 4.dp, bottom = if (floating) 4.dp else bottomInset + 4.dp),
+        indicatorColor = scheme.primaryContainer.copy(alpha = .48f),
         selectedColor = scheme.primary,
         unselectedColor = scheme.onSurfaceVariant,
         label = "luoshuMaterialDockIndicator",
@@ -507,28 +505,28 @@ private fun MiuixAppDock(
     val dark = scheme.background.luminance() < .5f
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val floating = appearance.floatingDock
-    val shape = if (floating) RoundedCornerShape(29.dp) else RoundedCornerShape(topStart = 29.dp, topEnd = 29.dp)
+    val shape = if (floating) RoundedCornerShape(24.dp) else RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
     val activeGlass = appearance.glassEnabled
     val activeHaze = activeGlass && appearance.blurEnabled
     val hazeModifier = if (activeHaze) {
         Modifier.hazeEffect(state = hazeState, style = HazeMaterials.ultraThin()) {
-            blurRadius = 36.dp
-            noiseFactor = .06f
+            blurRadius = 30.dp
+            noiseFactor = .04f
         }
     } else Modifier
     val glassBrush = when {
         activeGlass && dark -> Brush.verticalGradient(
             listOf(
-                Color.White.copy(alpha = .16f),
-                tokens.elevatedCardBackground.copy(alpha = .22f),
-                scheme.primary.copy(alpha = .10f),
+                Color.White.copy(alpha = .13f),
+                tokens.elevatedCardBackground.copy(alpha = .20f),
+                scheme.primary.copy(alpha = .07f),
             ),
         )
         activeGlass -> Brush.verticalGradient(
             listOf(
-                Color.White.copy(alpha = .72f),
-                Color.White.copy(alpha = .30f),
-                scheme.primary.copy(alpha = .10f),
+                Color.White.copy(alpha = .62f),
+                Color.White.copy(alpha = .26f),
+                scheme.primary.copy(alpha = .07f),
             ),
         )
         else -> Brush.verticalGradient(
@@ -540,61 +538,45 @@ private fun MiuixAppDock(
         pages = dockPages,
         current = current,
         onSelect = onSelect,
-        itemHeight = 56.dp,
+        itemHeight = 48.dp,
         modifier = modifier
-            .then(if (floating) Modifier.padding(horizontal = 14.dp).padding(bottom = bottomInset + 8.dp) else Modifier)
+            .then(if (floating) Modifier.padding(horizontal = 18.dp).padding(bottom = bottomInset + 8.dp) else Modifier)
             .fillMaxWidth()
-            .shadow(if (floating) if (activeGlass) 20.dp else 12.dp else 5.dp, shape, clip = false)
+            .shadow(if (floating) if (activeGlass) 8.dp else 6.dp else 3.dp, shape, clip = false)
             .clip(shape)
             .then(hazeModifier)
             .background(glassBrush)
             .drawBehind {
                 if (activeGlass) {
-                    val radius = 29.dp.toPx()
+                    val radius = 24.dp.toPx()
                     drawRoundRect(
                         brush = Brush.linearGradient(
                             colors = listOf(
-                                Color.White.copy(alpha = if (dark) .34f else .90f),
+                                Color.White.copy(alpha = if (dark) .28f else .76f),
                                 Color.Transparent,
-                                scheme.primary.copy(alpha = if (dark) .16f else .13f),
+                                scheme.primary.copy(alpha = if (dark) .12f else .09f),
                             ),
                             start = Offset.Zero,
                             end = Offset(size.width, size.height),
                         ),
                         cornerRadius = CornerRadius(radius, radius),
-                        style = Stroke(width = 1.2.dp.toPx()),
-                    )
-                    drawLine(
-                        color = Color.White.copy(alpha = if (dark) .24f else .68f),
-                        start = Offset(radius * .78f, 1.4.dp.toPx()),
-                        end = Offset(size.width - radius * .78f, 1.4.dp.toPx()),
-                        strokeWidth = .9.dp.toPx(),
+                        style = Stroke(width = .8.dp.toPx()),
                     )
                 }
             }
             .border(
-                if (activeGlass) .7.dp else 1.dp,
+                if (activeGlass) .6.dp else 1.dp,
                 if (activeGlass) {
-                    if (dark) Color.White.copy(alpha = .18f) else Color.White.copy(alpha = .76f)
-                } else if (dark) Color.White.copy(alpha = .10f) else Color.White.copy(alpha = .58f),
+                    if (dark) Color.White.copy(alpha = .14f) else Color.White.copy(alpha = .58f)
+                } else if (dark) Color.White.copy(alpha = .10f) else Color.White.copy(alpha = .48f),
                 shape,
             )
-            .padding(start = 5.dp, top = 5.dp, end = 5.dp, bottom = if (floating) 5.dp else bottomInset + 5.dp),
-        indicatorColor = scheme.primary.copy(
-            alpha = if (activeGlass) {
-                if (dark) .18f else .12f
-            } else {
-                if (dark) .20f else .12f
-            },
-        ),
-        indicatorBorderColor = if (activeGlass) {
-            scheme.primary.copy(alpha = if (dark) .30f else .20f)
-        } else {
-            Color.Transparent
-        },
+            .padding(start = 4.dp, top = 4.dp, end = 4.dp, bottom = if (floating) 4.dp else bottomInset + 4.dp),
+        indicatorColor = scheme.primary.copy(alpha = if (dark) .16f else .10f),
+        indicatorBorderColor = if (activeGlass) scheme.primary.copy(alpha = if (dark) .24f else .14f) else Color.Transparent,
         indicatorShadow = 0.dp,
         selectedColor = scheme.primary,
-        unselectedColor = scheme.onSurfaceVariant.copy(alpha = .82f),
+        unselectedColor = scheme.onSurfaceVariant.copy(alpha = .78f),
         label = "luoshuMiuixDockIndicator",
     )
 }
@@ -618,18 +600,18 @@ private fun AppDockLayout(
         val targetIndex = pages.indexOf(current).coerceAtLeast(0)
         val indicatorX by animateDpAsState(
             targetValue = itemWidth * targetIndex.toFloat(),
-            animationSpec = tween(240, easing = LuoShuStandardEasing),
+            animationSpec = tween(220, easing = LuoShuStandardEasing),
             label = label,
         )
         Box(
             modifier = Modifier
-                .offset(x = indicatorX + 5.dp)
-                .width(itemWidth - 10.dp)
+                .offset(x = indicatorX + 4.dp)
+                .width(itemWidth - 8.dp)
                 .height(itemHeight)
-                .shadow(indicatorShadow, RoundedCornerShape(20.dp), clip = false)
-                .clip(RoundedCornerShape(20.dp))
+                .shadow(indicatorShadow, RoundedCornerShape(16.dp), clip = false)
+                .clip(RoundedCornerShape(16.dp))
                 .background(indicatorColor)
-                .border(1.dp, indicatorBorderColor, RoundedCornerShape(20.dp)),
+                .border(1.dp, indicatorBorderColor, RoundedCornerShape(16.dp)),
         )
         Row(Modifier.fillMaxWidth()) {
             pages.forEach { page ->
@@ -638,7 +620,7 @@ private fun AppDockLayout(
                     modifier = Modifier
                         .width(itemWidth)
                         .height(itemHeight)
-                        .clip(RoundedCornerShape(20.dp))
+                        .clip(RoundedCornerShape(16.dp))
                         .clickable { onSelect(page) },
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center,
@@ -646,15 +628,15 @@ private fun AppDockLayout(
                     Icon(
                         page.icon,
                         contentDescription = page.label,
-                        modifier = Modifier.size(if (selected) 22.dp else 20.dp),
+                        modifier = Modifier.size(if (selected) 20.dp else 19.dp),
                         tint = if (selected) selectedColor else unselectedColor,
                     )
-                    Spacer(Modifier.height(2.dp))
+                    Spacer(Modifier.height(1.dp))
                     Text(
                         page.label,
                         color = if (selected) selectedColor else unselectedColor,
-                        fontSize = 11.sp,
-                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+                        fontSize = 10.sp,
+                        fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
                         maxLines = 1,
                     )
                 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeRoute.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeRoute.kt
@@ -44,7 +44,7 @@ fun HomeRoute(
         }
     }
 
-    HomeScreenCompact(
+    HomeScreenVideoExact(
         style = style,
         state = state,
         actions = actions,

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeScreenVideoExact.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeScreenVideoExact.kt
@@ -1,0 +1,713 @@
+package io.github.xgl34222220.luoshu.ui.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.FontDownload
+import androidx.compose.material.icons.rounded.Layers
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.RestartAlt
+import androidx.compose.material.icons.rounded.Restore
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.Speed
+import androidx.compose.material.icons.rounded.TaskAlt
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
+import io.github.xgl34222220.luoshu.ui.theme.LocalLuoShuTokens
+
+private val PagePadding = 12.dp
+private val GroupRadius = 22.dp
+private val RowHeight = 58.dp
+
+@Composable
+@Suppress("UNUSED_PARAMETER")
+internal fun HomeScreenVideoExact(
+    style: UiStyle,
+    state: HomeUiState,
+    actions: HomeActions,
+    trustContent: @Composable () -> Unit,
+) {
+    val tokens = LocalLuoShuTokens.current
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(
+            start = PagePadding,
+            top = 10.dp,
+            end = PagePadding,
+            bottom = 104.dp,
+        ),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        item { HomeHeader(state = state, actions = actions) }
+        item { EngineSummary(state = state, actions = actions) }
+        item { trustContent() }
+
+        if (state.error.isNotBlank()) {
+            item {
+                MessageRow(
+                    icon = Icons.Rounded.Warning,
+                    title = "字体引擎需要处理",
+                    message = state.error,
+                    tint = tokens.danger,
+                    action = "查看",
+                    onClick = actions.openLogs,
+                )
+            }
+        }
+
+        item { SectionTitle("设备状态") }
+        item { DeviceStatusGroup(state = state, actions = actions) }
+
+        item { SectionTitle("下一步") }
+        item { NextStepGroup(next = nextStepFor(state, actions)) }
+
+        item { SectionTitle("全局粗细") }
+        item { WeightGroup(weight = state.systemWeight, actions = actions) }
+    }
+}
+
+@Composable
+private fun HomeHeader(state: HomeUiState, actions: HomeActions) {
+    val tokens = LocalLuoShuTokens.current
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(start = 4.dp, end = 2.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = "洛书",
+                color = tokens.textPrimary,
+                fontSize = 28.sp,
+                lineHeight = 34.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+            )
+            Text(
+                text = "无 Hook 全局字体引擎 · ${state.version}",
+                color = tokens.textSecondary,
+                fontSize = 13.sp,
+                lineHeight = 18.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        HeaderAction(
+            icon = Icons.Rounded.Refresh,
+            description = "刷新",
+            enabled = !state.loading,
+            onClick = actions.refresh,
+            loading = state.loading,
+        )
+        Spacer(Modifier.width(8.dp))
+        HeaderAction(
+            icon = Icons.Rounded.Settings,
+            description = "设置",
+            onClick = actions.openSettings,
+        )
+    }
+}
+
+@Composable
+private fun HeaderAction(
+    icon: ImageVector,
+    description: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    loading: Boolean = false,
+) {
+    val tokens = LocalLuoShuTokens.current
+    Surface(
+        modifier = Modifier.size(44.dp).clickable(enabled = enabled, onClick = onClick),
+        shape = RoundedCornerShape(15.dp),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = .94f),
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            if (loading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            } else {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = description,
+                    tint = tokens.textPrimary.copy(alpha = if (enabled) 1f else .38f),
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EngineSummary(state: HomeUiState, actions: HomeActions) {
+    val tokens = LocalLuoShuTokens.current
+    val healthy = state.moduleInstalled && state.rootGranted && state.mountHealthy
+    val statusColor = when {
+        state.error.isNotBlank() -> tokens.danger
+        state.rebootRequired -> tokens.warning
+        healthy -> tokens.success
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val statusText = when {
+        state.taskRunning -> "任务执行中"
+        state.rebootRequired -> "等待完整重启"
+        healthy -> "字体引擎运行正常"
+        else -> "正在检查运行环境"
+    }
+
+    VideoGroup {
+        Column(Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 15.dp, end = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(Modifier.size(7.dp).background(statusColor, CircleShape))
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = statusText,
+                    color = statusColor,
+                    fontSize = 13.sp,
+                    lineHeight = 18.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f),
+                )
+                Surface(
+                    modifier = Modifier.size(40.dp),
+                    shape = CircleShape,
+                    color = statusColor.copy(alpha = .10f),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        if (state.taskRunning) {
+                            CircularProgressIndicator(
+                                progress = { state.taskProgress.coerceIn(0, 100) / 100f },
+                                modifier = Modifier.size(25.dp),
+                                color = statusColor,
+                                trackColor = statusColor.copy(alpha = .13f),
+                                strokeWidth = 3.dp,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = if (state.error.isBlank()) Icons.Rounded.CheckCircle else Icons.Rounded.Warning,
+                                contentDescription = null,
+                                tint = statusColor,
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
+                    }
+                }
+            }
+
+            Column(Modifier.padding(start = 16.dp, top = 4.dp, end = 16.dp, bottom = 13.dp)) {
+                Text(
+                    text = state.currentFont,
+                    color = tokens.textPrimary,
+                    fontSize = 26.sp,
+                    lineHeight = 32.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = state.taskMessage.ifBlank { state.taskTitle },
+                    color = tokens.textSecondary,
+                    fontSize = 12.sp,
+                    lineHeight = 17.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (state.taskRunning) {
+                    Spacer(Modifier.height(10.dp))
+                    LinearProgressIndicator(
+                        progress = { state.taskProgress.coerceIn(0, 100) / 100f },
+                        modifier = Modifier.fillMaxWidth().height(4.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                        trackColor = MaterialTheme.colorScheme.primary.copy(alpha = .10f),
+                    )
+                }
+            }
+
+            SoftDivider()
+            Row(Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 3.dp)) {
+                PlainAction(
+                    modifier = Modifier.weight(1f),
+                    icon = Icons.Rounded.Refresh,
+                    label = "刷新",
+                    onClick = actions.refresh,
+                    enabled = !state.loading,
+                )
+                VerticalSoftDivider()
+                PlainAction(
+                    modifier = Modifier.weight(1f),
+                    icon = Icons.Rounded.Restore,
+                    label = "恢复",
+                    tint = tokens.danger,
+                    onClick = actions.restoreDefault,
+                    enabled = !state.taskRunning,
+                )
+                VerticalSoftDivider()
+                PlainAction(
+                    modifier = Modifier.weight(1f),
+                    icon = if (state.rebootRequired) Icons.Rounded.RestartAlt else Icons.Rounded.Description,
+                    label = if (state.rebootRequired) "重启" else "任务",
+                    tint = if (state.rebootRequired) tokens.warning else MaterialTheme.colorScheme.primary,
+                    onClick = if (state.rebootRequired) actions.reboot else actions.openLogs,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlainAction(
+    modifier: Modifier,
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    tint: Color = MaterialTheme.colorScheme.primary,
+) {
+    val tokens = LocalLuoShuTokens.current
+    Row(
+        modifier = modifier.height(46.dp).clickable(enabled = enabled, onClick = onClick),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = tint.copy(alpha = if (enabled) 1f else .38f),
+            modifier = Modifier.size(19.dp),
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text = label,
+            color = tokens.textPrimary.copy(alpha = if (enabled) .88f else .38f),
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun DeviceStatusGroup(state: HomeUiState, actions: HomeActions) {
+    val tokens = LocalLuoShuTokens.current
+    VideoGroup {
+        Column {
+            StatusRow(
+                icon = Icons.Rounded.Security,
+                title = "Root 权限",
+                subtitle = if (state.rootGranted) "字体事务权限已获得" else "需要授予 Root 权限",
+                value = if (state.rootGranted) state.rootManager else "未授权",
+                tint = if (state.rootGranted) tokens.success else tokens.danger,
+            )
+            SoftDivider(indented = true)
+            StatusRow(
+                icon = Icons.Rounded.Layers,
+                title = "挂载引擎",
+                subtitle = if (state.mountHealthy) "当前挂载链工作正常" else "挂载链需要检查",
+                value = state.mountEngine,
+                tint = if (state.mountHealthy) tokens.success else tokens.warning,
+            )
+            SoftDivider(indented = true)
+            StatusRow(
+                icon = Icons.Rounded.TaskAlt,
+                title = "当前任务",
+                subtitle = state.taskMessage.ifBlank { "暂无后台字体任务" },
+                value = if (state.taskRunning) "${state.taskProgress}%" else "空闲",
+                tint = if (state.taskRunning) MaterialTheme.colorScheme.primary else tokens.success,
+                onClick = actions.openLogs,
+            )
+            SoftDivider(indented = true)
+            StatusRow(
+                icon = Icons.Rounded.RestartAlt,
+                title = "重启状态",
+                subtitle = if (state.rebootRequired) "重启后应用并验证字体" else "本次操作无需重启",
+                value = if (state.rebootRequired) "等待重启" else "无需重启",
+                tint = if (state.rebootRequired) tokens.warning else tokens.success,
+                onClick = if (state.rebootRequired) actions.reboot else null,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    value: String,
+    tint: Color,
+    onClick: (() -> Unit)? = null,
+) {
+    val tokens = LocalLuoShuTokens.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = RowHeight)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 14.dp, vertical = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Surface(
+            modifier = Modifier.size(36.dp),
+            shape = RoundedCornerShape(12.dp),
+            color = tint.copy(alpha = .09f),
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(20.dp))
+            }
+        }
+        Spacer(Modifier.width(11.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = tokens.textPrimary,
+                fontSize = 15.sp,
+                lineHeight = 19.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+            )
+            Text(
+                text = subtitle,
+                color = tokens.textSecondary,
+                fontSize = 11.sp,
+                lineHeight = 16.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text = value,
+            color = MaterialTheme.colorScheme.primary,
+            fontSize = 12.sp,
+            lineHeight = 17.sp,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.End,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.widthIn(max = 130.dp),
+        )
+    }
+}
+
+private data class NextStep(
+    val title: String,
+    val description: String,
+    val actionLabel: String,
+    val icon: ImageVector,
+    val tint: Color? = null,
+    val enabled: Boolean = true,
+    val onClick: () -> Unit,
+)
+
+@Composable
+private fun NextStepGroup(next: NextStep) {
+    val tokens = LocalLuoShuTokens.current
+    val tint = next.tint ?: MaterialTheme.colorScheme.primary
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(enabled = next.enabled, onClick = next.onClick),
+        shape = RoundedCornerShape(GroupRadius),
+        color = MaterialTheme.colorScheme.primary.copy(alpha = .075f),
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Surface(
+                modifier = Modifier.size(40.dp),
+                shape = RoundedCornerShape(13.dp),
+                color = tint.copy(alpha = .10f),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(next.icon, contentDescription = null, tint = tint, modifier = Modifier.size(22.dp))
+                }
+            }
+            Spacer(Modifier.width(11.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = next.title,
+                    color = tokens.textPrimary,
+                    fontSize = 15.sp,
+                    lineHeight = 20.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = next.description,
+                    color = tokens.textSecondary,
+                    fontSize = 11.sp,
+                    lineHeight = 16.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = next.actionLabel,
+                color = tint,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.End,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WeightGroup(weight: HomeWeightUiState, actions: HomeActions) {
+    val tokens = LocalLuoShuTokens.current
+    VideoGroup {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(
+                    modifier = Modifier.size(36.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = .09f),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            Icons.Rounded.Speed,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
+                Spacer(Modifier.width(11.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = "系统字体粗细",
+                        color = tokens.textPrimary,
+                        fontSize = 15.sp,
+                        lineHeight = 20.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+                    Text(
+                        text = "仅调整系统渲染参数",
+                        color = tokens.textSecondary,
+                        fontSize = 11.sp,
+                        lineHeight = 16.sp,
+                    )
+                }
+                Surface(
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = .08f),
+                ) {
+                    Text(
+                        text = weight.weight.toString(),
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(7.dp))
+            when {
+                weight.loading -> LinearProgressIndicator(Modifier.fillMaxWidth())
+                !weight.supported -> Text(
+                    text = weight.error.ifBlank { "当前系统不支持全局粗细微调" },
+                    color = tokens.danger,
+                    fontSize = 11.sp,
+                    lineHeight = 16.sp,
+                )
+                else -> {
+                    Slider(
+                        value = weight.weight.toFloat(),
+                        onValueChange = actions.previewSystemWeight,
+                        enabled = !weight.applying,
+                        valueRange = weight.min.toFloat()..weight.max.toFloat(),
+                        steps = (((weight.max - weight.min) / weight.step) - 1).coerceAtLeast(0),
+                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = weight.error.ifBlank { weight.message },
+                            modifier = Modifier.weight(1f),
+                            color = if (weight.error.isNotBlank()) tokens.danger else tokens.textSecondary,
+                            fontSize = 11.sp,
+                            lineHeight = 16.sp,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        TextButton(onClick = actions.resetSystemWeight, enabled = !weight.applying) {
+                            Text("恢复原始", fontSize = 12.sp)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MessageRow(
+    icon: ImageVector,
+    title: String,
+    message: String,
+    tint: Color,
+    action: String,
+    onClick: () -> Unit,
+) {
+    val tokens = LocalLuoShuTokens.current
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        shape = RoundedCornerShape(18.dp),
+        color = tint.copy(alpha = .075f),
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 13.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.width(10.dp))
+            Column(Modifier.weight(1f)) {
+                Text(title, color = tokens.textPrimary, fontSize = 13.sp, fontWeight = FontWeight.Medium)
+                Text(
+                    message,
+                    color = tokens.textSecondary,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Text(action, color = tint, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    val tokens = LocalLuoShuTokens.current
+    Text(
+        text = text,
+        color = tokens.textPrimary,
+        fontSize = 18.sp,
+        lineHeight = 23.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(start = 4.dp, top = 7.dp, bottom = 1.dp),
+    )
+}
+
+@Composable
+private fun VideoGroup(content: @Composable () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(GroupRadius),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = .96f),
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp,
+        content = content,
+    )
+}
+
+@Composable
+private fun SoftDivider(indented: Boolean = false) {
+    val tokens = LocalLuoShuTokens.current
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .padding(start = if (indented) 61.dp else 0.dp, end = 14.dp)
+            .height(1.dp)
+            .background(tokens.outline.copy(alpha = .12f)),
+    )
+}
+
+@Composable
+private fun VerticalSoftDivider() {
+    val tokens = LocalLuoShuTokens.current
+    Box(Modifier.width(1.dp).height(22.dp).background(tokens.outline.copy(alpha = .14f)))
+}
+
+private fun nextStepFor(state: HomeUiState, actions: HomeActions): NextStep = when {
+    !state.moduleInstalled -> NextStep(
+        title = "连接洛书模块",
+        description = "安装模块并授予 Root 权限后才能应用全局字体",
+        actionLabel = "检查",
+        icon = Icons.Rounded.Refresh,
+        onClick = actions.refresh,
+    )
+    state.taskRunning -> NextStep(
+        title = "字体任务正在处理",
+        description = state.taskMessage.ifBlank { "后台任务会继续运行" },
+        actionLabel = "任务",
+        icon = Icons.Rounded.Description,
+        onClick = actions.openLogs,
+    )
+    state.rebootRequired -> NextStep(
+        title = "字体已经准备完成",
+        description = "完整重启后应用并自动验证字体",
+        actionLabel = "重启",
+        icon = Icons.Rounded.RestartAlt,
+        onClick = actions.reboot,
+    )
+    state.error.isNotBlank() -> NextStep(
+        title = "发现需要处理的问题",
+        description = "打开任务中心查看原因和诊断信息",
+        actionLabel = "查看",
+        icon = Icons.Rounded.Warning,
+        onClick = actions.openLogs,
+    )
+    state.currentFont.contains("系统") -> NextStep(
+        title = "选择一款字体",
+        description = "从字体库导入、预览并应用字体",
+        actionLabel = "字体库",
+        icon = Icons.Rounded.FontDownload,
+        onClick = actions.openFontLibrary,
+    )
+    else -> NextStep(
+        title = "继续调整当前字体",
+        description = "组合中文、英文和数字字体",
+        actionLabel = "组合",
+        icon = Icons.Rounded.Layers,
+        onClick = actions.openFontStudio,
+    )
+}

--- a/scripts/font_library_ui_layout_test.sh
+++ b/scripts/font_library_ui_layout_test.sh
@@ -6,7 +6,7 @@ MATERIAL="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/li
 ROUTE="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryRoute.kt"
 COMPACT="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryScreenCompact.kt"
 HOME_ROUTE="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeRoute.kt"
-HOME_COMPACT="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeScreenCompact.kt"
+HOME_COMPACT="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeScreenVideoExact.kt"
 ACCEPTANCE="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/DeviceAcceptanceGuide.kt"
 MATRIX="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/DeviceTestMatrix.kt"
 LOGS_ROUTE="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsRoute.kt"
@@ -24,16 +24,15 @@ COMPONENTS="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/
 UTIL="$ROOT/common/util_functions.sh"
 CACHE="$ROOT/common/device_font_cache.sh"
 
-# Legacy style screens stay available as a rollback path while the routes use the
-# shared compact hierarchy.
+# Legacy style screens remain as rollback paths while active routes use the
+# compact business hierarchy.
 grep -q 'private fun MiuixCapabilityStrip' "$MIUIX"
 grep -q 'private fun MaterialCapabilityStrip' "$MATERIAL"
 grep -q 'FontLibraryScreenCompact' "$ROUTE"
-grep -q 'HomeScreenCompact' "$HOME_ROUTE"
+grep -q 'HomeScreenVideoExact' "$HOME_ROUTE"
 grep -q 'LogsScreenCompact' "$LOGS_ROUTE"
 
-# Font library: management tools are collapsed, the card itself opens details,
-# and the default row is compact rather than a 102 dp showcase card.
+# Font library keeps its compact management hierarchy.
 grep -q 'var showTools' "$COMPACT"
 grep -q '导入与管理' "$COMPACT"
 grep -q 'CompactFontRow' "$COMPACT"
@@ -41,11 +40,20 @@ grep -q 'NativeFontPreview' "$COMPACT"
 grep -q 'clickable(onClick = onDetails)' "$COMPACT"
 ! grep -q 'height(102.dp)' "$COMPACT"
 
-# Home: one dynamic next action replaces duplicate navigation shortcuts and the
-# trust chip participates in normal layout rather than using a fixed 108 dp offset.
-grep -q 'HomeNextStep' "$HOME_COMPACT"
+# Home follows the lightweight reference-video hierarchy: one calm status card,
+# grouped setting rows and no dashboard grid, giant status orb or heavy card stack.
+grep -q 'private val PagePadding = 12.dp' "$HOME_COMPACT"
+grep -q 'private val GroupRadius = 22.dp' "$HOME_COMPACT"
+grep -q 'bottom = 104.dp' "$HOME_COMPACT"
+grep -q 'private fun EngineSummary' "$HOME_COMPACT"
+grep -q 'private fun DeviceStatusGroup' "$HOME_COMPACT"
+grep -q 'private fun StatusRow' "$HOME_COMPACT"
+grep -q 'private fun VideoGroup' "$HOME_COMPACT"
 grep -q '继续调整当前字体' "$HOME_COMPACT"
-grep -q '打开任务中心查看错误原因' "$HOME_COMPACT"
+grep -q '打开任务中心查看原因和诊断信息' "$HOME_COMPACT"
+! grep -q 'StatusOrb' "$HOME_COMPACT"
+! grep -q 'LuoShuMetricTile' "$HOME_COMPACT"
+! grep -q 'LuoShuPageHeader' "$HOME_COMPACT"
 ! grep -q 'QUICK ACCESS' "$HOME_COMPACT"
 ! grep -q 'bottom = 108.dp' "$HOME_ROUTE"
 
@@ -62,20 +70,15 @@ grep -q '加载验证失败，请打开问题页查看具体失败分区' "$ACCE
 ! grep -q 'v2.2.2' "$MATRIX"
 ! grep -q 'v2.2.2' "$ACCEPTANCE"
 
-# ROM detection is a state fact, not a polling log. Existing duplicate records
-# are compacted once and new entries are emitted only when the detected version changes.
+# ROM detection and detached cache workers keep their existing contracts.
 grep -q 'compact_rom_detection_logs' "$UTIL"
 grep -q 'log_rom_detection_once coloros' "$UTIL"
 grep -q 'log_rom_detection_once hyperos' "$UTIL"
-
-# A detached background cache worker must load the transaction and mount layers
-# itself before activating a generated payload.
 grep -q 'device_font_transaction_guard.sh' "$CACHE"
 grep -q 'mount_compat.sh' "$CACHE"
 grep -q 'type luoshu_sync_mount_payload' "$CACHE"
 
-# Task center separates user-facing tasks/issues from raw logs. It is opened as
-# a right-side rounded sheet and uses the common 48 dp icon-button hit target.
+# Task center remains a right-side rounded sheet.
 grep -q 'enum class LogsTab' "$LOGS_COMPACT"
 grep -q 'TASKS("任务")' "$LOGS_COMPACT"
 grep -q 'ISSUES("问题")' "$LOGS_COMPACT"
@@ -87,8 +90,7 @@ grep -q 'onClose: (() -> Unit)? = null' "$LOGS_ROUTE"
 grep -q 'LuoShuSideSheet' "$SHELL"
 grep -q 'logsSheetVisible' "$SHELL"
 
-# Studio uses one in-flow final action. Both title actions share one Row and the
-# viewport ends above the floating dock instead of drawing cards under it.
+# Studio uses one in-flow final action and ends above the floating dock.
 grep -q 'MiuixFinalAction(state, actions)' "$STUDIO_MIUIX"
 grep -q 'MaterialFinalAction(state, actions)' "$STUDIO_MATERIAL"
 grep -q 'topAction: @Composable () -> Unit' "$STUDIO_MIUIX"
@@ -108,8 +110,7 @@ grep -q 'padding(bottom = dockClearance)' "$SHELL"
 grep -q 'RoundedCornerShape(22.dp)' "$STUDIO_MIUIX"
 grep -q 'RoundedCornerShape(22.dp)' "$STUDIO_MATERIAL"
 
-# Unified design system: business pages consume semantic tokens and shared
-# components instead of maintaining separate visual constants.
+# Unified design tokens and shared components remain available.
 grep -q 'data class LuoShuTokens' "$THEME"
 grep -q 'pageBackground = Color(0xFFECEBFA)' "$THEME"
 grep -q 'dark -> Color(0xFF11131A)' "$THEME"
@@ -124,32 +125,32 @@ grep -q 'fun LuoShuSideSheet' "$COMPONENTS"
 grep -q 'val sheetWidth = maxWidth \* .94f' "$COMPONENTS"
 grep -q 'topStart = tokens.sideSheetRadius' "$COMPONENTS"
 grep -q 'tween(300, easing = LuoShuEnterEasing)' "$COMPONENTS"
-grep -q 'LuoShuPageHeader' "$HOME_COMPACT"
+! grep -q 'LuoShuPageHeader' "$HOME_COMPACT"
 grep -q 'LuoShuPageHeader' "$COMPACT"
 grep -q 'LuoShuPageHeader' "$STUDIO_MIUIX"
 grep -q 'LuoShuPageHeader' "$STUDIO_MATERIAL"
 
-# Four stable primary destinations. Settings stays in the dock; task/log details
-# and nested theme settings temporarily hide it and preserve the underlay.
+# Four stable primary destinations with a compact glass dock.
 grep -q 'private val dockPages' "$SHELL"
 [ "$(sed -n '/private val dockPages = listOf(/,/^)/p' "$SHELL" | grep -c 'AppPage\.')" -eq 4 ]
 grep -q 'Settings("设置", Icons.Rounded.Settings)' "$SHELL"
 ! grep -q 'Logs("' "$SHELL"
 grep -q 'if (!logsSheetVisible && !settingsThemeOpen)' "$SHELL"
 grep -q 'targetValue = if (logsSheetVisible) (-12).dp else 0.dp' "$SHELL"
-grep -q 'fontSize = 11.sp' "$SHELL"
+grep -q 'itemHeight = 48.dp' "$SHELL"
+grep -q 'fontSize = 10.sp' "$SHELL"
+grep -q 'RoundedCornerShape(16.dp)' "$SHELL"
 grep -q 'private fun MiuixAppDock' "$SHELL"
 MIUIX_DOCK=$(sed -n '/private fun MiuixAppDock/,/private fun AppDockLayout/p' "$SHELL")
 printf '%s\n' "$MIUIX_DOCK" | grep -q 'hazeEffect'
-printf '%s\n' "$MIUIX_DOCK" | grep -q 'blurRadius = 36.dp'
+printf '%s\n' "$MIUIX_DOCK" | grep -q 'blurRadius = 30.dp'
 printf '%s\n' "$MIUIX_DOCK" | grep -q 'activeGlass'
 printf '%s\n' "$MIUIX_DOCK" | grep -q 'drawRoundRect'
 printf '%s\n' "$MIUIX_DOCK" | grep -q 'indicatorBorderColor'
 printf '%s\n' "$MIUIX_DOCK" | grep -q 'indicatorShadow = 0.dp'
-printf '%s\n' "$MIUIX_DOCK" | grep -q 'scheme.primary.copy(alpha = if (dark) .30f else .20f)'
+printf '%s\n' "$MIUIX_DOCK" | grep -q 'scheme.primary.copy(alpha = if (dark) .24f else .14f)'
 
-# Settings is a grouped overview plus a nested animated theme page. All style,
-# Monet, dark, pure-black and glass options stay in one shared page hierarchy.
+# Settings and native import hierarchy remain intact.
 grep -q 'showThemeSettings: Boolean = false' "$SETTINGS"
 grep -q 'ThemeSettingsPage' "$SETTINGS"
 grep -q 'title = "主题设置"' "$SETTINGS"
@@ -164,4 +165,4 @@ grep -q 'embedded = true' "$SHELL"
 grep -q 'dockClearance' "$SHELL"
 ! grep -q 'if (page == AppPage.Studio)' "$SHELL"
 
-echo 'LuoShu unified V1.1 UI layout regression passed.'
+echo 'LuoShu lightweight reference-video UI layout regression passed.'


### PR DESCRIPTION
## 结论
本手写组件方案停止继续迭代，未合并 main。

## 原因
继续自定义页面、卡片、按钮和底栏会重复产生尺寸失衡、层级过重和真机适配问题。后续改用成熟 Miuix 组件库作为主体，MaterialKolor 负责 Monet，Haze 仅用于底栏与侧滑层玻璃效果。

main 未包含本 PR 的 UI 改动。