### PR TITLE
refactor(ui): rebuild LuoShu with separate Miuix and Material themes

### DIFF
--- a/.github/workflows/ui-apk-refresh.yml
+++ b/.github/workflows/ui-apk-refresh.yml
@@ -1,0 +1,82 @@
+name: Refresh bundled UI APK
+
+on:
+  push:
+    branches:
+      - ui-miuix-library-rebuild
+    paths:
+      - 'android-app/**'
+      - '.github/workflows/ui-apk-refresh.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: luoshu-ui-apk-refresh-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-signed-apk:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: android-actions/setup-android@v3
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '9.5.0'
+
+      - name: Restore release signing key
+        shell: bash
+        env:
+          KEYSTORE_BASE64: ${{ secrets.LUOSHU_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.LUOSHU_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.LUOSHU_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+          for value in KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS; do
+            [[ -n "${!value}" ]] || { echo "Missing signing secret: $value" >&2; exit 3; }
+          done
+          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/luoshu-release.jks"
+          keytool -list -keystore "$RUNNER_TEMP/luoshu-release.jks" \
+            -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" >/dev/null
+
+      - name: Build signed release APK
+        working-directory: android-app
+        env:
+          LUOSHU_KEYSTORE_FILE: ${{ runner.temp }}/luoshu-release.jks
+          LUOSHU_KEYSTORE_PASSWORD: ${{ secrets.LUOSHU_KEYSTORE_PASSWORD }}
+          LUOSHU_KEY_ALIAS: ${{ secrets.LUOSHU_KEY_ALIAS }}
+          LUOSHU_KEY_PASSWORD: ${{ secrets.LUOSHU_KEY_PASSWORD }}
+        run: gradle --no-daemon --stacktrace :app:assembleRelease
+
+      - name: Verify signed APK
+        shell: bash
+        env:
+          EXPECTED_CERT_SHA256: e0043b560a10111d3ffddd3a7afba680b854e14ed793c7a3fdb7f8b7aa95ff27
+        run: |
+          set -euo pipefail
+          apk='android-app/app/build/outputs/apk/release/app-release.apk'
+          test -s "$apk"
+          apksigner="$(find "$ANDROID_HOME/build-tools" -type f -name apksigner | sort -V | tail -n1)"
+          "$apksigner" verify --verbose --print-certs "$apk" | tee "$RUNNER_TEMP/apk-signature.txt"
+          actual_cert="$(awk -F': ' '/Signer.*certificate SHA-256 digest:/ {print $NF; exit}' "$RUNNER_TEMP/apk-signature.txt" | tr -d ':[:space:]' | tr '[:upper:]' '[:lower:]')"
+          [[ "$actual_cert" == "$EXPECTED_CERT_SHA256" ]]
+          sha256sum "$apk" > "$RUNNER_TEMP/LuoShu-App.apk.sha256"
+
+      - name: Upload signed APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: LuoShu-UI-signed-APK
+          path: |
+            android-app/app/build/outputs/apk/release/app-release.apk
+            ${{ runner.temp }}/LuoShu-App.apk.sha256
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/ui-apk-refresh.yml
+++ b/.github/workflows/ui-apk-refresh.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - 'android-app/**'
       - '.github/workflows/ui-apk-refresh.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'android-app/**'
+      - '.github/workflows/ui-apk-refresh.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/ui-startup-smoke.yml
+++ b/.github/workflows/ui-startup-smoke.yml
@@ -6,12 +6,14 @@ on:
       - ui-miuix-library-rebuild
     paths:
       - 'android-app/**'
+      - 'scripts/ui_startup_smoke.sh'
       - '.github/workflows/ui-startup-smoke.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'android-app/**'
+      - 'scripts/ui_startup_smoke.sh'
       - '.github/workflows/ui-startup-smoke.yml'
   workflow_dispatch:
 
@@ -72,27 +74,7 @@ jobs:
           profile: pixel_2
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          script: |
-            set -eu
-            apk='android-app/app/build/outputs/apk/release/app-release.apk'
-            package='io.github.xgl34222220.luoshu'
-            diagnostics='dist/startup-smoke'
-            mkdir -p "$diagnostics"
-            adb install -r "$apk" > "$diagnostics/install.txt" 2>&1
-            adb shell am force-stop "$package"
-            adb logcat -c
-            adb shell am start -W -n "$package/.MainActivity" > "$diagnostics/am-start.txt" 2>&1 || true
-            sleep 8
-            adb shell pidof "$package" > "$diagnostics/pid.txt" 2>&1 || true
-            adb logcat -d -v threadtime > "$diagnostics/logcat.txt"
-            if grep -nE 'FATAL EXCEPTION|AndroidRuntime.*Process: io\.github\.xgl34222220\.luoshu' "$diagnostics/logcat.txt"; then
-              echo 'LuoShu crashed during cold start.' >&2
-              exit 1
-            fi
-            if [ ! -s "$diagnostics/pid.txt" ]; then
-              echo 'LuoShu process did not survive cold start.' >&2
-              exit 1
-            fi
+          script: sh scripts/ui_startup_smoke.sh
 
       - name: Upload startup diagnostics
         if: always()

--- a/.github/workflows/ui-startup-smoke.yml
+++ b/.github/workflows/ui-startup-smoke.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - 'android-app/**'
       - '.github/workflows/ui-startup-smoke.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'android-app/**'
+      - '.github/workflows/ui-startup-smoke.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ui-startup-smoke.yml
+++ b/.github/workflows/ui-startup-smoke.yml
@@ -1,0 +1,101 @@
+name: UI cold-start smoke test
+
+on:
+  push:
+    branches:
+      - ui-miuix-library-rebuild
+    paths:
+      - 'android-app/**'
+      - '.github/workflows/ui-startup-smoke.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: luoshu-ui-startup-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android-10-cold-start:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: android-actions/setup-android@v3
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '9.5.0'
+
+      - name: Restore release signing key
+        shell: bash
+        env:
+          KEYSTORE_BASE64: ${{ secrets.LUOSHU_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.LUOSHU_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.LUOSHU_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+          for value in KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS; do
+            [[ -n "${!value}" ]] || { echo "Missing signing secret: $value" >&2; exit 3; }
+          done
+          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/luoshu-release.jks"
+          keytool -list -keystore "$RUNNER_TEMP/luoshu-release.jks" \
+            -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" >/dev/null
+
+      - name: Build signed release APK
+        working-directory: android-app
+        env:
+          LUOSHU_KEYSTORE_FILE: ${{ runner.temp }}/luoshu-release.jks
+          LUOSHU_KEYSTORE_PASSWORD: ${{ secrets.LUOSHU_KEYSTORE_PASSWORD }}
+          LUOSHU_KEY_ALIAS: ${{ secrets.LUOSHU_KEY_ALIAS }}
+          LUOSHU_KEY_PASSWORD: ${{ secrets.LUOSHU_KEY_PASSWORD }}
+        run: gradle --no-daemon --stacktrace :app:assembleRelease
+
+      - name: Install and cold-start on Android 10
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          arch: x86_64
+          profile: pixel_2
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: |
+            set -euo pipefail
+            apk='android-app/app/build/outputs/apk/release/app-release.apk'
+            package='io.github.xgl34222220.luoshu'
+            mkdir -p dist/startup-smoke
+            adb install -r "$apk"
+            adb shell am force-stop "$package"
+            adb logcat -c
+            set +e
+            adb shell am start -W -n "$package/.MainActivity" | tee dist/startup-smoke/am-start.txt
+            start_status=${PIPESTATUS[0]}
+            sleep 8
+            adb shell pidof "$package" | tee dist/startup-smoke/pid.txt
+            pid_status=${PIPESTATUS[0]}
+            adb logcat -d -v threadtime > dist/startup-smoke/logcat.txt
+            set -e
+            if grep -nE 'FATAL EXCEPTION|AndroidRuntime.*Process: io\.github\.xgl34222220\.luoshu' dist/startup-smoke/logcat.txt; then
+              echo 'LuoShu crashed during cold start.' >&2
+              exit 1
+            fi
+            [[ $start_status -eq 0 && $pid_status -eq 0 && -s dist/startup-smoke/pid.txt ]] || {
+              echo 'LuoShu process did not survive cold start.' >&2
+              exit 1
+            }
+
+      - name: Upload startup diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: LuoShu-UI-startup-smoke
+          path: dist/startup-smoke/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/ui-startup-smoke.yml
+++ b/.github/workflows/ui-startup-smoke.yml
@@ -73,29 +73,26 @@ jobs:
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: |
-            set -euo pipefail
+            set -eu
             apk='android-app/app/build/outputs/apk/release/app-release.apk'
             package='io.github.xgl34222220.luoshu'
-            mkdir -p dist/startup-smoke
-            adb install -r "$apk"
+            diagnostics='dist/startup-smoke'
+            mkdir -p "$diagnostics"
+            adb install -r "$apk" > "$diagnostics/install.txt" 2>&1
             adb shell am force-stop "$package"
             adb logcat -c
-            set +e
-            adb shell am start -W -n "$package/.MainActivity" | tee dist/startup-smoke/am-start.txt
-            start_status=${PIPESTATUS[0]}
+            adb shell am start -W -n "$package/.MainActivity" > "$diagnostics/am-start.txt" 2>&1 || true
             sleep 8
-            adb shell pidof "$package" | tee dist/startup-smoke/pid.txt
-            pid_status=${PIPESTATUS[0]}
-            adb logcat -d -v threadtime > dist/startup-smoke/logcat.txt
-            set -e
-            if grep -nE 'FATAL EXCEPTION|AndroidRuntime.*Process: io\.github\.xgl34222220\.luoshu' dist/startup-smoke/logcat.txt; then
+            adb shell pidof "$package" > "$diagnostics/pid.txt" 2>&1 || true
+            adb logcat -d -v threadtime > "$diagnostics/logcat.txt"
+            if grep -nE 'FATAL EXCEPTION|AndroidRuntime.*Process: io\.github\.xgl34222220\.luoshu' "$diagnostics/logcat.txt"; then
               echo 'LuoShu crashed during cold start.' >&2
               exit 1
             fi
-            [[ $start_status -eq 0 && $pid_status -eq 0 && -s dist/startup-smoke/pid.txt ]] || {
+            if [ ! -s "$diagnostics/pid.txt" ]; then
               echo 'LuoShu process did not survive cold start.' >&2
               exit 1
-            }
+            fi
 
       - name: Upload startup diagnostics
         if: always()

--- a/.github/workflows/ui-startup-smoke.yml
+++ b/.github/workflows/ui-startup-smoke.yml
@@ -25,9 +25,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  android-10-cold-start:
+  cold-start:
+    name: Android ${{ matrix.api-level }} cold start
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [29, 35]
     steps:
       - uses: actions/checkout@v4
 
@@ -66,21 +71,21 @@ jobs:
           LUOSHU_KEY_PASSWORD: ${{ secrets.LUOSHU_KEY_PASSWORD }}
         run: gradle --no-daemon --stacktrace :app:assembleRelease
 
-      - name: Install and cold-start on Android 10
+      - name: Install and cold-start
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
+          api-level: ${{ matrix.api-level }}
           arch: x86_64
           profile: pixel_2
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          script: sh scripts/ui_startup_smoke.sh
+          script: sh scripts/ui_startup_smoke.sh android-app/app/build/outputs/apk/release/app-release.apk io.github.xgl34222220.luoshu dist/startup-smoke-${{ matrix.api-level }}
 
       - name: Upload startup diagnostics
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: LuoShu-UI-startup-smoke
-          path: dist/startup-smoke/
+          name: LuoShu-UI-startup-smoke-${{ matrix.api-level }}
+          path: dist/startup-smoke-${{ matrix.api-level }}/
           if-no-files-found: warn
           retention-days: 7

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -108,6 +108,7 @@ android {
 dependencies {
     val composeBom = platform("androidx.compose:compose-bom:2026.03.00")
     val miuixVersion = "0.9.3"
+    val material3AdaptiveVersion = "1.2.0"
     implementation(composeBom)
 
     implementation("androidx.activity:activity-compose:1.13.0")
@@ -116,11 +117,24 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
     implementation("androidx.datastore:datastore-preferences:1.2.1")
     implementation("androidx.compose.foundation:foundation")
-    implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
+
+    // Complete Material 2 + Material 3 visual stack, version-aligned by the Compose BOM.
+    implementation("androidx.compose.material:material")
+    implementation("androidx.compose.material:material-ripple")
+    implementation("androidx.compose.material:material-icons-core")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material3:material3-window-size-class")
+    implementation("androidx.compose.material3:material3-adaptive-navigation-suite")
+
+    // Complete Material 3 adaptive stack for phones, tablets, foldables and Navigation 3.
+    implementation("androidx.compose.material3.adaptive:adaptive:$material3AdaptiveVersion")
+    implementation("androidx.compose.material3.adaptive:adaptive-layout:$material3AdaptiveVersion")
+    implementation("androidx.compose.material3.adaptive:adaptive-navigation:$material3AdaptiveVersion")
+    implementation("androidx.compose.material3.adaptive:adaptive-navigation3:$material3AdaptiveVersion")
 
     // Complete Miuix visual stack. Keep every module on the exact same version.
     implementation("top.yukonga.miuix.kmp:miuix-core:$miuixVersion")
@@ -132,6 +146,7 @@ dependencies {
     implementation("top.yukonga.miuix.kmp:miuix-shader:$miuixVersion")
     implementation("top.yukonga.miuix.kmp:miuix-squircle:$miuixVersion")
 
+    // Dynamic color and glass layers shared by Material and Miuix themes.
     implementation("com.materialkolor:material-kolor:2.0.0")
     implementation("dev.chrisbanes.haze:haze:1.6.10")
     implementation("dev.chrisbanes.haze:haze-materials:1.6.10")

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -151,8 +151,9 @@ dependencies {
     implementation("top.yukonga.miuix.kmp:miuix-shader:$miuixVersion")
     implementation("top.yukonga.miuix.kmp:miuix-squircle:$miuixVersion")
 
-    // Dynamic color and glass layers shared by Material and Miuix themes.
-    implementation("com.materialkolor:material-kolor:2.0.0")
+    // Miuix 0.9.3 ThemeController is compiled against Material Color Utilities 4.1.1.
+    // Do not force the legacy material-kolor 2.x artifact: its Hct ABI crashes at startup.
+    implementation("com.materialkolor:material-color-utilities-android:4.1.1")
     implementation("dev.chrisbanes.haze:haze:1.6.10")
     implementation("dev.chrisbanes.haze:haze-materials:1.6.10")
 

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -130,11 +130,14 @@ dependencies {
     implementation("androidx.compose.material3:material3-window-size-class")
     implementation("androidx.compose.material3:material3-adaptive-navigation-suite")
 
-    // Complete Material 3 adaptive stack for phones, tablets, foldables and Navigation 3.
+    // Complete Material 3 adaptive stack for phones, tablets and foldables.
     implementation("androidx.compose.material3.adaptive:adaptive:$material3AdaptiveVersion")
     implementation("androidx.compose.material3.adaptive:adaptive-layout:$material3AdaptiveVersion")
     implementation("androidx.compose.material3.adaptive:adaptive-navigation:$material3AdaptiveVersion")
-    implementation("androidx.compose.material3.adaptive:adaptive-navigation3:$material3AdaptiveVersion")
+    // Miuix Navigation 3 republishes the same androidx.navigation3 classes. Keep the Material
+    // Navigation 3 API available for the Material source implementation without packaging a
+    // second runtime copy into the same APK.
+    compileOnly("androidx.compose.material3.adaptive:adaptive-navigation3:$material3AdaptiveVersion")
 
     // Complete Miuix visual stack. Keep every module on the exact same version.
     implementation("top.yukonga.miuix.kmp:miuix-core:$miuixVersion")

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -31,7 +31,7 @@ val hasReleaseSigning = listOf(
 
 android {
     namespace = "io.github.xgl34222220.luoshu"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "io.github.xgl34222220.luoshu"

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -141,7 +141,9 @@ dependencies {
     implementation("top.yukonga.miuix.kmp:miuix-ui:$miuixVersion")
     implementation("top.yukonga.miuix.kmp:miuix-preference:$miuixVersion")
     implementation("top.yukonga.miuix.kmp:miuix-icons:$miuixVersion")
-    implementation("top.yukonga.miuix.kmp:miuix-blur:$miuixVersion")
+    // miuix-blur requires minSdk 33. Keep its API available to the source set while Haze
+    // remains the packaged fallback for LuoShu's Android 9+ support range.
+    compileOnly("top.yukonga.miuix.kmp:miuix-blur:$miuixVersion")
     implementation("top.yukonga.miuix.kmp:miuix-navigation3-ui:$miuixVersion")
     implementation("top.yukonga.miuix.kmp:miuix-shader:$miuixVersion")
     implementation("top.yukonga.miuix.kmp:miuix-squircle:$miuixVersion")

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -107,6 +107,7 @@ android {
 
 dependencies {
     val composeBom = platform("androidx.compose:compose-bom:2026.03.00")
+    val miuixVersion = "0.9.3"
     implementation(composeBom)
 
     implementation("androidx.activity:activity-compose:1.13.0")
@@ -121,9 +122,15 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
-    implementation("top.yukonga.miuix.kmp:miuix-ui:0.9.3")
-    implementation("top.yukonga.miuix.kmp:miuix-preference:0.9.3")
-    implementation("top.yukonga.miuix.kmp:miuix-icons:0.9.3")
+    // Complete Miuix visual stack. Keep every module on the exact same version.
+    implementation("top.yukonga.miuix.kmp:miuix-core:$miuixVersion")
+    implementation("top.yukonga.miuix.kmp:miuix-ui:$miuixVersion")
+    implementation("top.yukonga.miuix.kmp:miuix-preference:$miuixVersion")
+    implementation("top.yukonga.miuix.kmp:miuix-icons:$miuixVersion")
+    implementation("top.yukonga.miuix.kmp:miuix-blur:$miuixVersion")
+    implementation("top.yukonga.miuix.kmp:miuix-navigation3-ui:$miuixVersion")
+    implementation("top.yukonga.miuix.kmp:miuix-shader:$miuixVersion")
+    implementation("top.yukonga.miuix.kmp:miuix-squircle:$miuixVersion")
 
     implementation("com.materialkolor:material-kolor:2.0.0")
     implementation("dev.chrisbanes.haze:haze:1.6.10")

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -121,6 +121,10 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
+    implementation("top.yukonga.miuix.kmp:miuix-ui:0.9.3")
+    implementation("top.yukonga.miuix.kmp:miuix-preference:0.9.3")
+    implementation("top.yukonga.miuix.kmp:miuix-icons:0.9.3")
+
     implementation("com.materialkolor:material-kolor:2.0.0")
     implementation("dev.chrisbanes.haze:haze:1.6.10")
     implementation("dev.chrisbanes.haze:haze-materials:1.6.10")

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -151,9 +151,9 @@ dependencies {
     implementation("top.yukonga.miuix.kmp:miuix-shader:$miuixVersion")
     implementation("top.yukonga.miuix.kmp:miuix-squircle:$miuixVersion")
 
-    // Miuix 0.9.3 ThemeController is compiled against Material Color Utilities 4.1.1.
-    // Do not force the legacy material-kolor 2.x artifact: its Hct ABI crashes at startup.
-    implementation("com.materialkolor:material-color-utilities-android:4.1.1")
+    // Material and Miuix must use the same Material Color Utilities ABI.
+    // MaterialKolor 4.1.1 retains DynamicMaterialTheme and matches Miuix 0.9.3.
+    implementation("com.materialkolor:material-kolor:4.1.1")
     implementation("dev.chrisbanes.haze:haze:1.6.10")
     implementation("dev.chrisbanes.haze:haze-materials:1.6.10")
 

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -108,7 +108,7 @@ android {
 dependencies {
     val composeBom = platform("androidx.compose:compose-bom:2026.03.00")
     val miuixVersion = "0.9.3"
-    val material3AdaptiveVersion = "1.2.0"
+    val material3AdaptiveVersion = "1.3.0-rc01"
     implementation(composeBom)
 
     implementation("androidx.activity:activity-compose:1.13.0")

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt
@@ -2,51 +2,14 @@ package io.github.xgl34222220.luoshu
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.spring
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Add
-import androidx.compose.material.icons.rounded.Cancel
-import androidx.compose.material.icons.rounded.CheckCircle
-import androidx.compose.material.icons.rounded.Error
-import androidx.compose.material.icons.rounded.PlayArrow
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
-import io.github.xgl34222220.luoshu.ui.theme.LocalMiuixTokens
 
 @Composable
 internal fun NativeImportOverlay(
@@ -85,250 +48,36 @@ internal fun NativeImportOverlay(
         }
     }
 
-    if (embedded) {
-        val tokens = LocalMiuixTokens.current
-        Surface(
-            modifier = modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(28.dp),
-            color = if (style == UiStyle.MIUIX) tokens.cardBackground else MaterialTheme.colorScheme.surfaceContainerLow,
-            shadowElevation = if (style == UiStyle.MIUIX) 4.dp else 2.dp,
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = .08f)),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                FontMetadataInspector(
-                    viewModel = viewModel,
-                    style = style,
-                )
-                ImportActionButton(
-                    style = style,
-                    state = state,
-                    expanded = true,
-                    enabled = importEnabled,
-                    onImport = onImport,
-                    modifier = Modifier.weight(1f),
-                    embedded = true,
-                )
-            }
-        }
-    } else {
-        Row(
-            modifier = modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            ImportActionButton(
-                style = style,
-                state = state,
-                expanded = expanded,
-                enabled = importEnabled,
-                onImport = onImport,
-            )
-        }
+    when (style) {
+        UiStyle.MIUIX -> NativeImportOverlayMiuix(
+            state = state,
+            expanded = expanded,
+            enabled = importEnabled,
+            embedded = embedded,
+            onImport = onImport,
+            modifier = modifier,
+        )
+        UiStyle.MATERIAL -> NativeImportOverlayMaterial(
+            viewModel = viewModel,
+            state = state,
+            expanded = expanded,
+            enabled = importEnabled,
+            embedded = embedded,
+            onImport = onImport,
+            modifier = modifier,
+        )
     }
 
     if (state.resultVisible) {
-        ImportResultDialog(
-            style = style,
-            state = state,
-            onDismiss = importViewModel::dismissResult,
-        )
-    }
-}
-
-@Composable
-private fun ImportActionButton(
-    style: UiStyle,
-    state: NativeImportState,
-    expanded: Boolean,
-    enabled: Boolean,
-    onImport: () -> Unit,
-    modifier: Modifier = Modifier,
-    embedded: Boolean = false,
-) {
-    val scheme = MaterialTheme.colorScheme
-    val tokens = LocalMiuixTokens.current
-    val dark = scheme.background.luminance() < .5f
-    val taskVisible = state.busy || state.paused
-    val targetWidth = when {
-        !expanded -> 54.dp
-        taskVisible -> 180.dp
-        else -> 148.dp
-    }
-    val targetHeight = when {
-        embedded && taskVisible -> 68.dp
-        embedded -> 56.dp
-        taskVisible -> 68.dp
-        else -> 54.dp
-    }
-    val width by animateDpAsState(
-        targetValue = targetWidth,
-        animationSpec = spring(dampingRatio = .78f, stiffness = 430f),
-        label = "nativeImportGlassWidth",
-    )
-    val height by animateDpAsState(
-        targetValue = targetHeight,
-        animationSpec = spring(dampingRatio = .82f, stiffness = 470f),
-        label = "nativeImportGlassHeight",
-    )
-    val glassColor = when {
-        embedded && style == UiStyle.MIUIX -> scheme.primary.copy(alpha = if (dark) .18f else .10f)
-        embedded -> scheme.primaryContainer.copy(alpha = if (dark) .46f else .62f)
-        style == UiStyle.MIUIX -> tokens.elevatedCardBackground.copy(alpha = if (dark) .76f else .72f)
-        dark -> scheme.surfaceContainerHigh.copy(alpha = .72f)
-        else -> Color.White.copy(alpha = .70f)
-    }
-    val borderColor = if (dark) Color.White.copy(alpha = .14f) else Color.White.copy(alpha = .82f)
-    val textColor = if (style == UiStyle.MIUIX) tokens.textPrimary else scheme.onSurface
-
-    val buttonModifier = if (embedded) {
-        modifier.fillMaxWidth().height(height)
-    } else {
-        modifier.width(width).height(height)
-    }
-    Surface(
-        onClick = onImport,
-        enabled = enabled,
-        modifier = buttonModifier,
-        shape = if (embedded) RoundedCornerShape(20.dp) else CircleShape,
-        color = glassColor,
-        contentColor = scheme.primary,
-        shadowElevation = if (embedded) 0.dp else if (style == UiStyle.MIUIX) 10.dp else 8.dp,
-        border = BorderStroke(1.dp, if (embedded) scheme.primary.copy(alpha = .10f) else borderColor),
-    ) {
-        if (!expanded) {
-            Box(contentAlignment = Alignment.Center) {
-                Icon(Icons.Rounded.Add, contentDescription = "导入字体", modifier = Modifier.size(24.dp))
-            }
-        } else {
-            Column(
-                modifier = Modifier.padding(horizontal = 14.dp, vertical = if (taskVisible) 10.dp else 12.dp),
-                horizontalAlignment = if (embedded) Alignment.CenterHorizontally else Alignment.End,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    when {
-                        state.busy -> CircularProgressIndicator(
-                            modifier = Modifier.size(19.dp),
-                            strokeWidth = 2.dp,
-                            color = scheme.primary,
-                        )
-                        state.paused -> Icon(Icons.Rounded.PlayArrow, contentDescription = null)
-                        else -> Icon(Icons.Rounded.Add, contentDescription = null)
-                    }
-                    Spacer(Modifier.width(8.dp))
-                    Text(
-                        when {
-                            state.busy -> "导入 ${state.processed}/${state.total}"
-                            state.paused -> "继续 ${state.processed}/${state.total}"
-                            else -> "导入字体"
-                        },
-                        color = textColor,
-                        fontWeight = FontWeight.Black,
-                        fontSize = 14.sp,
-                        maxLines = 1,
-                        softWrap = false,
-                    )
-                }
-                if (taskVisible) {
-                    Spacer(Modifier.height(7.dp))
-                    LinearProgressIndicator(
-                        progress = { state.progress / 100f },
-                        modifier = Modifier.fillMaxWidth(),
-                        color = scheme.primary,
-                        trackColor = scheme.primary.copy(alpha = .18f),
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ImportResultDialog(
-    style: UiStyle,
-    state: NativeImportState,
-    onDismiss: () -> Unit,
-) {
-    val failed = state.failed.isNotEmpty()
-    val cancelled = state.phase == NativeImportPhase.CANCELLED
-    val icon = when {
-        cancelled -> Icons.Rounded.Cancel
-        failed -> Icons.Rounded.Error
-        else -> Icons.Rounded.CheckCircle
-    }
-    val accent = when {
-        failed -> MaterialTheme.colorScheme.error
-        cancelled -> MaterialTheme.colorScheme.secondary
-        else -> MaterialTheme.colorScheme.primary
-    }
-
-    if (style == UiStyle.MATERIAL) {
-        AlertDialog(
-            onDismissRequest = onDismiss,
-            icon = {
-                Icon(icon, contentDescription = null, tint = accent)
-            },
-            title = { Text(state.title, fontWeight = FontWeight.Black) },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                    Text(state.summary)
-                    Text(
-                        "支持 TTF、OTF、TTC 与字体模块 ZIP。ZIP 只提取字体文件，不执行包内脚本。",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
-            },
-            confirmButton = { Button(onClick = onDismiss) { Text("完成") } },
-            shape = MaterialTheme.shapes.extraLarge,
-        )
-    } else {
-        val tokens = LocalMiuixTokens.current
-        Dialog(onDismissRequest = onDismiss) {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(38.dp),
-                color = tokens.elevatedCardBackground,
-                shadowElevation = 20.dp,
-            ) {
-                Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(13.dp),
-                ) {
-                    Text(
-                        "IMPORT RESULT",
-                        color = accent,
-                        fontSize = 9.sp,
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 2.sp,
-                    )
-                    Text(
-                        state.title,
-                        color = tokens.textPrimary,
-                        fontSize = 25.sp,
-                        lineHeight = 30.sp,
-                        fontWeight = FontWeight.Black,
-                    )
-                    Text(state.summary, color = tokens.textPrimary, lineHeight = 20.sp)
-                    Text(
-                        "ZIP 仅安全提取字体，不执行包内脚本。导入记录可在任务中心控制。",
-                        color = tokens.textSecondary,
-                        fontSize = 11.sp,
-                    )
-                    Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
-                        Button(onClick = onDismiss, shape = RoundedCornerShape(18.dp)) {
-                            Text("完成", fontWeight = FontWeight.Bold)
-                        }
-                    }
-                }
-            }
+        when (style) {
+            UiStyle.MIUIX -> ImportResultDialogMiuix(
+                state = state,
+                onDismiss = importViewModel::dismissResult,
+            )
+            UiStyle.MATERIAL -> ImportResultDialogMaterial(
+                state = state,
+                onDismiss = importViewModel::dismissResult,
+            )
         }
     }
 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlayMaterial.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlayMaterial.kt
@@ -1,0 +1,231 @@
+package io.github.xgl34222220.luoshu
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Cancel
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Error
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun NativeImportOverlayMaterial(
+    viewModel: LuoShuViewModel,
+    state: NativeImportState,
+    expanded: Boolean,
+    enabled: Boolean,
+    embedded: Boolean,
+    onImport: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (embedded) {
+        Surface(
+            modifier = modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerLow,
+            shadowElevation = 2.dp,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = .5f)),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                FontMetadataInspector(
+                    viewModel = viewModel,
+                    style = io.github.xgl34222220.luoshu.ui.appearance.UiStyle.MATERIAL,
+                )
+                MaterialImportActionButton(
+                    state = state,
+                    expanded = true,
+                    enabled = enabled,
+                    onImport = onImport,
+                    modifier = Modifier.weight(1f),
+                    embedded = true,
+                )
+            }
+        }
+    } else {
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            MaterialImportActionButton(
+                state = state,
+                expanded = expanded,
+                enabled = enabled,
+                onImport = onImport,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MaterialImportActionButton(
+    state: NativeImportState,
+    expanded: Boolean,
+    enabled: Boolean,
+    onImport: () -> Unit,
+    modifier: Modifier = Modifier,
+    embedded: Boolean = false,
+) {
+    val scheme = MaterialTheme.colorScheme
+    val dark = scheme.background.luminance() < .5f
+    val taskVisible = state.busy || state.paused
+    val targetWidth = when {
+        !expanded -> 54.dp
+        taskVisible -> 180.dp
+        else -> 148.dp
+    }
+    val targetHeight = when {
+        taskVisible -> 68.dp
+        else -> 54.dp
+    }
+    val width by animateDpAsState(
+        targetValue = targetWidth,
+        animationSpec = spring(dampingRatio = .78f, stiffness = 430f),
+        label = "materialImportWidth",
+    )
+    val height by animateDpAsState(
+        targetValue = targetHeight,
+        animationSpec = spring(dampingRatio = .82f, stiffness = 470f),
+        label = "materialImportHeight",
+    )
+    val glassColor = when {
+        embedded -> scheme.primaryContainer.copy(alpha = if (dark) .46f else .62f)
+        dark -> scheme.surfaceContainerHigh.copy(alpha = .72f)
+        else -> Color.White.copy(alpha = .70f)
+    }
+    val borderColor = if (dark) Color.White.copy(alpha = .14f) else Color.White.copy(alpha = .82f)
+    val buttonModifier = if (embedded) {
+        modifier.fillMaxWidth().height(height)
+    } else {
+        modifier.width(width).height(height)
+    }
+
+    Surface(
+        onClick = onImport,
+        enabled = enabled,
+        modifier = buttonModifier,
+        shape = if (embedded) RoundedCornerShape(20.dp) else CircleShape,
+        color = glassColor,
+        contentColor = scheme.primary,
+        shadowElevation = if (embedded) 0.dp else 8.dp,
+        border = BorderStroke(1.dp, if (embedded) scheme.primary.copy(alpha = .10f) else borderColor),
+    ) {
+        if (!expanded) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(Icons.Rounded.Add, contentDescription = "导入字体", modifier = Modifier.size(24.dp))
+            }
+        } else {
+            Column(
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = if (taskVisible) 10.dp else 12.dp),
+                horizontalAlignment = if (embedded) Alignment.CenterHorizontally else Alignment.End,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    when {
+                        state.busy -> CircularProgressIndicator(
+                            modifier = Modifier.size(19.dp),
+                            strokeWidth = 2.dp,
+                            color = scheme.primary,
+                        )
+                        state.paused -> Icon(Icons.Rounded.PlayArrow, contentDescription = null)
+                        else -> Icon(Icons.Rounded.Add, contentDescription = null)
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = when {
+                            state.busy -> "导入 ${state.processed}/${state.total}"
+                            state.paused -> "继续 ${state.processed}/${state.total}"
+                            else -> "导入字体"
+                        },
+                        fontWeight = FontWeight.Black,
+                        maxLines = 1,
+                        softWrap = false,
+                    )
+                }
+                if (taskVisible) {
+                    Spacer(Modifier.height(7.dp))
+                    LinearProgressIndicator(
+                        progress = { state.progress / 100f },
+                        modifier = Modifier.fillMaxWidth(),
+                        color = scheme.primary,
+                        trackColor = scheme.primary.copy(alpha = .18f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ImportResultDialogMaterial(
+    state: NativeImportState,
+    onDismiss: () -> Unit,
+) {
+    val failed = state.failed.isNotEmpty()
+    val cancelled = state.phase == NativeImportPhase.CANCELLED
+    val icon = when {
+        cancelled -> Icons.Rounded.Cancel
+        failed -> Icons.Rounded.Error
+        else -> Icons.Rounded.CheckCircle
+    }
+    val accent = when {
+        failed -> MaterialTheme.colorScheme.error
+        cancelled -> MaterialTheme.colorScheme.secondary
+        else -> MaterialTheme.colorScheme.primary
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(icon, contentDescription = null, tint = accent) },
+        title = { Text(state.title, fontWeight = FontWeight.Black) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text(state.summary)
+                Text(
+                    "支持 TTF、OTF、TTC 与字体模块 ZIP。ZIP 只提取字体文件，不执行包内脚本。",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        },
+        confirmButton = { Button(onClick = onDismiss) { Text("完成") } },
+        shape = MaterialTheme.shapes.extraLarge,
+    )
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlayMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlayMiuix.kt
@@ -1,0 +1,168 @@
+package io.github.xgl34222220.luoshu
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Error
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.CircularProgressIndicator
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.LinearProgressIndicator
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.overlay.OverlayDialog
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+
+@Composable
+internal fun NativeImportOverlayMiuix(
+    state: NativeImportState,
+    expanded: Boolean,
+    enabled: Boolean,
+    embedded: Boolean,
+    onImport: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MiuixTheme.colorScheme
+    val taskVisible = state.busy || state.paused
+    val title = when {
+        state.busy -> "正在导入字体"
+        state.paused -> "字体导入已暂停"
+        else -> "导入字体"
+    }
+    val summary = when {
+        state.busy -> "已处理 ${state.processed}/${state.total} · ${state.progress}%"
+        state.paused -> "已处理 ${state.processed}/${state.total}，点击继续"
+        else -> "支持 TTF、OTF、TTC 与字体模块 ZIP"
+    }
+
+    if (!embedded && !expanded) {
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            Button(
+                onClick = onImport,
+                enabled = enabled,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+                Text("导入", modifier = Modifier.padding(start = 7.dp))
+            }
+        }
+        return
+    }
+
+    Card(modifier = modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = title,
+            summary = summary,
+            startAction = {
+                if (state.busy) {
+                    CircularProgressIndicator(
+                        progress = null,
+                        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+                    )
+                } else {
+                    Icon(
+                        imageVector = if (state.paused) Icons.Rounded.PlayArrow else Icons.Rounded.Add,
+                        contentDescription = null,
+                        tint = colors.primary,
+                        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+                    )
+                }
+            },
+        )
+        if (taskVisible) {
+            LinearProgressIndicator(
+                progress = state.progress.coerceIn(0, 100) / 100f,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            )
+            Spacer(Modifier.size(12.dp))
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "ZIP 只安全提取字体，不执行包内脚本",
+                modifier = Modifier.weight(1f),
+                color = colors.onSurfaceSecondary,
+            )
+            Spacer(Modifier.width(12.dp))
+            Button(
+                onClick = onImport,
+                enabled = enabled,
+            ) {
+                Icon(
+                    imageVector = if (state.paused) Icons.Rounded.PlayArrow else Icons.Rounded.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+                Text(
+                    text = if (state.paused) "继续" else "选择文件",
+                    modifier = Modifier.padding(start = 7.dp),
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ImportResultDialogMiuix(
+    state: NativeImportState,
+    onDismiss: () -> Unit,
+) {
+    val failed = state.failed.isNotEmpty()
+    val icon = if (failed) Icons.Rounded.Error else Icons.Rounded.CheckCircle
+    val colors = MiuixTheme.colorScheme
+
+    OverlayDialog(
+        title = state.title,
+        summary = state.summary,
+        show = true,
+        onDismissRequest = onDismiss,
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = if (failed) colors.error else colors.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = "ZIP 仅安全提取字体，不执行包内脚本。导入记录可在任务中心控制。",
+                    color = colors.onSurfaceSecondary,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("完成", fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeRoute.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeRoute.kt
@@ -44,20 +44,29 @@ fun HomeRoute(
         }
     }
 
-    HomeScreenCompact(
-        style = style,
-        state = state,
-        actions = actions,
-        trustContent = {
-            if (state.moduleInstalled) {
-                DeviceTrustChip(
-                    style = style,
-                    state = trustState,
-                    onClick = { showTrustDetails = true },
-                )
-            }
-        },
-    )
+    val trustContent: @Composable () -> Unit = {
+        if (state.moduleInstalled) {
+            DeviceTrustChip(
+                style = style,
+                state = trustState,
+                onClick = { showTrustDetails = true },
+            )
+        }
+    }
+
+    when (style) {
+        UiStyle.MIUIX -> HomeScreenMiuix(
+            state = state,
+            actions = actions,
+            trustContent = trustContent,
+        )
+        UiStyle.MATERIAL -> HomeScreenCompact(
+            style = style,
+            state = state,
+            actions = actions,
+            trustContent = trustContent,
+        )
+    }
 
     if (showTrustDetails) {
         DeviceTrustDialog(

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeScreenMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeScreenMiuix.kt
@@ -62,7 +62,7 @@ internal fun HomeScreenMiuix(
                 Text(
                     text = "无 Hook 全局字体引擎 · ${state.version}",
                     fontSize = 14.sp,
-                    color = colors.onSurfaceVariant,
+                    color = colors.onSurfaceSecondary,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeScreenMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/HomeScreenMiuix.kt
@@ -1,500 +1,311 @@
 package io.github.xgl34222220.luoshu.ui.home
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.CheckCircle
-import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.FontDownload
 import androidx.compose.material.icons.rounded.Layers
-import androidx.compose.material.icons.rounded.List
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.RestartAlt
+import androidx.compose.material.icons.rounded.Restore
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.Speed
-import androidx.compose.material.icons.rounded.Tune
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Slider
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material.icons.rounded.TaskAlt
+import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.github.xgl34222220.luoshu.ui.theme.LocalMiuixTokens
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.Slider
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 @Composable
-fun HomeScreenMiuix(
+internal fun HomeScreenMiuix(
     state: HomeUiState,
     actions: HomeActions,
+    trustContent: @Composable () -> Unit,
 ) {
+    val colors = MiuixTheme.colorScheme
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 132.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background),
+        contentPadding = PaddingValues(start = 16.dp, top = 18.dp, end = 16.dp, bottom = 112.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        item { MiuixPageHeader(state = state, onRefresh = actions.refresh) }
-        item { MiuixFontHero(state) }
+        item {
+            Column(modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp)) {
+                Text(
+                    text = "洛书",
+                    fontSize = 34.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = colors.onBackground,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = "无 Hook 全局字体引擎 · ${state.version}",
+                    fontSize = 14.sp,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        item {
+            MiuixHomeCard(
+                title = state.currentFont,
+                summary = engineSummary(state),
+                icon = Icons.Rounded.FontDownload,
+                onClick = actions.openFontLibrary,
+            )
+        }
+
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                BasicComponent(
+                    title = "刷新状态",
+                    summary = if (state.loading) "正在重新读取模块与字体状态" else "重新检查字体、挂载和任务状态",
+                    startAction = { MiuixHomeIcon(Icons.Rounded.Refresh) },
+                    enabled = !state.loading,
+                    onClick = actions.refresh,
+                )
+                BasicComponent(
+                    title = "恢复系统字体",
+                    summary = "撤销当前字体覆盖并恢复 ROM 原始映射",
+                    startAction = { MiuixHomeIcon(Icons.Rounded.Restore) },
+                    enabled = !state.taskRunning,
+                    onClick = actions.restoreDefault,
+                )
+                BasicComponent(
+                    title = if (state.rebootRequired) "完整重启" else "任务中心",
+                    summary = if (state.rebootRequired) "当前字体已准备完成，重启后生效" else taskSummary(state),
+                    startAction = {
+                        MiuixHomeIcon(if (state.rebootRequired) Icons.Rounded.RestartAlt else Icons.Rounded.Description)
+                    },
+                    onClick = if (state.rebootRequired) actions.reboot else actions.openLogs,
+                )
+            }
+        }
+
+        item { trustContent() }
 
         if (state.error.isNotBlank()) {
             item {
-                Surface(
-                    shape = RoundedCornerShape(24.dp),
-                    color = MaterialTheme.colorScheme.errorContainer,
-                ) {
-                    Text(
-                        text = state.error,
-                        modifier = Modifier.padding(16.dp),
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
-                }
+                MiuixHomeCard(
+                    title = "字体引擎需要处理",
+                    summary = state.error,
+                    icon = Icons.Rounded.Warning,
+                    onClick = actions.openLogs,
+                )
             }
         }
 
-        item { MiuixSectionTitle("SYSTEM STATUS", "运行状态", "Root 与字体挂载") }
+        item { MiuixSectionTitle("设备状态") }
         item {
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                MiuixMetricCard(
-                    modifier = Modifier.weight(1f),
-                    icon = Icons.Rounded.Security,
-                    label = "Root",
-                    value = if (state.rootGranted) state.rootManager else "未授权",
-                    positive = state.rootGranted,
-                )
-                MiuixMetricCard(
-                    modifier = Modifier.weight(1f),
-                    icon = Icons.Rounded.Layers,
-                    label = "挂载引擎",
-                    value = state.mountEngine,
-                    positive = state.mountHealthy,
-                )
-            }
+            MiuixHomeCard(
+                title = "Root",
+                summary = if (state.rootGranted) "已由 ${state.rootManager} 授予字体事务权限" else "尚未获得 Root 权限",
+                icon = Icons.Rounded.Security,
+                onClick = actions.refresh,
+            )
         }
-
-        item { MiuixSectionTitle("QUICK ACCESS", "常用入口", "字体管理与诊断") }
         item {
-            MiuixActionGroup(
-                items = listOf(
-                    MiuixHomeAction(
-                        icon = Icons.Rounded.List,
-                        title = "字体库",
-                        description = "导入、预览和直接应用字体",
-                        onClick = actions.openFontLibrary,
-                    ),
-                    MiuixHomeAction(
-                        icon = Icons.Rounded.Tune,
-                        title = "字体组合",
-                        description = "中文、英文、数字与可变轴",
-                        onClick = actions.openFontStudio,
-                    ),
-                    MiuixHomeAction(
-                        icon = Icons.Rounded.Description,
-                        title = "运行日志",
-                        description = "查看任务进度与错误原因",
-                        onClick = actions.openLogs,
-                    ),
-                ),
+            MiuixHomeCard(
+                title = "挂载引擎",
+                summary = state.mountEngine,
+                icon = Icons.Rounded.Layers,
+                onClick = actions.openLogs,
             )
         }
-
-        item { MiuixSectionTitle("SYSTEM WEIGHT", "全局粗细微调", "向左更细，向右更粗") }
-        item { MiuixSystemWeightCard(state.systemWeight, actions) }
-
         item {
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                OutlinedButton(
-                    onClick = actions.restoreDefault,
-                    enabled = !state.taskRunning,
-                    modifier = Modifier.weight(1f).height(54.dp),
-                    shape = RoundedCornerShape(20.dp),
-                ) {
-                    Text("恢复系统字体", fontWeight = FontWeight.Bold)
-                }
-                Button(
-                    onClick = actions.reboot,
-                    enabled = state.rebootRequired && !state.taskRunning,
-                    modifier = Modifier.weight(1f).height(54.dp),
-                    shape = RoundedCornerShape(20.dp),
-                ) {
-                    Icon(Icons.Rounded.RestartAlt, contentDescription = null)
-                    Spacer(Modifier.width(7.dp))
-                    Text("立即重启", fontWeight = FontWeight.Bold)
-                }
-            }
+            MiuixHomeCard(
+                title = "当前任务",
+                summary = taskSummary(state),
+                icon = Icons.Rounded.TaskAlt,
+                onClick = actions.openLogs,
+            )
         }
-    }
-}
+        item {
+            MiuixHomeCard(
+                title = "重启状态",
+                summary = if (state.rebootRequired) "等待完整重启" else "当前操作无需重启",
+                icon = Icons.Rounded.RestartAlt,
+                onClick = if (state.rebootRequired) actions.reboot else actions.openLogs,
+            )
+        }
 
-@Composable
-private fun MiuixPageHeader(state: HomeUiState, onRefresh: () -> Unit) {
-    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "FONT ENGINE",
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 10.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 2.4.sp,
-            )
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = "洛书",
-                color = LocalMiuixTokens.current.textPrimary,
-                fontSize = 42.sp,
-                lineHeight = 47.sp,
-                fontWeight = FontWeight.Black,
-            )
-            Text(
-                text = "Miuix · ${state.version}",
-                color = LocalMiuixTokens.current.textSecondary,
-                fontSize = 12.sp,
+        item { MiuixSectionTitle("下一步") }
+        item {
+            val next = miuixNextStep(state, actions)
+            MiuixHomeCard(
+                title = next.title,
+                summary = next.summary,
+                icon = next.icon,
+                enabled = next.enabled,
+                onClick = next.onClick,
             )
         }
-        Card(
-            shape = RoundedCornerShape(18.dp),
-            colors = CardDefaults.cardColors(containerColor = LocalMiuixTokens.current.elevatedCardBackground),
-            elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
-        ) {
-            IconButton(onClick = onRefresh, modifier = Modifier.size(56.dp)) {
-                if (state.loading) {
-                    CircularProgressIndicator(modifier = Modifier.size(23.dp), strokeWidth = 2.dp)
-                } else {
-                    Icon(Icons.Rounded.Refresh, contentDescription = "刷新")
-                }
-            }
-        }
-    }
-}
 
-@Composable
-private fun MiuixFontHero(state: HomeUiState) {
-    val tokens = LocalMiuixTokens.current
-    val scheme = MaterialTheme.colorScheme
-    val shape = RoundedCornerShape(36.dp)
-    Card(
-        modifier = Modifier.fillMaxWidth().shadow(12.dp, shape, clip = false),
-        shape = shape,
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .drawBehind {
-                    drawCircle(
-                        brush = Brush.radialGradient(
-                            listOf(scheme.primary.copy(alpha = .18f), Color.Transparent),
-                            center = Offset(size.width, 0f),
-                            radius = size.width * .78f,
-                        ),
-                        radius = size.width * .78f,
-                        center = Offset(size.width, 0f),
-                    )
-                    drawRoundRect(
-                        brush = Brush.verticalGradient(listOf(Color.White.copy(alpha = .24f), Color.Transparent)),
-                        cornerRadius = androidx.compose.ui.geometry.CornerRadius(36.dp.toPx()),
-                        size = size.copy(height = size.height * .36f),
-                    )
-                }
-                .padding(24.dp),
-        ) {
-            Column {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(
-                        modifier = Modifier
-                            .size(10.dp)
-                            .background(
-                                color = if (state.moduleInstalled && state.rootGranted) tokens.success else tokens.warning,
-                                shape = CircleShape,
-                            ),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(
-                        text = if (state.moduleInstalled) "模块与字体引擎已连接" else "正在等待模块连接",
-                        color = tokens.textSecondary,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 12.sp,
-                    )
-                }
-                Spacer(Modifier.height(25.dp))
-                Text("当前字体", color = tokens.textSecondary, fontSize = 12.sp)
-                Text(
-                    text = state.currentFont,
-                    color = tokens.textPrimary,
-                    fontSize = 42.sp,
-                    lineHeight = 47.sp,
-                    fontWeight = FontWeight.Black,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
+        item { MiuixSectionTitle("全局粗细") }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                BasicComponent(
+                    title = "系统字体粗细",
+                    summary = when {
+                        state.systemWeight.loading -> "正在读取系统渲染参数"
+                        !state.systemWeight.supported -> state.systemWeight.error.ifBlank { "当前系统不支持粗细微调" }
+                        else -> "当前 ${state.systemWeight.weight} · 仅调整系统渲染参数"
+                    },
+                    startAction = { MiuixHomeIcon(Icons.Rounded.Speed) },
                 )
-                Spacer(Modifier.height(21.dp))
-                Surface(
-                    shape = RoundedCornerShape(22.dp),
-                    color = tokens.textPrimary.copy(alpha = .045f),
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 15.dp, vertical = 13.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = if (state.taskRunning) Icons.Rounded.Refresh else Icons.Rounded.CheckCircle,
-                            contentDescription = null,
-                            tint = if (state.moduleInstalled && state.rootGranted) tokens.success else scheme.primary,
-                        )
-                        Spacer(Modifier.width(11.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(state.taskTitle, fontSize = 16.sp, fontWeight = FontWeight.Bold)
-                            Text(
-                                text = state.taskMessage,
-                                color = tokens.textSecondary,
-                                fontSize = 11.sp,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
-                        if (state.taskRunning) {
-                            Text("${state.taskProgress}%", fontWeight = FontWeight.Black)
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun MiuixMetricCard(
-    modifier: Modifier,
-    icon: ImageVector,
-    label: String,
-    value: String,
-    positive: Boolean,
-) {
-    val tokens = LocalMiuixTokens.current
-    Card(
-        modifier = modifier,
-        shape = RoundedCornerShape(30.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 5.dp),
-    ) {
-        Column(modifier = Modifier.padding(18.dp)) {
-            Surface(
-                modifier = Modifier.size(44.dp),
-                shape = RoundedCornerShape(17.dp),
-                color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                }
-            }
-            Spacer(Modifier.height(14.dp))
-            Text(label, color = tokens.textSecondary, fontSize = 10.sp)
-            Text(
-                text = value,
-                color = tokens.textPrimary,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Black,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Text(
-                text = if (positive) "运行正常" else "需要检查",
-                color = if (positive) tokens.success else MaterialTheme.colorScheme.error,
-                fontSize = 10.sp,
-                fontWeight = FontWeight.Bold,
-            )
-        }
-    }
-}
-
-@Composable
-private fun MiuixSystemWeightCard(weight: HomeWeightUiState, actions: HomeActions) {
-    val tokens = LocalMiuixTokens.current
-    Card(
-        shape = RoundedCornerShape(34.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 7.dp),
-    ) {
-        Column(Modifier.padding(20.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(
-                    modifier = Modifier.size(50.dp),
-                    shape = RoundedCornerShape(18.dp),
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(Icons.Rounded.Speed, null, tint = MaterialTheme.colorScheme.primary)
-                    }
-                }
-                Spacer(Modifier.width(13.dp))
-                Column(Modifier.weight(1f)) {
-                    Text("当前粗细", color = tokens.textPrimary, fontSize = 18.sp, fontWeight = FontWeight.Black)
-                    Text("不修改字体文件", color = tokens.textSecondary, fontSize = 10.sp)
-                }
-                Text(
-                    if (weight.loading) "读取中" else weight.weight.toString(),
-                    color = MaterialTheme.colorScheme.primary,
-                    fontSize = 27.sp,
-                    fontWeight = FontWeight.Black,
-                )
-            }
-            Spacer(Modifier.height(16.dp))
-            when {
-                weight.loading -> LinearProgressIndicator(Modifier.fillMaxWidth())
-                !weight.supported -> Text(
-                    weight.error.ifBlank { "当前系统不支持全局粗细微调" },
-                    color = MaterialTheme.colorScheme.error,
-                    fontSize = 11.sp,
-                )
-                else -> {
+                if (state.systemWeight.supported && !state.systemWeight.loading) {
+                    val range = (state.systemWeight.max - state.systemWeight.min).coerceAtLeast(1)
+                    val normalized = ((state.systemWeight.weight - state.systemWeight.min).toFloat() / range.toFloat())
+                        .coerceIn(0f, 1f)
                     Slider(
-                        value = weight.weight.toFloat(),
-                        onValueChange = actions.previewSystemWeight,
-                        enabled = !weight.applying,
-                        valueRange = weight.min.toFloat()..weight.max.toFloat(),
-                        steps = (((weight.max - weight.min) / weight.step) - 1).coerceAtLeast(0),
+                        value = normalized,
+                        onValueChange = { value ->
+                            val raw = state.systemWeight.min + (range * value).toInt()
+                            val step = state.systemWeight.step.coerceAtLeast(1)
+                            val snapped = state.systemWeight.min + ((raw - state.systemWeight.min) / step) * step
+                            actions.previewSystemWeight(snapped.toFloat())
+                        },
+                        enabled = !state.systemWeight.applying,
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 4.dp),
                     )
-                    Row(Modifier.fillMaxWidth()) {
-                        Text("更细 ${weight.min}", color = tokens.textSecondary, fontSize = 10.sp)
-                        Spacer(Modifier.weight(1f))
-                        Text("标准 400", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold)
-                        Spacer(Modifier.weight(1f))
-                        Text("${weight.max} 更粗", color = tokens.textSecondary, fontSize = 10.sp)
-                    }
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            weight.error.ifBlank { weight.message },
-                            modifier = Modifier.weight(1f),
-                            color = if (weight.error.isNotBlank()) MaterialTheme.colorScheme.error else tokens.textSecondary,
-                            fontSize = 10.sp,
-                            maxLines = 2,
-                        )
-                        TextButton(onClick = actions.resetSystemWeight, enabled = !weight.applying) {
-                            Text("恢复原始")
-                        }
-                    }
                 }
+                BasicComponent(
+                    title = "恢复原始粗细",
+                    summary = "恢复系统默认字体渲染参数",
+                    enabled = !state.systemWeight.applying,
+                    onClick = actions.resetSystemWeight,
+                )
+                BasicComponent(
+                    title = "打开字体组合",
+                    summary = "分别选择中文、英文和数字字体",
+                    onClick = actions.openFontStudio,
+                )
             }
         }
     }
 }
 
-private data class MiuixHomeAction(
-    val icon: ImageVector,
+@Composable
+private fun MiuixHomeCard(
+    title: String,
+    summary: String,
+    icon: ImageVector,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = title,
+            summary = summary,
+            startAction = { MiuixHomeIcon(icon) },
+            enabled = enabled,
+            onClick = onClick,
+        )
+    }
+}
+
+@Composable
+private fun MiuixHomeIcon(icon: ImageVector) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = MiuixTheme.colorScheme.primary,
+        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+    )
+}
+
+@Composable
+private fun MiuixSectionTitle(title: String) {
+    Text(
+        text = title,
+        color = MiuixTheme.colorScheme.onBackground,
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(start = 4.dp, top = 14.dp, bottom = 2.dp),
+    )
+}
+
+private data class MiuixNextStep(
     val title: String,
-    val description: String,
+    val summary: String,
+    val icon: ImageVector,
+    val enabled: Boolean = true,
     val onClick: () -> Unit,
 )
 
-@Composable
-private fun MiuixActionGroup(items: List<MiuixHomeAction>) {
-    val tokens = LocalMiuixTokens.current
-    Card(
-        shape = RoundedCornerShape(34.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 7.dp),
-    ) {
-        Column(modifier = Modifier.padding(horizontal = 15.dp, vertical = 5.dp)) {
-            items.forEachIndexed { index, item ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(onClick = item.onClick)
-                        .padding(horizontal = 2.dp, vertical = 14.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Surface(
-                        modifier = Modifier.size(48.dp),
-                        shape = RoundedCornerShape(17.dp),
-                        color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(
-                                imageVector = item.icon,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(25.dp),
-                            )
-                        }
-                    }
-                    Spacer(Modifier.width(13.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(item.title, color = tokens.textPrimary, fontSize = 17.sp, fontWeight = FontWeight.Black)
-                        Text(
-                            text = item.description,
-                            color = tokens.textSecondary,
-                            fontSize = 11.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                    Icon(
-                        imageVector = Icons.Rounded.ChevronRight,
-                        contentDescription = null,
-                        tint = tokens.textSecondary,
-                    )
-                }
-                if (index != items.lastIndex) {
-                    HorizontalDivider(
-                        modifier = Modifier.padding(start = 61.dp),
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .55f),
-                    )
-                }
-            }
-        }
-    }
+private fun miuixNextStep(state: HomeUiState, actions: HomeActions): MiuixNextStep = when {
+    !state.moduleInstalled -> MiuixNextStep(
+        title = "连接洛书模块",
+        summary = "安装模块并授予 Root 权限后才能应用全局字体",
+        icon = Icons.Rounded.Refresh,
+        onClick = actions.refresh,
+    )
+    state.taskRunning -> MiuixNextStep(
+        title = "字体任务正在处理",
+        summary = state.taskMessage.ifBlank { "可以离开 App，后台任务会继续运行" },
+        icon = Icons.Rounded.Description,
+        onClick = actions.openLogs,
+    )
+    state.rebootRequired -> MiuixNextStep(
+        title = "字体已经准备完成",
+        summary = "执行一次完整重启后应用全局字体并自动验证",
+        icon = Icons.Rounded.RestartAlt,
+        onClick = actions.reboot,
+    )
+    state.error.isNotBlank() -> MiuixNextStep(
+        title = "发现需要处理的问题",
+        summary = "打开任务中心查看错误原因与诊断信息",
+        icon = Icons.Rounded.Warning,
+        onClick = actions.openLogs,
+    )
+    state.currentFont.contains("系统") -> MiuixNextStep(
+        title = "选择一款字体",
+        summary = "从字体库导入、预览并应用单字体",
+        icon = Icons.Rounded.FontDownload,
+        onClick = actions.openFontLibrary,
+    )
+    else -> MiuixNextStep(
+        title = "继续调整当前字体",
+        summary = "组合中文、英文与数字字体，或调整真实设计轴",
+        icon = Icons.Rounded.Layers,
+        onClick = actions.openFontStudio,
+    )
 }
 
-@Composable
-private fun MiuixSectionTitle(eyebrow: String, title: String, subtitle: String) {
-    val tokens = LocalMiuixTokens.current
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 3.dp),
-        verticalAlignment = Alignment.Bottom,
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                eyebrow,
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 9.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 2.sp,
-            )
-            Text(title, color = tokens.textPrimary, fontSize = 25.sp, fontWeight = FontWeight.Black)
-        }
-        Text(subtitle, color = tokens.textSecondary, fontSize = 11.sp)
-    }
+private fun engineSummary(state: HomeUiState): String = when {
+    state.error.isNotBlank() -> state.error
+    state.taskRunning -> state.taskMessage.ifBlank { "任务执行中 · ${state.taskProgress}%" }
+    state.rebootRequired -> "字体负载已准备完成，等待完整重启"
+    state.moduleInstalled && state.rootGranted && state.mountHealthy -> "字体引擎运行正常"
+    else -> "正在检查模块、Root 与挂载环境"
+}
+
+private fun taskSummary(state: HomeUiState): String = when {
+    state.taskRunning -> state.taskMessage.ifBlank { "${state.taskTitle} · ${state.taskProgress}%" }
+    state.taskMessage.isNotBlank() -> state.taskMessage
+    state.taskTitle.isNotBlank() -> state.taskTitle
+    else -> "暂无后台任务"
 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryManagementMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryManagementMiuix.kt
@@ -1,0 +1,420 @@
+package io.github.xgl34222220.luoshu.ui.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Label
+import androidx.compose.material.icons.rounded.ListAlt
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material.icons.rounded.StarBorder
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.luoshu.FontItem
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.Checkbox
+import top.yukonga.miuix.kmp.basic.CircularProgressIndicator
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.overlay.OverlayDialog
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+
+@Composable
+internal fun FontLibraryManagementButtonMiuix(
+    favoriteCount: Int,
+    issueCount: Int,
+    loading: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        enabled = !loading,
+        modifier = modifier,
+    ) {
+        if (loading) {
+            CircularProgressIndicator(
+                progress = null,
+                modifier = Modifier.size(20.dp),
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Rounded.ListAlt,
+                contentDescription = null,
+                modifier = Modifier.size(21.dp),
+            )
+        }
+        Column(modifier = Modifier.padding(start = 10.dp)) {
+            Text("管理字体库", fontWeight = FontWeight.Bold)
+            Text(
+                text = "收藏 $favoriteCount · 提示 $issueCount",
+                fontSize = 11.sp,
+                color = MiuixTheme.colorScheme.onPrimary.copy(alpha = .74f),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun FontLibraryManagementDialogMiuix(
+    fonts: List<FontItem>,
+    activeFontId: String,
+    collections: FontLibraryCollections,
+    conflicts: FontLibraryConflictReport,
+    onCollectionsChange: (FontLibraryCollections) -> Unit,
+    onOpenDetails: (FontItem) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selectedIds by remember(fonts) { mutableStateOf(emptySet<String>()) }
+    val sections = remember(fonts) { groupFontFamilies(fonts) }
+    val allIds = remember(fonts) { fonts.map { it.id }.toSet() }
+
+    OverlayDialog(
+        title = "Family 与收藏管理",
+        summary = "${fonts.size} 个 Family · ${collections.favoriteIds.size} 个收藏 · ${conflicts.issueIds.size} 个提示",
+        show = true,
+        onDismissRequest = onDismiss,
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            MiuixManagementBatchPanel(
+                selectedIds = selectedIds,
+                allIds = allIds,
+                collections = collections,
+                onSelectAll = {
+                    selectedIds = if (selectedIds.size == allIds.size) emptySet() else allIds
+                },
+                onClear = { selectedIds = emptySet() },
+                onToggleFavorite = {
+                    onCollectionsChange(toggleFontFavorite(collections, selectedIds))
+                },
+                onToggleTag = { tag ->
+                    onCollectionsChange(toggleFontTag(collections, selectedIds, tag))
+                },
+            )
+
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth().heightIn(max = 520.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                sections.forEach { section ->
+                    item(key = "miuix-header-${section.bucket.name}") {
+                        Column(Modifier.padding(start = 4.dp, top = 7.dp, bottom = 2.dp)) {
+                            Text(
+                                text = section.bucket.label,
+                                fontSize = 17.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = MiuixTheme.colorScheme.onBackground,
+                            )
+                            Text(
+                                text = section.bucket.description,
+                                fontSize = 11.sp,
+                                color = MiuixTheme.colorScheme.onSurfaceSecondary,
+                            )
+                        }
+                    }
+                    items(section.fonts, key = { it.id }) { font ->
+                        MiuixManagementFamilyRow(
+                            font = font,
+                            active = font.id == activeFontId,
+                            selected = font.id in selectedIds,
+                            favorite = font.id in collections.favoriteIds,
+                            tags = collections.tags[font.id].orEmpty(),
+                            conflictMessage = conflicts.messages[font.id].orEmpty(),
+                            duplicate = font.id in conflicts.duplicateIds,
+                            onSelect = {
+                                selectedIds = if (font.id in selectedIds) {
+                                    selectedIds - font.id
+                                } else {
+                                    selectedIds + font.id
+                                }
+                            },
+                            onFavorite = {
+                                onCollectionsChange(toggleFontFavorite(collections, setOf(font.id)))
+                            },
+                            onDetails = { onOpenDetails(font) },
+                        )
+                    }
+                }
+            }
+
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("完成", fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MiuixManagementBatchPanel(
+    selectedIds: Set<String>,
+    allIds: Set<String>,
+    collections: FontLibraryCollections,
+    onSelectAll: () -> Unit,
+    onClear: () -> Unit,
+    onToggleFavorite: () -> Unit,
+    onToggleTag: (String) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = "批量整理",
+            summary = if (selectedIds.isEmpty()) {
+                "选择 Family 后可批量收藏或添加标签"
+            } else {
+                "已选择 ${selectedIds.size} 个 Family"
+            },
+            startAction = {
+                MiuixManagementIcon(Icons.Rounded.Label)
+            },
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextButton(
+                text = if (selectedIds.size == allIds.size && allIds.isNotEmpty()) "取消全选" else "全选",
+                enabled = allIds.isNotEmpty(),
+                onClick = onSelectAll,
+            )
+            if (selectedIds.isNotEmpty()) {
+                Spacer(Modifier.width(8.dp))
+                TextButton(text = "清空", onClick = onClear)
+            }
+        }
+        if (selectedIds.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                val allFavorite = selectedIds.all { it in collections.favoriteIds }
+                MiuixManagementAction(
+                    label = if (allFavorite) "取消收藏" else "加入收藏",
+                    active = allFavorite,
+                    icon = if (allFavorite) Icons.Rounded.Star else Icons.Rounded.StarBorder,
+                    onClick = onToggleFavorite,
+                )
+                fontLibraryTagOptions.forEach { tag ->
+                    MiuixManagementAction(
+                        label = tag,
+                        active = selectedIds.all { tag in collections.tags[it].orEmpty() },
+                        icon = Icons.Rounded.Label,
+                        onClick = { onToggleTag(tag) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MiuixManagementAction(
+    label: String,
+    active: Boolean,
+    icon: ImageVector,
+    onClick: () -> Unit,
+) {
+    if (active) {
+        Button(onClick = onClick) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(17.dp))
+            Text(label, modifier = Modifier.padding(start = 6.dp))
+        }
+    } else {
+        TextButton(text = label, onClick = onClick)
+    }
+}
+
+@Composable
+private fun MiuixManagementFamilyRow(
+    font: FontItem,
+    active: Boolean,
+    selected: Boolean,
+    favorite: Boolean,
+    tags: Set<String>,
+    conflictMessage: String,
+    duplicate: Boolean,
+    onSelect: () -> Unit,
+    onFavorite: () -> Unit,
+    onDetails: () -> Unit,
+) {
+    val colors = MiuixTheme.colorScheme
+    val warning = conflictMessage.isNotBlank()
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = when {
+                        !font.valid -> colors.errorContainer.copy(alpha = .52f)
+                        selected -> colors.primaryContainer.copy(alpha = .62f)
+                        else -> Color.Transparent
+                    },
+                    shape = RoundedCornerShape(24.dp),
+                )
+                .padding(horizontal = 14.dp, vertical = 13.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(
+                state = if (selected) ToggleableState.On else ToggleableState.Off,
+                onClick = onSelect,
+            )
+            Spacer(Modifier.width(11.dp))
+            Box(
+                modifier = Modifier
+                    .size(46.dp)
+                    .background(colors.tertiaryContainer, RoundedCornerShape(16.dp))
+                    .clickable(onClick = onDetails),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "Aa",
+                    color = colors.primary,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+            Spacer(Modifier.width(11.dp))
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(onClick = onDetails),
+            ) {
+                Text(
+                    text = font.name,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = colors.onBackground,
+                )
+                Text(
+                    text = miuixFamilyStructureLabel(font),
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = colors.onSurfaceSecondary,
+                )
+                if (active || tags.isNotEmpty() || warning || !font.valid) {
+                    Spacer(Modifier.size(6.dp))
+                    Row(
+                        modifier = Modifier.horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        if (active) {
+                            MiuixManagementTag("使用中", colors.primary, Icons.Rounded.CheckCircle)
+                        }
+                        tags.sorted().forEach { tag ->
+                            MiuixManagementTag(tag, colors.secondary, Icons.Rounded.Label)
+                        }
+                        if (warning) {
+                            MiuixManagementTag(
+                                if (duplicate) "疑似重复" else "命名冲突",
+                                colors.error,
+                                Icons.Rounded.Warning,
+                            )
+                        }
+                        if (!font.valid) {
+                            MiuixManagementTag("需检查", colors.error, Icons.Rounded.Warning)
+                        }
+                    }
+                }
+                if (warning) {
+                    Spacer(Modifier.size(5.dp))
+                    Text(
+                        text = conflictMessage,
+                        fontSize = 10.sp,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        color = colors.error,
+                    )
+                }
+            }
+            Spacer(Modifier.width(8.dp))
+            TextButton(
+                text = if (favorite) "已收藏" else "收藏",
+                onClick = onFavorite,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiuixManagementTag(
+    text: String,
+    color: Color,
+    icon: ImageVector,
+) {
+    Row(
+        modifier = Modifier
+            .background(color.copy(alpha = .12f), RoundedCornerShape(999.dp))
+            .padding(horizontal = 8.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = color,
+            modifier = Modifier.size(13.dp),
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(
+            text = text,
+            color = color,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun MiuixManagementIcon(icon: ImageVector) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = MiuixTheme.colorScheme.primary,
+        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+    )
+}
+
+private fun miuixFamilyStructureLabel(font: FontItem): String = when {
+    !font.valid -> font.error.ifBlank { "字体检查未通过" }
+    font.variable -> "可变 Family · 连续设计轴 · ${font.format}"
+    font.weights.size >= 2 -> "静态 Family · ${font.weights.size} 个字重 · ${font.format}"
+    else -> "单字体 · ${font.weightLabel} · ${font.format}"
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryRoute.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryRoute.kt
@@ -60,25 +60,37 @@ internal fun FontLibraryRoute(
         collectionStore.save(next)
     }
 
-    val managementTools: @Composable () -> Unit = {
+    val miuixTools: @Composable () -> Unit = {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            topActions()
+            FontLibraryManagementButtonMiuix(
+                favoriteCount = collections.favoriteIds.size,
+                issueCount = conflicts.issueIds.size,
+                loading = state.loading,
+                onClick = { showManagement = true },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+    val materialTools: @Composable () -> Unit = {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             topActions()
             FontLibraryUtilitiesBar(
-                style = style,
+                style = UiStyle.MATERIAL,
                 fonts = state.allFonts,
                 collections = collections,
                 enabled = !state.loading && !state.operationBusy,
                 onCollectionsChange = ::persistCollections,
             )
             FontArchiveExportTool(
-                style = style,
+                style = UiStyle.MATERIAL,
                 fonts = state.allFonts,
                 collections = collections,
                 enabled = !state.loading && !state.operationBusy,
                 modifier = Modifier.fillMaxWidth(),
             )
             FontLibraryManagementButton(
-                style = style,
+                style = UiStyle.MATERIAL,
                 favoriteCount = collections.favoriteIds.size,
                 issueCount = conflicts.issueIds.size,
                 loading = state.loading,
@@ -92,37 +104,50 @@ internal fun FontLibraryRoute(
         UiStyle.MIUIX -> FontLibraryScreenMiuix(
             state = displayState,
             actions = displayActions,
-            topActions = managementTools,
+            topActions = miuixTools,
         )
         UiStyle.MATERIAL -> FontLibraryScreenCompact(
             style = UiStyle.MATERIAL,
             state = displayState,
             actions = displayActions,
-            tools = managementTools,
+            tools = materialTools,
         )
     }
 
     if (showManagement) {
-        FontLibraryManagementDialog(
-            style = style,
-            fonts = state.fonts,
-            activeFontId = state.activeFontId,
-            collections = collections,
-            conflicts = conflicts,
-            onCollectionsChange = { visibleNext ->
-                val visibleIds = state.fonts.map { it.id }.toSet()
-                val merged = FontLibraryCollections(
-                    favoriteIds = (collections.favoriteIds - visibleIds) + visibleNext.favoriteIds,
-                    tags = collections.tags.filterKeys { it !in visibleIds } + visibleNext.tags,
-                )
-                persistCollections(merged)
-            },
-            onOpenDetails = { font ->
-                showManagement = false
-                detailFont = font
-            },
-            onDismiss = { showManagement = false },
-        )
+        val onCollectionsUpdate: (FontLibraryCollections) -> Unit = { visibleNext ->
+            val visibleIds = state.fonts.map { it.id }.toSet()
+            val merged = FontLibraryCollections(
+                favoriteIds = (collections.favoriteIds - visibleIds) + visibleNext.favoriteIds,
+                tags = collections.tags.filterKeys { it !in visibleIds } + visibleNext.tags,
+            )
+            persistCollections(merged)
+        }
+        val onOpenDetails: (FontItem) -> Unit = { font ->
+            showManagement = false
+            detailFont = font
+        }
+        when (style) {
+            UiStyle.MIUIX -> FontLibraryManagementDialogMiuix(
+                fonts = state.fonts,
+                activeFontId = state.activeFontId,
+                collections = collections,
+                conflicts = conflicts,
+                onCollectionsChange = onCollectionsUpdate,
+                onOpenDetails = onOpenDetails,
+                onDismiss = { showManagement = false },
+            )
+            UiStyle.MATERIAL -> FontLibraryManagementDialog(
+                style = UiStyle.MATERIAL,
+                fonts = state.fonts,
+                activeFontId = state.activeFontId,
+                collections = collections,
+                conflicts = conflicts,
+                onCollectionsChange = onCollectionsUpdate,
+                onOpenDetails = onOpenDetails,
+                onDismiss = { showManagement = false },
+            )
+        }
     }
 
     detailFont?.let { font ->

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryRoute.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryRoute.kt
@@ -88,12 +88,19 @@ internal fun FontLibraryRoute(
         }
     }
 
-    FontLibraryScreenCompact(
-        style = style,
-        state = displayState,
-        actions = displayActions,
-        tools = managementTools,
-    )
+    when (style) {
+        UiStyle.MIUIX -> FontLibraryScreenMiuix(
+            state = displayState,
+            actions = displayActions,
+            topActions = managementTools,
+        )
+        UiStyle.MATERIAL -> FontLibraryScreenCompact(
+            style = UiStyle.MATERIAL,
+            state = displayState,
+            actions = displayActions,
+            tools = managementTools,
+        )
+    }
 
     if (showManagement) {
         FontLibraryManagementDialog(

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryScreenMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontLibraryScreenMiuix.kt
@@ -1,6 +1,7 @@
 package io.github.xgl34222220.luoshu.ui.library
 
-import androidx.compose.foundation.clickable
+import android.view.Gravity
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -8,11 +9,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -22,39 +21,35 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CheckCircle
-import androidx.compose.material.icons.rounded.ChevronRight
-import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.FontDownload
 import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Restore
 import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Sort
+import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material.icons.rounded.Warning
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import android.view.Gravity
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.xgl34222220.luoshu.FontItem
 import io.github.xgl34222220.luoshu.NativeFontPreview
 import io.github.xgl34222220.luoshu.ui.font.fontCapabilityLabel
-import io.github.xgl34222220.luoshu.ui.font.fontPreviewText
-import io.github.xgl34222220.luoshu.ui.theme.LocalMiuixTokens
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.basic.TextField
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 @Composable
 internal fun FontLibraryScreenMiuix(
@@ -62,61 +57,170 @@ internal fun FontLibraryScreenMiuix(
     actions: FontLibraryActions,
     topActions: @Composable () -> Unit = {},
 ) {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 28.dp),
-        verticalArrangement = Arrangement.spacedBy(14.dp),
-    ) {
-        item { MiuixLibraryHeader(state, actions.refresh) }
-        item { topActions() }
-        item { MiuixBrowsePanel(state, actions) }
+    val colors = MiuixTheme.colorScheme
+    var showTools by rememberSaveable { mutableStateOf(false) }
 
-        if (state.loading || state.operationBusy) {
-            item {
-                LinearProgressIndicator(
-                    modifier = Modifier.fillMaxWidth().height(4.dp),
-                    trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background),
+        contentPadding = PaddingValues(start = 16.dp, top = 18.dp, end = 16.dp, bottom = 112.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        item {
+            Row(
+                modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "字体库",
+                        fontSize = 34.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.onBackground,
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = "${state.validCount}/${state.totalCount} 可用 · 当前显示 ${state.visibleCount}",
+                        fontSize = 14.sp,
+                        color = colors.onSurfaceSecondary,
+                    )
+                }
+                Button(
+                    onClick = actions.refresh,
+                    enabled = !state.loading,
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Refresh,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Text(
+                        text = if (state.loading) "读取中" else "刷新",
+                        modifier = Modifier.padding(start = 7.dp),
+                    )
+                }
+            }
+        }
+
+        item {
+            TextField(
+                value = state.query,
+                onValueChange = actions.setQuery,
+                label = "搜索名称、ID 或格式",
+                useLabelAsPlaceholder = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Search,
+                    contentDescription = null,
+                    tint = colors.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+                FontLibraryFilter.entries.forEach { option ->
+                    if (state.filter == option) {
+                        Button(onClick = { actions.setFilter(option) }) {
+                            Text(option.label)
+                        }
+                    } else {
+                        TextButton(
+                            text = option.label,
+                            onClick = { actions.setFilter(option) },
+                        )
+                    }
+                }
+            }
+        }
+
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                BasicComponent(
+                    title = "排序方式",
+                    summary = state.sort.label,
+                    startAction = { MiuixLibraryIcon(Icons.Rounded.Sort) },
+                    onClick = {
+                        val entries = FontLibrarySort.entries
+                        val next = entries[(entries.indexOf(state.sort) + 1) % entries.size]
+                        actions.setSort(next)
+                    },
+                )
+                BasicComponent(
+                    title = if (showTools) "收起导入与管理" else "导入与管理",
+                    summary = "导入字体、整理收藏、标签与归档",
+                    startAction = { MiuixLibraryIcon(Icons.Rounded.Tune) },
+                    onClick = { showTools = !showTools },
                 )
             }
         }
+
+        if (showTools) {
+            item { topActions() }
+        }
+
         if (state.error.isNotBlank()) {
-            item { MiuixLibraryNotice(state.error, error = true) }
+            item {
+                MiuixLibraryNotice(
+                    title = "字体库需要处理",
+                    message = state.error,
+                    icon = Icons.Rounded.Warning,
+                    error = true,
+                )
+            }
         }
         if (state.operationMessage.isNotBlank()) {
             item {
                 MiuixLibraryNotice(
+                    title = "字体任务",
                     message = state.operationMessage,
+                    icon = Icons.Rounded.CheckCircle,
                     error = false,
-                    busy = state.operationBusy,
                 )
             }
         }
 
+        item { MiuixLibrarySectionTitle("系统字体") }
         item {
-            MiuixSectionLabel(
-                title = "系统字体",
-                subtitle = if (state.activeFontId == "default") "当前使用 ROM 原始字体" else "可随时恢复原始映射",
-            )
-        }
-        item {
-            MiuixSystemFontRow(
-                active = state.activeFontId == "default",
-                busy = state.operationBusy,
-                onRestore = actions.restoreDefault,
-            )
+            Card(modifier = Modifier.fillMaxWidth()) {
+                BasicComponent(
+                    title = "系统默认字体",
+                    summary = if (state.activeFontId == "default") {
+                        "当前正在使用 ROM 原始字体映射"
+                    } else {
+                        "撤销覆盖并恢复 ROM 原始字体映射"
+                    },
+                    startAction = { MiuixLibraryIcon(Icons.Rounded.Restore) },
+                    enabled = !state.operationBusy,
+                    onClick = actions.restoreDefault,
+                )
+            }
         }
 
-        item {
-            MiuixSectionLabel(
-                title = "已导入字体",
-                subtitle = "显示 ${state.visibleCount} 个 · ${state.sort.label}",
-            )
-        }
+        item { MiuixLibrarySectionTitle("已导入字体") }
+
         if (!state.loading && state.fonts.isEmpty()) {
-            item { MiuixLibraryEmpty(state) }
+            item {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    BasicComponent(
+                        title = "没有符合条件的字体",
+                        summary = "调整搜索或筛选，也可以展开导入与管理工具",
+                        startAction = { MiuixLibraryIcon(Icons.Rounded.FontDownload) },
+                    )
+                }
+            }
         }
+
         items(state.fonts, key = { it.id }) { font ->
-            MiuixFontCard(
+            MiuixFontFamilyCard(
                 font = font,
                 active = state.activeFontId == font.id,
                 busy = state.operationBusy,
@@ -129,255 +233,7 @@ internal fun FontLibraryScreenMiuix(
 }
 
 @Composable
-private fun MiuixLibraryHeader(state: FontLibraryUiState, onRefresh: () -> Unit) {
-    val tokens = LocalMiuixTokens.current
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(top = 2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(Modifier.weight(1f)) {
-            Text(
-                "FONT LIBRARY",
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 10.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 2.4.sp,
-            )
-            Spacer(Modifier.height(3.dp))
-            Text(
-                "字体库",
-                color = tokens.textPrimary,
-                fontSize = 38.sp,
-                lineHeight = 43.sp,
-                fontWeight = FontWeight.Black,
-            )
-            Text(
-                "管理与应用本地字体 · ${state.validCount}/${state.totalCount} 可用",
-                color = tokens.textSecondary,
-                fontSize = 12.sp,
-            )
-        }
-        Card(
-            shape = RoundedCornerShape(18.dp),
-            colors = CardDefaults.cardColors(containerColor = tokens.elevatedCardBackground),
-            elevation = CardDefaults.cardElevation(defaultElevation = 5.dp),
-        ) {
-            IconButton(
-                onClick = onRefresh,
-                enabled = !state.loading,
-                modifier = Modifier.size(52.dp),
-            ) {
-                if (state.loading) {
-                    CircularProgressIndicator(Modifier.size(21.dp), strokeWidth = 2.dp)
-                } else {
-                    Icon(Icons.Rounded.Refresh, contentDescription = "刷新字体库")
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun MiuixBrowsePanel(state: FontLibraryUiState, actions: FontLibraryActions) {
-    val tokens = LocalMiuixTokens.current
-    Card(
-        shape = RoundedCornerShape(30.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-    ) {
-        Column(Modifier.padding(12.dp)) {
-            OutlinedTextField(
-                value = state.query,
-                onValueChange = actions.setQuery,
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                shape = RoundedCornerShape(22.dp),
-                leadingIcon = { Icon(Icons.Rounded.Search, contentDescription = null) },
-                placeholder = { Text("搜索名称、ID 或格式") },
-            )
-            Spacer(Modifier.height(12.dp))
-            MiuixPanelLabel("筛选")
-            Spacer(Modifier.height(7.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                FontLibraryFilter.entries.forEach { option ->
-                    MiuixChoicePill(
-                        label = option.label,
-                        active = state.filter == option,
-                        onClick = { actions.setFilter(option) },
-                    )
-                }
-            }
-            Spacer(Modifier.height(12.dp))
-            MiuixPanelLabel("排序")
-            Spacer(Modifier.height(7.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                FontLibrarySort.entries.forEach { option ->
-                    MiuixChoicePill(
-                        label = option.label,
-                        active = state.sort == option,
-                        onClick = { actions.setSort(option) },
-                    )
-                }
-            }
-            Spacer(Modifier.height(12.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                MiuixMetricPill("结果", state.visibleCount, Modifier.weight(1f))
-                MiuixMetricPill("可变", state.variableCount, Modifier.weight(1f))
-                MiuixMetricPill("多字重", state.multiWeightCount, Modifier.weight(1f))
-            }
-        }
-    }
-}
-
-@Composable
-private fun MiuixPanelLabel(text: String) {
-    val tokens = LocalMiuixTokens.current
-    Text(
-        text,
-        color = tokens.textSecondary,
-        fontSize = 10.sp,
-        fontWeight = FontWeight.Bold,
-        letterSpacing = .5.sp,
-    )
-}
-
-@Composable
-private fun MiuixChoicePill(label: String, active: Boolean, onClick: () -> Unit) {
-    Surface(
-        modifier = Modifier.clickable(onClick = onClick),
-        shape = RoundedCornerShape(999.dp),
-        color = if (active) {
-            MaterialTheme.colorScheme.primary
-        } else {
-            MaterialTheme.colorScheme.surfaceContainerHigh
-        },
-    ) {
-        Text(
-            text = label,
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp),
-            color = if (active) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
-            fontSize = 11.sp,
-            fontWeight = FontWeight.Bold,
-            maxLines = 1,
-            softWrap = false,
-        )
-    }
-}
-
-@Composable
-private fun MiuixMetricPill(label: String, value: Int, modifier: Modifier) {
-    val tokens = LocalMiuixTokens.current
-    Surface(
-        modifier = modifier,
-        shape = RoundedCornerShape(18.dp),
-        color = MaterialTheme.colorScheme.primary.copy(alpha = .09f),
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                value.toString(),
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 17.sp,
-                fontWeight = FontWeight.Black,
-            )
-            Spacer(Modifier.width(6.dp))
-            Text(label, color = tokens.textSecondary, fontSize = 10.sp)
-        }
-    }
-}
-
-@Composable
-private fun MiuixSectionLabel(title: String, subtitle: String) {
-    val tokens = LocalMiuixTokens.current
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 2.dp),
-        verticalAlignment = Alignment.Bottom,
-    ) {
-        Text(
-            title,
-            color = tokens.textPrimary,
-            fontSize = 22.sp,
-            fontWeight = FontWeight.Black,
-            modifier = Modifier.weight(1f),
-        )
-        Text(
-            subtitle,
-            color = tokens.textSecondary,
-            fontSize = 10.sp,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}
-
-@Composable
-private fun MiuixSystemFontRow(active: Boolean, busy: Boolean, onRestore: () -> Unit) {
-    val tokens = LocalMiuixTokens.current
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(28.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Surface(
-                modifier = Modifier.size(54.dp),
-                shape = RoundedCornerShape(19.dp),
-                color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Text(
-                        "系",
-                        color = MaterialTheme.colorScheme.primary,
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight.Black,
-                    )
-                }
-            }
-            Spacer(Modifier.width(13.dp))
-            Column(Modifier.weight(1f)) {
-                Text(
-                    "系统默认字体",
-                    color = tokens.textPrimary,
-                    fontSize = 17.sp,
-                    fontWeight = FontWeight.Black,
-                )
-                Text(
-                    "ROM 原始字体映射",
-                    color = tokens.textSecondary,
-                    fontSize = 11.sp,
-                )
-            }
-            Spacer(Modifier.width(8.dp))
-            if (active) {
-                MiuixLibraryPill("使用中", tokens.success)
-            } else {
-                MiuixCardAction(
-                    label = "恢复",
-                    primary = false,
-                    enabled = !busy,
-                    onClick = onRestore,
-                    modifier = Modifier.width(82.dp),
-                    showArrow = false,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun MiuixFontCard(
+private fun MiuixFontFamilyCard(
     font: FontItem,
     active: Boolean,
     busy: Boolean,
@@ -385,380 +241,134 @@ private fun MiuixFontCard(
     onApply: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    val tokens = LocalMiuixTokens.current
-    val scheme = MaterialTheme.colorScheme
-    val shape = RoundedCornerShape(30.dp)
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .shadow(if (active) 8.dp else 4.dp, shape, clip = false),
-        shape = shape,
-        colors = CardDefaults.cardColors(
-            containerColor = if (font.valid) {
-                tokens.cardBackground
-            } else {
-                scheme.errorContainer.copy(alpha = .42f)
+    val colors = MiuixTheme.colorScheme
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = font.name,
+            summary = buildString {
+                append(listOf(font.format, font.size, font.date).filter { it.isNotBlank() }.joinToString(" · "))
+                val capability = fontCapabilityLabel(font)
+                if (capability.isNotBlank()) {
+                    if (isNotEmpty()) append("\n")
+                    append(capability)
+                }
+                if (!font.valid && font.error.isNotBlank()) {
+                    if (isNotEmpty()) append("\n")
+                    append(font.error)
+                }
             },
-        ),
-    ) {
-        Column(Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(
-                    modifier = Modifier.size(56.dp).clickable(onClick = onDetails),
-                    shape = RoundedCornerShape(20.dp),
-                    color = scheme.primary.copy(alpha = .105f),
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        if (font.valid) {
-                            NativeFontPreview(
-                                font = font,
-                                text = "Aa",
-                                axes = if (font.variable) mapOf("wght" to 400f) else emptyMap(),
-                                modifier = Modifier.size(56.dp).padding(7.dp),
-                                textSizeSp = 19f,
-                                gravity = Gravity.CENTER,
-                                maxLines = 1,
-                            )
-                        } else {
-                            Text(
-                                "Aa",
-                                color = scheme.primary,
-                                fontSize = 18.sp,
-                                fontWeight = FontWeight.Black,
-                            )
-                        }
-                    }
-                }
-                Spacer(Modifier.width(13.dp))
-                Column(
-                    modifier = Modifier
-                        .weight(1f)
-                        .heightIn(min = 56.dp)
-                        .clickable(onClick = onDetails),
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Text(
-                        font.name,
-                        color = tokens.textPrimary,
-                        fontSize = 18.sp,
-                        lineHeight = 22.sp,
-                        fontWeight = FontWeight.Black,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Spacer(Modifier.height(2.dp))
-                    Text(
-                        listOf(font.format, font.size, font.date)
-                            .filter { it.isNotBlank() }
-                            .joinToString(" · "),
-                        color = tokens.textSecondary,
-                        fontSize = 10.sp,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                Spacer(Modifier.width(6.dp))
-                if (active) {
-                    MiuixLibraryPill("使用中", tokens.success)
-                } else {
-                    Surface(
-                        onClick = onDelete,
-                        enabled = !busy,
-                        modifier = Modifier.size(40.dp),
-                        shape = RoundedCornerShape(14.dp),
-                        color = tokens.textPrimary.copy(alpha = .055f),
-                        contentColor = tokens.textSecondary,
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(
-                                Icons.Rounded.Delete,
-                                contentDescription = "删除字体",
-                                modifier = Modifier.size(20.dp),
-                            )
-                        }
-                    }
-                }
-            }
-
-            Spacer(Modifier.height(14.dp))
-            Surface(
-                modifier = Modifier.fillMaxWidth().clickable(onClick = onDetails),
-                shape = RoundedCornerShape(23.dp),
-                color = tokens.textPrimary.copy(alpha = .038f),
-            ) {
-                NativeFontPreview(
-                    font = font,
-                    text = fontPreviewText(font, detailed = true),
-                    axes = if (font.variable) mapOf("wght" to 400f) else emptyMap(),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(102.dp)
-                        .padding(horizontal = 16.dp, vertical = 14.dp),
-                    textSizeSp = 23f,
-                    maxLines = 2,
-                )
-            }
-
-            if (!font.valid && font.error.isNotBlank()) {
-                Spacer(Modifier.height(10.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        Icons.Rounded.Warning,
-                        contentDescription = null,
-                        tint = scheme.error,
-                        modifier = Modifier.size(16.dp),
-                    )
-                    Spacer(Modifier.width(6.dp))
-                    Text(
-                        font.error,
-                        color = scheme.error,
-                        fontSize = 10.sp,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
-
-            Spacer(Modifier.height(12.dp))
-            HorizontalDivider(color = scheme.outlineVariant.copy(alpha = .30f))
-            Spacer(Modifier.height(11.dp))
-            MiuixCapabilityStrip(fontCapabilityLabel(font))
-            Spacer(Modifier.height(10.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                MiuixCardAction(
-                    label = "查看详情",
-                    primary = false,
-                    enabled = true,
-                    onClick = onDetails,
-                    modifier = Modifier.weight(1f),
-                    showArrow = false,
-                )
-                if (active) {
-                    MiuixCurrentAction(
-                        modifier = Modifier.weight(1f),
-                        color = tokens.success,
-                    )
-                } else {
-                    MiuixCardAction(
-                        label = "应用字体",
-                        primary = true,
-                        enabled = font.valid && !busy,
-                        onClick = onApply,
-                        modifier = Modifier.weight(1f),
-                        showArrow = true,
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun MiuixCapabilityStrip(text: String) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(17.dp),
-        color = MaterialTheme.colorScheme.primary.copy(alpha = .08f),
-    ) {
-        Text(
-            text = text,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 9.dp),
-            color = MaterialTheme.colorScheme.primary,
-            fontSize = 10.sp,
-            lineHeight = 14.sp,
-            fontWeight = FontWeight.Black,
-            maxLines = 1,
-            softWrap = false,
-            overflow = TextOverflow.Ellipsis,
+            startAction = { MiuixFontPreviewTile(font) },
+            onClick = onDetails,
         )
-    }
-}
-
-@Composable
-private fun MiuixCardAction(
-    label: String,
-    primary: Boolean,
-    enabled: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    showArrow: Boolean,
-) {
-    val scheme = MaterialTheme.colorScheme
-    val container = when {
-        primary && enabled -> scheme.primary
-        primary -> scheme.surfaceVariant
-        else -> scheme.surfaceContainerHigh
-    }
-    val content = when {
-        primary && enabled -> scheme.onPrimary
-        primary -> scheme.onSurfaceVariant.copy(alpha = .68f)
-        else -> scheme.onSurface
-    }
-    Surface(
-        onClick = onClick,
-        enabled = enabled,
-        modifier = modifier.defaultMinSize(minHeight = 46.dp),
-        shape = RoundedCornerShape(17.dp),
-        color = container,
-        contentColor = content,
-        shadowElevation = if (primary && enabled) 3.dp else 0.dp,
-    ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 12.dp),
-            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 72.dp, end = 16.dp, bottom = 14.dp),
+            horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                label,
-                color = content,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Black,
-                maxLines = 1,
-                softWrap = false,
-            )
-            if (showArrow) {
-                Spacer(Modifier.width(4.dp))
+            if (active) {
                 Icon(
-                    Icons.Rounded.ChevronRight,
+                    imageVector = Icons.Rounded.CheckCircle,
                     contentDescription = null,
-                    modifier = Modifier.size(17.dp),
-                    tint = content,
+                    tint = colors.primary,
+                    modifier = Modifier.size(20.dp),
                 )
-            }
-        }
-    }
-}
-
-@Composable
-private fun MiuixCurrentAction(modifier: Modifier = Modifier, color: Color) {
-    Surface(
-        modifier = modifier.defaultMinSize(minHeight = 46.dp),
-        shape = RoundedCornerShape(17.dp),
-        color = color.copy(alpha = .11f),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 12.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                Icons.Rounded.CheckCircle,
-                contentDescription = null,
-                tint = color,
-                modifier = Modifier.size(17.dp),
-            )
-            Spacer(Modifier.width(6.dp))
-            Text(
-                "正在使用",
-                color = color,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Black,
-                maxLines = 1,
-                softWrap = false,
-            )
-        }
-    }
-}
-
-@Composable
-private fun MiuixLibraryNotice(message: String, error: Boolean, busy: Boolean = false) {
-    val tokens = LocalMiuixTokens.current
-    Surface(
-        shape = RoundedCornerShape(27.dp),
-        color = if (error) MaterialTheme.colorScheme.errorContainer else tokens.cardBackground,
-        shadowElevation = if (error) 0.dp else 4.dp,
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(15.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            if (busy) {
-                CircularProgressIndicator(Modifier.size(19.dp), strokeWidth = 2.dp)
+                Text(
+                    text = "使用中",
+                    color = colors.primary,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(start = 6.dp),
+                )
             } else {
-                Icon(
-                    if (error) Icons.Rounded.Warning else Icons.Rounded.CheckCircle,
-                    contentDescription = null,
-                    tint = if (error) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                TextButton(
+                    text = "删除",
+                    enabled = !busy,
+                    onClick = onDelete,
                 )
-            }
-            Spacer(Modifier.width(10.dp))
-            Text(
-                message,
-                modifier = Modifier.weight(1f),
-                color = if (error) MaterialTheme.colorScheme.onErrorContainer else tokens.textPrimary,
-                fontSize = 12.sp,
-            )
-        }
-    }
-}
-
-@Composable
-private fun MiuixLibraryEmpty(state: FontLibraryUiState) {
-    val tokens = LocalMiuixTokens.current
-    val filtered = state.filter != FontLibraryFilter.ALL
-    Card(
-        shape = RoundedCornerShape(34.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 5.dp),
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(34.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Surface(
-                modifier = Modifier.size(58.dp),
-                shape = RoundedCornerShape(21.dp),
-                color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        Icons.Rounded.FontDownload,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = onApply,
+                    enabled = font.valid && !busy,
+                ) {
+                    Text("应用")
                 }
             }
-            Spacer(Modifier.height(13.dp))
-            Text(
-                when {
-                    state.query.isNotBlank() -> "没有匹配的字体"
-                    filtered -> "当前筛选没有结果"
-                    else -> "还没有导入字体"
-                },
-                color = tokens.textPrimary,
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Black,
+        }
+    }
+}
+
+@Composable
+private fun MiuixFontPreviewTile(font: FontItem) {
+    val colors = MiuixTheme.colorScheme
+    Box(
+        modifier = Modifier
+            .padding(end = 16.dp)
+            .size(50.dp)
+            .background(colors.tertiaryContainer, RoundedCornerShape(16.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (font.valid) {
+            NativeFontPreview(
+                font = font,
+                text = "Aa",
+                axes = if (font.variable) mapOf("wght" to 400f) else emptyMap(),
+                modifier = Modifier.size(50.dp).padding(5.dp),
+                textSizeSp = 18f,
+                gravity = Gravity.CENTER,
+                maxLines = 1,
             )
+        } else {
             Text(
-                when {
-                    state.query.isNotBlank() -> "清空搜索或尝试其他关键词"
-                    filtered -> "切换到“全部”查看其他字体"
-                    else -> "使用页面上方的导入工具栏添加字体文件"
-                },
-                color = tokens.textSecondary,
-                fontSize = 11.sp,
-                textAlign = TextAlign.Center,
+                text = "Aa",
+                color = colors.error,
+                fontWeight = FontWeight.Bold,
             )
         }
     }
 }
 
 @Composable
-private fun MiuixLibraryPill(text: String, color: Color) {
-    Surface(shape = RoundedCornerShape(999.dp), color = color.copy(alpha = .12f)) {
-        Text(
-            text,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-            color = color,
-            fontSize = 10.sp,
-            fontWeight = FontWeight.Black,
-            maxLines = 1,
-            softWrap = false,
-            overflow = TextOverflow.Ellipsis,
+private fun MiuixLibraryNotice(
+    title: String,
+    message: String,
+    icon: ImageVector,
+    error: Boolean,
+) {
+    val colors = MiuixTheme.colorScheme
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = title,
+            summary = message,
+            startAction = {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = if (error) colors.error else colors.primary,
+                    modifier = Modifier.padding(end = 16.dp).size(24.dp),
+                )
+            },
         )
     }
+}
+
+@Composable
+private fun MiuixLibraryIcon(icon: ImageVector) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = MiuixTheme.colorScheme.primary,
+        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+    )
+}
+
+@Composable
+private fun MiuixLibrarySectionTitle(title: String) {
+    Text(
+        text = title,
+        color = MiuixTheme.colorScheme.onBackground,
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(start = 4.dp, top = 14.dp, bottom = 2.dp),
+    )
 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsMiuixOverlays.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsMiuixOverlays.kt
@@ -1,0 +1,163 @@
+package io.github.xgl34222220.luoshu.ui.logs
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import io.github.xgl34222220.luoshu.NativeImportPhase
+import io.github.xgl34222220.luoshu.NativeImportState
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.CircularProgressIndicator
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.LinearProgressIndicator
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.overlay.OverlayDialog
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+
+@Composable
+internal fun DiagnosticExportButtonMiuix(
+    state: DiagnosticExportState,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        enabled = !state.busy,
+        modifier = modifier,
+    ) {
+        if (state.busy) {
+            CircularProgressIndicator(
+                progress = null,
+                modifier = Modifier.size(21.dp),
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Rounded.Description,
+                contentDescription = null,
+                modifier = Modifier.size(21.dp),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun DiagnosticExportDialogMiuix(
+    state: DiagnosticExportState,
+    onDismiss: () -> Unit,
+) {
+    val colors = MiuixTheme.colorScheme
+    val failed = state.error.isNotBlank()
+    OverlayDialog(
+        title = if (failed) "诊断报告生成失败" else "脱敏诊断报告已生成",
+        summary = if (failed) {
+            state.error
+        } else {
+            "报告只包含引擎状态和错误数量，不包含设备指纹、序列号、型号、字体名称、字体文件名或私人路径。"
+        },
+        show = true,
+        onDismissRequest = onDismiss,
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                BasicComponent(
+                    title = if (failed) "生成失败" else "保存位置",
+                    summary = if (failed) state.error else state.path,
+                    startAction = {
+                        Icon(
+                            imageVector = if (failed) Icons.Rounded.Warning else Icons.Rounded.CheckCircle,
+                            contentDescription = null,
+                            tint = if (failed) colors.error else colors.primary,
+                            modifier = Modifier.padding(end = 16.dp).size(24.dp),
+                        )
+                    },
+                )
+            }
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("完成", fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ImportTaskControlsMiuix(
+    state: NativeImportState,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onCancel: () -> Unit,
+    onRetry: () -> Unit,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (state.taskId.isBlank() || state.phase == NativeImportPhase.IDLE) return
+
+    Card(modifier = modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = state.title,
+            summary = state.message,
+            startAction = {
+                if (state.busy) {
+                    CircularProgressIndicator(
+                        progress = null,
+                        modifier = Modifier.padding(end = 16.dp).size(23.dp),
+                    )
+                } else {
+                    Icon(
+                        imageVector = if (state.failed.isNotEmpty()) Icons.Rounded.Warning else Icons.Rounded.Description,
+                        contentDescription = null,
+                        tint = if (state.failed.isNotEmpty()) MiuixTheme.colorScheme.error else MiuixTheme.colorScheme.primary,
+                        modifier = Modifier.padding(end = 16.dp).size(23.dp),
+                    )
+                }
+            },
+        )
+        if (state.busy || state.paused) {
+            LinearProgressIndicator(
+                progress = state.progress.coerceIn(0, 100) / 100f,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (state.canPause) {
+                TextButton(text = "暂停", onClick = onPause)
+            }
+            if (state.canResume) {
+                Button(onClick = onResume) { Text("继续", fontWeight = FontWeight.Bold) }
+            }
+            if (state.canCancel) {
+                TextButton(text = "取消", onClick = onCancel)
+            }
+            if (state.canRetryFailed) {
+                Button(onClick = onRetry) { Text("重试失败项", fontWeight = FontWeight.Bold) }
+            }
+            if (state.canClear) {
+                TextButton(text = "清除记录", onClick = onClear)
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsRoute.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsRoute.kt
@@ -44,33 +44,62 @@ internal fun LogsRoute(
             .navigationBarsPadding()
             .padding(bottom = 96.dp),
     ) {
-        LogsScreenCompact(
-            style = style,
-            state = displayState,
-            actions = actions,
-            diagnosticState = diagnosticState,
-            onDiagnostic = onDiagnostic,
-            onClose = onClose,
-        )
-        ImportTaskControls(
-            style = style,
-            state = importState,
-            onPause = importViewModel::pauseImport,
-            onResume = importViewModel::resumeImport,
-            onCancel = importViewModel::cancelImport,
-            onRetry = importViewModel::retryFailed,
-            onClear = importViewModel::clearRecord,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(horizontal = 14.dp, vertical = 12.dp),
-        )
+        when (style) {
+            UiStyle.MIUIX -> LogsScreenMiuix(
+                state = displayState,
+                actions = actions,
+                diagnosticState = diagnosticState,
+                onDiagnostic = onDiagnostic,
+                onClose = onClose,
+            )
+            UiStyle.MATERIAL -> LogsScreenCompact(
+                style = UiStyle.MATERIAL,
+                state = displayState,
+                actions = actions,
+                diagnosticState = diagnosticState,
+                onDiagnostic = onDiagnostic,
+                onClose = onClose,
+            )
+        }
+
+        when (style) {
+            UiStyle.MIUIX -> ImportTaskControlsMiuix(
+                state = importState,
+                onPause = importViewModel::pauseImport,
+                onResume = importViewModel::resumeImport,
+                onCancel = importViewModel::cancelImport,
+                onRetry = importViewModel::retryFailed,
+                onClear = importViewModel::clearRecord,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+            )
+            UiStyle.MATERIAL -> ImportTaskControls(
+                style = UiStyle.MATERIAL,
+                state = importState,
+                onPause = importViewModel::pauseImport,
+                onResume = importViewModel::resumeImport,
+                onCancel = importViewModel::cancelImport,
+                onRetry = importViewModel::retryFailed,
+                onClear = importViewModel::clearRecord,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+            )
+        }
     }
 
     if (diagnosticState.resultVisible) {
-        DiagnosticExportDialog(
-            style = style,
-            state = diagnosticState,
-            onDismiss = { diagnosticState = DiagnosticExportState() },
-        )
+        when (style) {
+            UiStyle.MIUIX -> DiagnosticExportDialogMiuix(
+                state = diagnosticState,
+                onDismiss = { diagnosticState = DiagnosticExportState() },
+            )
+            UiStyle.MATERIAL -> DiagnosticExportDialog(
+                style = UiStyle.MATERIAL,
+                state = diagnosticState,
+                onDismiss = { diagnosticState = DiagnosticExportState() },
+            )
+        }
     }
 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsScreenMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/LogsScreenMiuix.kt
@@ -1,15 +1,14 @@
 package io.github.xgl34222220.luoshu.ui.logs
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,29 +16,18 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.CheckCircle
-import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Description
-import androidx.compose.material.icons.rounded.FontDownload
-import androidx.compose.material.icons.rounded.Layers
 import androidx.compose.material.icons.rounded.Refresh
-import androidx.compose.material.icons.rounded.RestartAlt
-import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Warning
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -49,8 +37,20 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
-import io.github.xgl34222220.luoshu.ui.theme.LocalMiuixTokens
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.LinearProgressIndicator
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+
+private enum class MiuixLogsTab(val label: String) {
+    TASKS("任务"),
+    ISSUES("问题"),
+    LOGS("日志"),
+}
 
 @Composable
 internal fun LogsScreenMiuix(
@@ -58,81 +58,153 @@ internal fun LogsScreenMiuix(
     actions: LogsActions,
     diagnosticState: DiagnosticExportState,
     onDiagnostic: () -> Unit,
+    onClose: (() -> Unit)? = null,
 ) {
+    val colors = MiuixTheme.colorScheme
+    var tab by remember { mutableStateOf(MiuixLogsTab.TASKS) }
+
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 132.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background),
+        contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 116.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         item {
-            MiuixTaskCenterHeader(
-                onRefresh = actions.refresh,
-                diagnosticState = diagnosticState,
-                onDiagnostic = onDiagnostic,
-            )
-        }
-        item { MiuixTaskOverview(state) }
-        item { MiuixSectionTitle("任务时间线", "最近 ${state.tasks.size} 条状态") }
-
-        if (state.tasks.isEmpty()) {
-            item { MiuixTaskEmpty() }
-        } else {
-            items(state.tasks, key = { it.id }) { task ->
-                MiuixTaskCard(task)
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (onClose != null) {
+                    Button(onClick = onClose) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                            contentDescription = null,
+                            modifier = Modifier.size(21.dp),
+                        )
+                    }
+                    Spacer(Modifier.width(10.dp))
+                }
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = "任务中心",
+                        fontSize = 30.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.onBackground,
+                    )
+                    Text(
+                        text = "任务、问题和原始日志",
+                        fontSize = 13.sp,
+                        color = colors.onSurfaceSecondary,
+                    )
+                }
+                DiagnosticExportButtonMiuix(
+                    state = diagnosticState,
+                    onClick = onDiagnostic,
+                )
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = actions.refresh) {
+                    Icon(
+                        imageVector = Icons.Rounded.Refresh,
+                        contentDescription = null,
+                        modifier = Modifier.size(21.dp),
+                    )
+                }
             }
         }
 
-        item { MiuixSectionTitle("原始日志", "诊断字体引擎和挂载问题") }
-        item { MiuixLogSummary(state) }
-        item { MiuixLogPanel(state.content) }
-    }
-}
-
-@Composable
-private fun MiuixTaskCenterHeader(
-    onRefresh: () -> Unit,
-    diagnosticState: DiagnosticExportState,
-    onDiagnostic: () -> Unit,
-) {
-    val tokens = LocalMiuixTokens.current
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(Modifier.weight(1f)) {
-            Text(
-                "TASK CENTER",
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 10.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 2.4.sp,
-            )
-            Spacer(Modifier.height(3.dp))
-            Text(
-                "任务中心",
-                color = tokens.textPrimary,
-                fontSize = 42.sp,
-                lineHeight = 47.sp,
-                fontWeight = FontWeight.Black,
-            )
-            Text("扫描、导入、应用、组合与重启状态", color = tokens.textSecondary, fontSize = 12.sp)
-        }
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            DiagnosticExportButton(
-                style = UiStyle.MIUIX,
-                state = diagnosticState,
-                onClick = onDiagnostic,
-            )
-            Card(
-                shape = RoundedCornerShape(18.dp),
-                colors = CardDefaults.cardColors(containerColor = tokens.elevatedCardBackground),
-                elevation = CardDefaults.cardElevation(defaultElevation = 7.dp),
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                IconButton(onClick = onRefresh, modifier = Modifier.size(56.dp)) {
-                    Icon(Icons.Rounded.Refresh, contentDescription = "刷新任务和日志")
+                MiuixLogsTab.entries.forEach { option ->
+                    if (tab == option) {
+                        Button(onClick = { tab = option }) {
+                            Text(option.label, fontWeight = FontWeight.Bold)
+                        }
+                    } else {
+                        TextButton(
+                            text = option.label,
+                            onClick = { tab = option },
+                        )
+                    }
+                }
+            }
+        }
+
+        when (tab) {
+            MiuixLogsTab.TASKS -> {
+                item { MiuixTaskOverview(state) }
+                if (state.tasks.isEmpty()) {
+                    item {
+                        MiuixLogsEmptyState(
+                            icon = Icons.Rounded.CheckCircle,
+                            title = "当前没有任务记录",
+                            message = "扫描、导入、应用或组合字体后会显示在这里",
+                        )
+                    }
+                } else {
+                    items(state.tasks, key = { it.id }) { task ->
+                        MiuixTaskCard(task)
+                    }
+                }
+            }
+
+            MiuixLogsTab.ISSUES -> {
+                val failed = state.tasks.filter { it.phase == TaskPhase.FAILED }
+                item { MiuixIssueOverview(state, failed.size) }
+                if (failed.isEmpty() && state.errorCount == 0 && state.warningCount == 0) {
+                    item {
+                        MiuixLogsEmptyState(
+                            icon = Icons.Rounded.CheckCircle,
+                            title = "没有发现需要处理的问题",
+                            message = "当前任务与日志中没有失败或警告记录",
+                        )
+                    }
+                } else {
+                    items(failed, key = { "miuix-issue-${it.id}" }) { task ->
+                        MiuixTaskCard(task)
+                    }
+                    if (failed.isEmpty()) {
+                        item {
+                            Card(modifier = Modifier.fillMaxWidth()) {
+                                BasicComponent(
+                                    title = "原始日志中存在异常记录",
+                                    summary = "${state.warningCount} 条警告 · ${state.errorCount} 条错误\n切换到日志页查看完整内容",
+                                    startAction = { MiuixLogsIcon(Icons.Rounded.Warning, colors.error) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            MiuixLogsTab.LOGS -> {
+                item { MiuixLogOverview(state) }
+                item {
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        BasicComponent(
+                            title = "原始日志",
+                            summary = "支持长按选择和复制，内容不会在界面中改写",
+                            startAction = { MiuixLogsIcon(Icons.Rounded.Description, colors.primary) },
+                        )
+                        SelectionContainer {
+                            Text(
+                                text = state.content,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .heightIn(min = 280.dp)
+                                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                                color = colors.onBackground,
+                                fontFamily = FontFamily.Monospace,
+                                fontSize = 11.sp,
+                                lineHeight = 16.sp,
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -141,293 +213,150 @@ private fun MiuixTaskCenterHeader(
 
 @Composable
 private fun MiuixTaskOverview(state: LogsUiState) {
-    val tokens = LocalMiuixTokens.current
-    Card(
-        shape = RoundedCornerShape(36.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
-    ) {
-        Column(Modifier.padding(19.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(
-                    modifier = Modifier.size(52.dp),
-                    shape = RoundedCornerShape(19.dp),
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(
-                            if (state.activeTaskCount > 0) Icons.Rounded.Refresh else Icons.Rounded.CheckCircle,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                }
-                Spacer(Modifier.width(13.dp))
-                Column(Modifier.weight(1f)) {
-                    Text(
-                        if (state.activeTaskCount > 0) "${state.activeTaskCount} 个任务正在处理" else "当前任务队列空闲",
-                        color = tokens.textPrimary,
-                        fontSize = 19.sp,
-                        fontWeight = FontWeight.Black,
-                    )
-                    Text(
-                        if (state.rebootRequired) "字体已准备完成，等待完整重启" else "进入页面时自动同步后台状态",
-                        color = if (state.rebootRequired) MaterialTheme.colorScheme.primary else tokens.textSecondary,
-                        fontSize = 11.sp,
-                    )
-                }
-            }
-            Spacer(Modifier.height(16.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                MiuixOverviewMetric("进行中", state.activeTaskCount, MaterialTheme.colorScheme.primary, Modifier.weight(1f))
-                MiuixOverviewMetric("已完成", state.completedTaskCount, tokens.success, Modifier.weight(1f))
-                MiuixOverviewMetric("失败", state.failedTaskCount, MaterialTheme.colorScheme.error, Modifier.weight(1f))
-            }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = if (state.activeTaskCount > 0) {
+                "${state.activeTaskCount} 个任务正在处理"
+            } else {
+                "当前任务队列空闲"
+            },
+            summary = if (state.rebootRequired) {
+                "字体已经准备完成，等待一次完整重启"
+            } else {
+                "进入页面时自动同步后台任务状态"
+            },
+            startAction = {
+                MiuixLogsIcon(
+                    icon = if (state.activeTaskCount > 0) Icons.Rounded.Refresh else Icons.Rounded.CheckCircle,
+                    tint = MiuixTheme.colorScheme.primary,
+                )
+            },
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            MiuixMetric("进行中", state.activeTaskCount, MiuixTheme.colorScheme.primary, Modifier.weight(1f))
+            MiuixMetric("已完成", state.completedTaskCount, Color(0xFF21966C), Modifier.weight(1f))
+            MiuixMetric("失败", state.failedTaskCount, MiuixTheme.colorScheme.error, Modifier.weight(1f))
         }
     }
 }
 
 @Composable
-private fun MiuixOverviewMetric(label: String, value: Int, color: Color, modifier: Modifier) {
-    val tokens = LocalMiuixTokens.current
-    Surface(modifier = modifier, shape = RoundedCornerShape(21.dp), color = color.copy(alpha = .10f)) {
-        Column(Modifier.padding(horizontal = 13.dp, vertical = 11.dp)) {
-            Text(value.toString(), color = color, fontSize = 20.sp, fontWeight = FontWeight.Black)
-            Text(label, color = tokens.textSecondary, fontSize = 10.sp)
-        }
-    }
-}
-
-@Composable
-private fun MiuixSectionTitle(title: String, subtitle: String) {
-    val tokens = LocalMiuixTokens.current
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 2.dp),
-        verticalAlignment = Alignment.Bottom,
-    ) {
-        Text(title, color = tokens.textPrimary, fontSize = 22.sp, fontWeight = FontWeight.Black, modifier = Modifier.weight(1f))
-        Text(subtitle, color = tokens.textSecondary, fontSize = 10.sp)
+private fun MiuixIssueOverview(state: LogsUiState, failedCount: Int) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = if (failedCount > 0) "$failedCount 个失败任务需要处理" else "没有失败任务",
+            summary = "${state.warningCount} 条警告 · ${state.errorCount} 条错误日志",
+            startAction = {
+                MiuixLogsIcon(
+                    icon = if (failedCount > 0) Icons.Rounded.Warning else Icons.Rounded.CheckCircle,
+                    tint = if (failedCount > 0) MiuixTheme.colorScheme.error else Color(0xFF21966C),
+                )
+            },
+        )
     }
 }
 
 @Composable
 private fun MiuixTaskCard(task: TaskCenterItem) {
-    val tokens = LocalMiuixTokens.current
-    val color = miuixTaskPhaseColor(task.phase)
-    Card(
-        shape = RoundedCornerShape(32.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = if (task.current) 7.dp else 4.dp),
-    ) {
-        Column(Modifier.padding(horizontal = 17.dp, vertical = 16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(
-                    modifier = Modifier.size(48.dp),
-                    shape = RoundedCornerShape(17.dp),
-                    color = color.copy(alpha = .11f),
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(miuixTaskKindIcon(task.kind), contentDescription = null, tint = color, modifier = Modifier.size(23.dp))
-                    }
-                }
-                Spacer(Modifier.width(12.dp))
-                Column(Modifier.weight(1f)) {
-                    Text(
-                        task.title,
-                        color = tokens.textPrimary,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Black,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        task.message,
-                        color = tokens.textSecondary,
-                        fontSize = 11.sp,
-                        maxLines = 3,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                Spacer(Modifier.width(8.dp))
-                Column(horizontalAlignment = Alignment.End) {
-                    Surface(shape = RoundedCornerShape(999.dp), color = color.copy(alpha = .11f)) {
-                        Text(
-                            task.phase.label,
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-                            color = color,
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Black,
-                        )
-                    }
-                    if (task.timeLabel.isNotBlank()) {
-                        Spacer(Modifier.height(5.dp))
-                        Text(task.timeLabel, color = tokens.textSecondary, fontSize = 9.sp)
-                    }
-                }
-            }
-            if (task.active && task.progress >= 0) {
-                Spacer(Modifier.height(13.dp))
-                LinearProgressIndicator(
-                    progress = { task.progress.coerceIn(0, 100) / 100f },
-                    modifier = Modifier.fillMaxWidth().height(7.dp),
+    val colors = MiuixTheme.colorScheme
+    val tint = when (task.phase) {
+        TaskPhase.FAILED -> colors.error
+        TaskPhase.SUCCESS -> Color(0xFF21966C)
+        TaskPhase.WAITING_REBOOT -> colors.tertiary
+        else -> colors.primary
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = task.title,
+            summary = buildString {
+                append(task.message)
+                if (task.timeLabel.isNotBlank()) append("\n${task.timeLabel}")
+            },
+            startAction = {
+                MiuixLogsIcon(
+                    icon = if (task.phase == TaskPhase.FAILED) Icons.Rounded.Warning else Icons.Rounded.Description,
+                    tint = tint,
                 )
-            }
-        }
-    }
-}
-
-@Composable
-private fun MiuixTaskEmpty() {
-    val tokens = LocalMiuixTokens.current
-    Card(
-        shape = RoundedCornerShape(34.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Surface(
-                modifier = Modifier.size(58.dp),
-                shape = RoundedCornerShape(21.dp),
-                color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(Icons.Rounded.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                }
-            }
-            Spacer(Modifier.height(13.dp))
-            Text("还没有字体任务记录", color = tokens.textPrimary, fontSize = 20.sp, fontWeight = FontWeight.Black)
-            Text("执行扫描、导入、应用或组合后会显示在这里", color = tokens.textSecondary, fontSize = 11.sp)
-        }
-    }
-}
-
-@Composable
-private fun MiuixLogSummary(state: LogsUiState) {
-    val tokens = LocalMiuixTokens.current
-    Card(
-        shape = RoundedCornerShape(32.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
-    ) {
-        Column(Modifier.padding(horizontal = 16.dp, vertical = 7.dp)) {
-            MiuixLogSummaryRow(Icons.Rounded.Description, "日志行数", state.lineCount.toString(), MaterialTheme.colorScheme.primary)
-            MiuixSummaryDivider()
-            MiuixLogSummaryRow(Icons.Rounded.Warning, "警告记录", state.warningCount.toString(), tokens.warning)
-            MiuixSummaryDivider()
-            MiuixLogSummaryRow(
-                Icons.Rounded.CheckCircle,
-                "错误记录",
-                state.errorCount.toString(),
-                if (state.errorCount == 0) tokens.success else MaterialTheme.colorScheme.error,
-            )
-        }
-    }
-}
-
-@Composable
-private fun MiuixLogSummaryRow(icon: ImageVector, title: String, value: String, color: Color) {
-    val tokens = LocalMiuixTokens.current
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 2.dp, vertical = 13.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Surface(modifier = Modifier.size(40.dp), shape = RoundedCornerShape(15.dp), color = color.copy(alpha = .11f)) {
-            Box(contentAlignment = Alignment.Center) {
-                Icon(icon, contentDescription = null, tint = color, modifier = Modifier.size(21.dp))
-            }
-        }
-        Spacer(Modifier.width(12.dp))
-        Text(title, color = tokens.textPrimary, fontSize = 15.sp, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
-        Text(value, color = color, fontSize = 17.sp, fontWeight = FontWeight.Black)
-    }
-}
-
-@Composable
-private fun MiuixSummaryDivider() {
-    Box(
-        Modifier
-            .fillMaxWidth()
-            .padding(start = 54.dp)
-            .height(1.dp)
-            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = .45f)),
-    )
-}
-
-@Composable
-private fun MiuixLogPanel(content: String) {
-    val tokens = LocalMiuixTokens.current
-    Card(
-        shape = RoundedCornerShape(34.dp),
-        colors = CardDefaults.cardColors(containerColor = tokens.cardBackground),
-        elevation = CardDefaults.cardElevation(defaultElevation = 7.dp),
-    ) {
-        Column {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 17.dp, vertical = 14.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Surface(
-                    modifier = Modifier.size(34.dp),
-                    shape = RoundedCornerShape(13.dp),
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = .11f),
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(Icons.Rounded.Description, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(19.dp))
-                    }
-                }
-                Spacer(Modifier.width(10.dp))
-                Column(Modifier.weight(1f)) {
-                    Text("运行输出", color = tokens.textPrimary, fontSize = 16.sp, fontWeight = FontWeight.Black)
-                    Text("长按可选择并复制日志文本", color = tokens.textSecondary, fontSize = 10.sp)
-                }
-            }
-            Box(
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 14.dp)
-                    .height(1.dp)
-                    .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = .45f)),
-            )
-            SelectionContainer {
+            },
+            endActions = {
                 Text(
-                    text = content,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(min = 300.dp, max = 620.dp)
-                        .verticalScroll(rememberScrollState())
-                        .padding(17.dp),
-                    color = tokens.textSecondary,
-                    fontFamily = FontFamily.Monospace,
+                    text = task.phase.label,
+                    color = tint,
                     fontSize = 10.sp,
-                    lineHeight = 15.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
-            }
+            },
+        )
+        if (task.active && task.progress >= 0) {
+            LinearProgressIndicator(
+                progress = task.progress.coerceIn(0, 100) / 100f,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+            )
         }
     }
 }
 
-private fun miuixTaskKindIcon(kind: TaskKind): ImageVector = when (kind) {
-    TaskKind.SCAN -> Icons.Rounded.Search
-    TaskKind.IMPORT -> Icons.Rounded.Add
-    TaskKind.APPLY -> Icons.Rounded.FontDownload
-    TaskKind.RESTORE -> Icons.Rounded.Refresh
-    TaskKind.MIX -> Icons.Rounded.Layers
-    TaskKind.DELETE -> Icons.Rounded.Delete
-    TaskKind.REBOOT -> Icons.Rounded.RestartAlt
-    TaskKind.DIAGNOSTIC -> Icons.Rounded.Description
+@Composable
+private fun MiuixLogOverview(state: LogsUiState) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = "日志概览",
+            summary = "${state.lineCount} 行 · ${state.warningCount} 条警告 · ${state.errorCount} 条错误",
+            startAction = { MiuixLogsIcon(Icons.Rounded.Description, MiuixTheme.colorScheme.primary) },
+        )
+    }
 }
 
 @Composable
-private fun miuixTaskPhaseColor(phase: TaskPhase): Color {
-    val tokens = LocalMiuixTokens.current
-    return when (phase) {
-        TaskPhase.FAILED -> MaterialTheme.colorScheme.error
-        TaskPhase.SUCCESS -> tokens.success
-        TaskPhase.WAITING_REBOOT -> MaterialTheme.colorScheme.secondary
-        TaskPhase.INFO -> tokens.textSecondary
-        TaskPhase.QUEUED, TaskPhase.RUNNING -> MaterialTheme.colorScheme.primary
+private fun MiuixMetric(
+    label: String,
+    value: Int,
+    color: Color,
+    modifier: Modifier,
+) {
+    Card(modifier = modifier) {
+        Column(Modifier.padding(horizontal = 12.dp, vertical = 11.dp)) {
+            Text(
+                text = value.toString(),
+                color = color,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = label,
+                color = MiuixTheme.colorScheme.onSurfaceSecondary,
+                fontSize = 10.sp,
+            )
+        }
     }
+}
+
+@Composable
+private fun MiuixLogsEmptyState(
+    icon: ImageVector,
+    title: String,
+    message: String,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = title,
+            summary = message,
+            startAction = { MiuixLogsIcon(icon, MiuixTheme.colorScheme.primary) },
+        )
+    }
+}
+
+@Composable
+private fun MiuixLogsIcon(icon: ImageVector, tint: Color) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = tint,
+        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+    )
 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/MiuixLogColors.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/logs/MiuixLogColors.kt
@@ -1,0 +1,12 @@
+package io.github.xgl34222220.luoshu.ui.logs
+
+import androidx.compose.ui.graphics.Color
+import top.yukonga.miuix.kmp.theme.Colors
+
+/**
+ * Miuix exposes tertiary container colors but no scalar tertiary role.
+ * Task-center status code previously used the Material role name, so map that
+ * semantic status to the native Miuix secondary role without importing Material.
+ */
+internal val Colors.tertiary: Color
+    get() = secondary

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/settings/AppearanceSettingsMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/settings/AppearanceSettingsMiuix.kt
@@ -1,0 +1,380 @@
+package io.github.xgl34222220.luoshu.ui.settings
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Layers
+import androidx.compose.material.icons.rounded.Palette
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.luoshu.BuildConfig
+import io.github.xgl34222220.luoshu.ui.appearance.AccentOptions
+import io.github.xgl34222220.luoshu.ui.appearance.AppearanceSettings
+import io.github.xgl34222220.luoshu.ui.appearance.KolorStyle
+import io.github.xgl34222220.luoshu.ui.appearance.ThemeMode
+import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.preference.RadioButtonLocation
+import top.yukonga.miuix.kmp.preference.RadioButtonPreference
+import top.yukonga.miuix.kmp.preference.SwitchPreference
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+
+@Composable
+internal fun AppearanceSettingsMiuix(
+    settings: AppearanceSettings,
+    actions: AppearanceActions,
+    showThemeSettings: Boolean,
+    onOpenThemeSettings: () -> Unit,
+    onCloseThemeSettings: () -> Unit,
+) {
+    AnimatedContent(
+        targetState = showThemeSettings,
+        modifier = Modifier.fillMaxSize(),
+        transitionSpec = {
+            if (targetState) {
+                (slideInHorizontally { it } + fadeIn())
+                    .togetherWith(slideOutHorizontally { -it / 7 } + fadeOut())
+            } else {
+                (slideInHorizontally { -it / 7 } + fadeIn())
+                    .togetherWith(slideOutHorizontally { it } + fadeOut())
+            }
+        },
+        label = "miuixSettingsTransition",
+    ) { detail ->
+        if (detail) {
+            MiuixThemeSettingsPage(
+                settings = settings,
+                actions = actions,
+                onBack = onCloseThemeSettings,
+            )
+        } else {
+            MiuixSettingsOverviewPage(
+                settings = settings,
+                actions = actions,
+                onOpenThemeSettings = onOpenThemeSettings,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiuixSettingsOverviewPage(
+    settings: AppearanceSettings,
+    actions: AppearanceActions,
+    onOpenThemeSettings: () -> Unit,
+) {
+    val colors = MiuixTheme.colorScheme
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background),
+        contentPadding = PaddingValues(start = 16.dp, top = 18.dp, end = 16.dp, bottom = 112.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item {
+            MiuixSettingsHeader(
+                title = "设置",
+                subtitle = "外观、任务与显示偏好",
+                icon = Icons.Rounded.Settings,
+            )
+        }
+
+        item { MiuixSettingsSectionTitle("常用") }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                BasicComponent(
+                    title = "主题设置",
+                    summary = "${settings.uiStyle.label} · ${settings.themeMode.label}\nMonet、深色模式与玻璃材质",
+                    startAction = { MiuixSettingsIcon(Icons.Rounded.Palette) },
+                    onClick = onOpenThemeSettings,
+                )
+                BasicComponent(
+                    title = "任务中心",
+                    summary = "查看字体任务、问题与诊断日志",
+                    startAction = { MiuixSettingsIcon(Icons.Rounded.Description) },
+                    onClick = actions.openTaskCenter,
+                )
+            }
+        }
+
+        item { MiuixSettingsSectionTitle("显示与性能") }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                SwitchPreference(
+                    title = "高刷新率",
+                    summary = "优先使用同分辨率高刷新率，省电模式下自动停用",
+                    checked = settings.highRefreshRate,
+                    onCheckedChange = actions.setHighRefreshRate,
+                )
+                SwitchPreference(
+                    title = "悬浮玻璃底栏",
+                    summary = "一级页面保持统一四项导航和手势安全区",
+                    checked = settings.floatingDock,
+                    onCheckedChange = actions.setFloatingDock,
+                )
+            }
+        }
+
+        item { MiuixSettingsSectionTitle("关于") }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                BasicComponent(
+                    title = "洛书",
+                    summary = "Android 无 Hook 全局字体引擎\nv${BuildConfig.VERSION_NAME}",
+                    startAction = { MiuixSettingsIcon(Icons.Rounded.Info) },
+                )
+                BasicComponent(
+                    title = "双界面系统",
+                    summary = "MIUIX 与 Material 3 独立渲染，共享字体业务层",
+                    startAction = { MiuixSettingsIcon(Icons.Rounded.Layers) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MiuixThemeSettingsPage(
+    settings: AppearanceSettings,
+    actions: AppearanceActions,
+    onBack: () -> Unit,
+) {
+    val colors = MiuixTheme.colorScheme
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background),
+        contentPadding = PaddingValues(start = 16.dp, top = 18.dp, end = 16.dp, bottom = 112.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Button(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = null,
+                        modifier = Modifier.size(21.dp),
+                    )
+                }
+                Spacer(Modifier.size(12.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = "主题设置",
+                        fontSize = 30.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.onBackground,
+                    )
+                    Text(
+                        text = "MIUIX 与 Material 3 分别渲染",
+                        fontSize = 13.sp,
+                        color = colors.onSurfaceSecondary,
+                    )
+                }
+            }
+        }
+
+        item { MiuixSettingsSectionTitle("界面风格") }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                UiStyle.entries.forEach { option ->
+                    RadioButtonPreference(
+                        title = option.label,
+                        summary = when (option) {
+                            UiStyle.MIUIX -> "HyperOS 风格原生 Miuix 控件"
+                            UiStyle.MATERIAL -> "标准 Material 3 控件与自适应布局"
+                        },
+                        selected = settings.uiStyle == option,
+                        onClick = { actions.setUiStyle(option) },
+                        radioButtonLocation = RadioButtonLocation.End,
+                    )
+                }
+            }
+        }
+
+        item { MiuixSettingsSectionTitle("主题模式") }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                ThemeMode.entries.forEach { option ->
+                    RadioButtonPreference(
+                        title = option.label,
+                        selected = settings.themeMode == option,
+                        onClick = { actions.setThemeMode(option) },
+                        radioButtonLocation = RadioButtonLocation.End,
+                    )
+                }
+            }
+        }
+
+        item { MiuixSettingsSectionTitle("颜色") }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                SwitchPreference(
+                    title = "使用 Monet 取色",
+                    summary = "从系统壁纸提取语义色，对比不足时回退洛书蓝",
+                    checked = settings.monetEnabled,
+                    onCheckedChange = actions.setMonetEnabled,
+                )
+                AccentOptions.forEach { option ->
+                    RadioButtonPreference(
+                        title = option.label,
+                        summary = if (settings.monetEnabled) "关闭 Monet 后可选" else "固定强调色",
+                        selected = settings.seedArgb == option.argb,
+                        onClick = { actions.setSeedArgb(option.argb) },
+                        enabled = !settings.monetEnabled,
+                        radioButtonLocation = RadioButtonLocation.End,
+                        startAction = {
+                            Spacer(
+                                modifier = Modifier
+                                    .padding(end = 12.dp)
+                                    .size(30.dp)
+                                    .background(Color(option.argb), RoundedCornerShape(11.dp)),
+                            )
+                        },
+                    )
+                }
+            }
+        }
+
+        item { MiuixSettingsSectionTitle("色彩风格") }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                KolorStyle.entries.forEach { option ->
+                    RadioButtonPreference(
+                        title = option.label,
+                        summary = kolorStyleSummary(option),
+                        selected = settings.kolorStyle == option,
+                        onClick = { actions.setKolorStyle(option) },
+                        radioButtonLocation = RadioButtonLocation.End,
+                    )
+                }
+            }
+        }
+
+        item { MiuixSettingsSectionTitle("深色与材质") }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                SwitchPreference(
+                    title = "纯黑模式",
+                    summary = "深色模式下使用 AMOLED 黑色背景",
+                    checked = settings.amoledBlack,
+                    onCheckedChange = actions.setAmoledBlack,
+                )
+                SwitchPreference(
+                    title = "玻璃效果",
+                    summary = "只用于悬浮底栏和临时浮层，主体卡片保持实色",
+                    checked = settings.glassEnabled,
+                    onCheckedChange = actions.setGlassEnabled,
+                )
+                SwitchPreference(
+                    title = "背景模糊",
+                    summary = "关闭后自动使用半透明实色与细描边",
+                    checked = settings.blurEnabled,
+                    onCheckedChange = actions.setBlurEnabled,
+                    enabled = settings.glassEnabled,
+                )
+                SwitchPreference(
+                    title = "悬浮底栏",
+                    summary = "距系统手势区保留安全间距",
+                    checked = settings.floatingDock,
+                    onCheckedChange = actions.setFloatingDock,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MiuixSettingsHeader(
+    title: String,
+    subtitle: String,
+    icon: ImageVector,
+) {
+    val colors = MiuixTheme.colorScheme
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = title,
+                fontSize = 34.sp,
+                fontWeight = FontWeight.Bold,
+                color = colors.onBackground,
+            )
+            Text(
+                text = subtitle,
+                fontSize = 14.sp,
+                color = colors.onSurfaceSecondary,
+            )
+        }
+        Card {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = colors.primary,
+                modifier = Modifier.padding(16.dp).size(25.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiuixSettingsIcon(icon: ImageVector) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = MiuixTheme.colorScheme.primary,
+        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+    )
+}
+
+@Composable
+private fun MiuixSettingsSectionTitle(title: String) {
+    Text(
+        text = title,
+        color = MiuixTheme.colorScheme.onBackground,
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(start = 4.dp, top = 12.dp, bottom = 2.dp),
+    )
+}
+
+private fun kolorStyleSummary(style: KolorStyle): String = when (style) {
+    KolorStyle.SOFT -> "低饱和、柔和背景与舒适对比"
+    KolorStyle.VIBRANT -> "更鲜明的强调色和状态色"
+    KolorStyle.NEUTRAL -> "减少彩度，突出内容层级"
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/settings/AppearanceSettingsScreen.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/settings/AppearanceSettingsScreen.kt
@@ -88,6 +88,32 @@ fun AppearanceSettingsRoute(
     onOpenThemeSettings: () -> Unit = {},
     onCloseThemeSettings: () -> Unit = {},
 ) {
+    when (settings.uiStyle) {
+        UiStyle.MIUIX -> AppearanceSettingsMiuix(
+            settings = settings,
+            actions = actions,
+            showThemeSettings = showThemeSettings,
+            onOpenThemeSettings = onOpenThemeSettings,
+            onCloseThemeSettings = onCloseThemeSettings,
+        )
+        UiStyle.MATERIAL -> AppearanceSettingsMaterial(
+            settings = settings,
+            actions = actions,
+            showThemeSettings = showThemeSettings,
+            onOpenThemeSettings = onOpenThemeSettings,
+            onCloseThemeSettings = onCloseThemeSettings,
+        )
+    }
+}
+
+@Composable
+private fun AppearanceSettingsMaterial(
+    settings: AppearanceSettings,
+    actions: AppearanceActions,
+    showThemeSettings: Boolean,
+    onOpenThemeSettings: () -> Unit,
+    onCloseThemeSettings: () -> Unit,
+) {
     AnimatedContent(
         targetState = showThemeSettings,
         modifier = Modifier.fillMaxSize(),
@@ -248,7 +274,7 @@ private fun ThemeSettingsPage(
         item {
             LuoShuPageHeader(
                 title = "主题设置",
-                subtitle = "同一页面骨架，两套系统级控件皮肤",
+                subtitle = "同一业务层，两套独立系统级控件",
                 leading = { LuoShuBackButton(onBack) },
             )
         }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/FontStudioRoute.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/FontStudioRoute.kt
@@ -1,10 +1,5 @@
 package io.github.xgl34222220.luoshu.ui.studio
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -15,11 +10,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.xgl34222220.luoshu.LuoShuViewModel
 import io.github.xgl34222220.luoshu.MixSlot
@@ -74,17 +66,25 @@ internal fun FontStudioRoute(
     }
 
     val studioTools: @Composable () -> Unit = {
-        StudioToolLauncher(
-            style = style,
-            enabled = state.hasFonts && !state.loading,
-            onPreview = { showCompositePreview = true },
-            onProfile = { showProfileTransfer = true },
-            onGlyphs = { showGlyphBrowser = true },
-        )
+        when (style) {
+            UiStyle.MIUIX -> StudioToolLauncherMiuix(
+                enabled = state.hasFonts && !state.loading,
+                onPreview = { showCompositePreview = true },
+                onProfile = { showProfileTransfer = true },
+                onGlyphs = { showGlyphBrowser = true },
+            )
+            UiStyle.MATERIAL -> StudioToolLauncher(
+                style = UiStyle.MATERIAL,
+                enabled = state.hasFonts && !state.loading,
+                onPreview = { showCompositePreview = true },
+                onProfile = { showProfileTransfer = true },
+                onGlyphs = { showGlyphBrowser = true },
+            )
+        }
     }
     when (style) {
         UiStyle.MATERIAL -> FontStudioScreenMaterial(state, stableActions, studioTools)
-        UiStyle.MIUIX -> FontStudioScreenMiuix(state, stableActions, studioTools)
+        UiStyle.MIUIX -> FontStudioScreenMiuixNative(state, stableActions, studioTools)
     }
 
     if (showCompositePreview) {
@@ -115,11 +115,21 @@ internal fun FontStudioRoute(
         )
     }
     if (restoreNotice.isNotBlank()) {
-        AlertDialog(
-            onDismissRequest = { restoreNotice = "" },
-            title = { Text("备份恢复结果", fontWeight = FontWeight.Black) },
-            text = { Text(restoreNotice) },
-            confirmButton = { TextButton(onClick = { restoreNotice = "" }) { Text("完成") } },
-        )
+        when (style) {
+            UiStyle.MIUIX -> StudioRestoreNoticeMiuix(
+                message = restoreNotice,
+                onDismiss = { restoreNotice = "" },
+            )
+            UiStyle.MATERIAL -> AlertDialog(
+                onDismissRequest = { restoreNotice = "" },
+                title = { Text("备份恢复结果", fontWeight = FontWeight.Black) },
+                text = { Text(restoreNotice) },
+                confirmButton = {
+                    TextButton(onClick = { restoreNotice = "" }) {
+                        Text("完成")
+                    }
+                },
+            )
+        }
     }
 }

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/FontStudioScreenMiuixNative.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/FontStudioScreenMiuixNative.kt
@@ -1,0 +1,463 @@
+package io.github.xgl34222220.luoshu.ui.studio
+
+import android.view.Gravity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AutoAwesome
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.FontDownload
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.luoshu.MixSlot
+import io.github.xgl34222220.luoshu.NativeFontPreview
+import io.github.xgl34222220.luoshu.ui.font.fontCapabilityLabel
+import kotlin.math.roundToInt
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.CircularProgressIndicator
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.LinearProgressIndicator
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+
+@Composable
+internal fun FontStudioScreenMiuixNative(
+    state: FontStudioUiState,
+    actions: FontStudioActions,
+    topAction: @Composable () -> Unit,
+) {
+    val colors = MiuixTheme.colorScheme
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background),
+        contentPadding = PaddingValues(start = 16.dp, top = 18.dp, end = 16.dp, bottom = 112.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = "字体组合",
+                        fontSize = 34.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.onBackground,
+                    )
+                    Text(
+                        text = "中文、英文、数字与真实设计轴",
+                        fontSize = 14.sp,
+                        color = colors.onSurfaceSecondary,
+                    )
+                }
+                topAction()
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = actions.refresh,
+                    enabled = !state.loading,
+                ) {
+                    if (state.loading) {
+                        CircularProgressIndicator(
+                            progress = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Rounded.Refresh,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
+            }
+        }
+
+        if (state.error.isNotBlank()) {
+            item {
+                MiuixStudioNoticeNative(
+                    title = "字体组合需要处理",
+                    message = state.error,
+                    icon = Icons.Rounded.Warning,
+                    error = true,
+                )
+            }
+        }
+        if (state.busy || state.taskState == "success") {
+            item { MiuixStudioTaskNative(state) }
+        }
+
+        item { MiuixCompositionMapNative(state) }
+
+        state.slots.forEach { slotState ->
+            item(key = "native-${slotState.slot.name}") {
+                MiuixStudioSlotNative(
+                    slotState = slotState,
+                    busy = state.busy || state.operationBusy,
+                    actions = actions,
+                )
+            }
+        }
+
+        item { MiuixCoverageNative(state, actions) }
+        item { MiuixFinalActionNative(state, actions) }
+    }
+}
+
+@Composable
+private fun MiuixCompositionMapNative(state: FontStudioUiState) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = "组合结构",
+            summary = "三个槽位独立预览，最终输出统一生成",
+            startAction = { MiuixStudioIconNative(Icons.Rounded.AutoAwesome) },
+        )
+        state.slots.forEach { slot ->
+            BasicComponent(
+                title = slot.title,
+                summary = slot.font?.name ?: "未选择字体",
+                startAction = {
+                    MiuixSlotPreviewNative(slot)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiuixSlotPreviewNative(slot: StudioSlotUiState) {
+    val font = slot.font
+    Box(
+        modifier = Modifier
+            .padding(end = 16.dp)
+            .size(46.dp)
+            .background(MiuixTheme.colorScheme.tertiaryContainer, RoundedCornerShape(16.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (font != null && font.valid) {
+            NativeFontPreview(
+                font = font,
+                text = slotPreviewText(slot.slot),
+                axes = if (font.variable) mapOf("wght" to 400f) else emptyMap(),
+                modifier = Modifier.size(46.dp).padding(5.dp),
+                textSizeSp = 16f,
+                gravity = Gravity.CENTER,
+                maxLines = 1,
+            )
+        } else {
+            Text(
+                text = slotPreviewText(slot.slot),
+                color = MiuixTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiuixStudioSlotNative(
+    slotState: StudioSlotUiState,
+    busy: Boolean,
+    actions: FontStudioActions,
+) {
+    val colors = MiuixTheme.colorScheme
+    val font = slotState.font
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = slotState.title,
+            summary = buildString {
+                append(slotState.subtitle)
+                if (font != null) append("\n${fontCapabilityLabel(font)}")
+            },
+            startAction = { MiuixSlotPreviewNative(slotState) },
+            enabled = !busy,
+            onClick = { actions.pickSlot(slotState.slot) },
+        )
+
+        if (font == null) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                Button(
+                    onClick = { actions.pickSlot(slotState.slot) },
+                    enabled = !busy,
+                ) {
+                    Text("选择字体", fontWeight = FontWeight.Bold)
+                }
+            }
+            return@Card
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column {
+                Text(
+                    text = font.name,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    color = colors.onBackground,
+                )
+                Text(
+                    text = font.format,
+                    color = colors.onSurfaceSecondary,
+                    fontSize = 11.sp,
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(86.dp)
+                    .background(colors.surfaceContainer, RoundedCornerShape(22.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                NativeFontPreview(
+                    font = font,
+                    text = slotState.sample,
+                    axes = slotState.axes,
+                    modifier = Modifier.fillMaxWidth().height(86.dp).padding(horizontal = 14.dp),
+                    textSizeSp = 25f,
+                    gravity = Gravity.CENTER,
+                    maxLines = 1,
+                )
+            }
+
+            StudioAxisControlsMiuix(
+                font = font,
+                weight = slotState.weight,
+                axes = slotState.axes,
+                enabled = !busy,
+                onWeight = { actions.updateWeight(slotState.slot, it) },
+                onAxis = { tag, value -> actions.updateAxis(slotState.slot, tag, value) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiuixStudioTaskNative(state: FontStudioUiState) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = if (state.busy) "复合任务执行中" else "复合字体已生成",
+            summary = state.message,
+            startAction = {
+                if (state.busy) {
+                    CircularProgressIndicator(
+                        progress = null,
+                        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+                    )
+                } else {
+                    MiuixStudioIconNative(Icons.Rounded.CheckCircle)
+                }
+            },
+        )
+        Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp)) {
+            LinearProgressIndicator(
+                progress = state.progress.coerceIn(0, 100) / 100f,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = "${state.progress}%",
+                color = MiuixTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.align(Alignment.End),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiuixCoverageNative(
+    state: FontStudioUiState,
+    actions: FontStudioActions,
+) {
+    val colors = MiuixTheme.colorScheme
+    val cjk = state.slots.firstOrNull { it.slot == MixSlot.Cjk }
+    val fontId = cjk?.font?.id.orEmpty()
+    val probe = state.coverage
+    val metrics = probe.metrics.takeIf { probe.fontId == fontId }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = "字形覆盖诊断",
+            summary = cjk?.font?.name ?: "请先选择中文基底",
+            startAction = { MiuixStudioIconNative(Icons.Rounded.CheckCircle) },
+        )
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Button(
+                onClick = { actions.inspectCoverage(fontId) },
+                enabled = fontId.isNotBlank() && !probe.loading,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (probe.loading) {
+                    CircularProgressIndicator(
+                        progress = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(if (probe.loading) "正在检测" else "检测字形覆盖", fontWeight = FontWeight.Bold)
+            }
+
+            if (metrics != null) {
+                MiuixCoverageRowNative("中文", metrics.cjkRatio)
+                MiuixCoverageRowNative("英文", metrics.latinRatio)
+                MiuixCoverageRowNative("数字", metrics.digitRatio)
+                MiuixCoverageRowNative("标点", metrics.punctuationRatio)
+                if (metrics.missingSample.isNotBlank()) {
+                    Text(
+                        text = "缺失示例：${metrics.missingSample}",
+                        color = colors.onSurfaceSecondary,
+                        fontSize = 11.sp,
+                    )
+                }
+            } else if (probe.error.isNotBlank() && probe.fontId == fontId) {
+                Text(
+                    text = probe.error,
+                    color = colors.error,
+                    fontSize = 12.sp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MiuixCoverageRowNative(label: String, ratio: Float) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.width(42.dp),
+            fontWeight = FontWeight.Bold,
+            color = MiuixTheme.colorScheme.onBackground,
+        )
+        LinearProgressIndicator(
+            progress = ratio.coerceIn(0f, 1f),
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text = "${(ratio * 100).roundToInt()}%",
+            color = MiuixTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun MiuixFinalActionNative(
+    state: FontStudioUiState,
+    actions: FontStudioActions,
+) {
+    val direct = state.directApplyFontId
+    val enabled = !state.busy && !state.operationBusy && state.hasFonts
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = if (direct != null) "同一字体，无需复合" else "生成完整复合字体",
+            summary = if (direct != null) {
+                "三个槽位保持标准 Regular 400，将直接应用原始字体"
+            } else {
+                "真实字重和全部设计轴会写入最终字体文件"
+            },
+            startAction = {
+                MiuixStudioIconNative(
+                    if (direct != null) Icons.Rounded.FontDownload else Icons.Rounded.AutoAwesome,
+                )
+            },
+        )
+        Button(
+            onClick = {
+                if (direct != null) actions.applyDirect(direct) else actions.startMix()
+            },
+            enabled = enabled,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp),
+        ) {
+            Icon(
+                imageVector = if (direct != null) Icons.Rounded.FontDownload else Icons.Rounded.AutoAwesome,
+                contentDescription = null,
+                modifier = Modifier.size(21.dp),
+            )
+            Text(
+                text = if (direct != null) "直接应用此字体" else "生成并应用到系统",
+                modifier = Modifier.padding(start = 8.dp),
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiuixStudioNoticeNative(
+    title: String,
+    message: String,
+    icon: ImageVector,
+    error: Boolean,
+) {
+    val colors = MiuixTheme.colorScheme
+    Card(modifier = Modifier.fillMaxWidth()) {
+        BasicComponent(
+            title = title,
+            summary = message,
+            startAction = {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = if (error) colors.error else colors.primary,
+                    modifier = Modifier.padding(end = 16.dp).size(24.dp),
+                )
+            },
+        )
+    }
+}
+
+@Composable
+private fun MiuixStudioIconNative(icon: ImageVector) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = MiuixTheme.colorScheme.primary,
+        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+    )
+}
+
+private fun slotPreviewText(slot: MixSlot): String = when (slot) {
+    MixSlot.Cjk -> "中"
+    MixSlot.Latin -> "Aa"
+    MixSlot.Digit -> "123"
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/StudioAxisControlsMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/StudioAxisControlsMiuix.kt
@@ -1,0 +1,149 @@
+package io.github.xgl34222220.luoshu.ui.studio
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.luoshu.FontItem
+import io.github.xgl34222220.luoshu.rememberWeightAxisInfo
+import io.github.xgl34222220.luoshu.ui.font.fontAxisDisplayName
+import io.github.xgl34222220.luoshu.ui.font.fontAxisValueLabel
+import io.github.xgl34222220.luoshu.ui.font.fontFixedWeight
+import io.github.xgl34222220.luoshu.ui.font.fontStaticWeights
+import io.github.xgl34222220.luoshu.ui.font.fontWeightName
+import kotlin.math.roundToInt
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.CircularProgressIndicator
+import top.yukonga.miuix.kmp.basic.Slider
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+
+@Composable
+internal fun StudioAxisControlsMiuix(
+    font: FontItem,
+    weight: Int,
+    axes: Map<String, Float>,
+    enabled: Boolean,
+    onWeight: (Int) -> Unit,
+    onAxis: (String, Float) -> Unit,
+) {
+    val axisInfo = rememberWeightAxisInfo(font)
+    val colors = MiuixTheme.colorScheme
+
+    when {
+        font.variable && axisInfo.loading -> {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(
+                    progress = null,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(Modifier.width(9.dp))
+                Text(
+                    text = "正在读取真实可变轴…",
+                    color = colors.onSurfaceSecondary,
+                )
+            }
+        }
+        font.variable && axisInfo.axes.isNotEmpty() -> {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                axisInfo.axes.forEach { axis ->
+                    val minimum = axis.min
+                    val maximum = axis.max.coerceAtLeast(minimum)
+                    val isWeight = axis.tag == "wght"
+                    val current = (axes[axis.tag] ?: if (isWeight) weight.toFloat() else axis.default)
+                        .coerceIn(minimum, maximum)
+
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        BasicComponent(
+                            title = fontAxisDisplayName(axis.tag),
+                            summary = "${axis.tag} · ${fontAxisValueLabel(current)}",
+                        )
+                        Column(Modifier.padding(horizontal = 16.dp, vertical = 10.dp)) {
+                            Slider(
+                                value = current,
+                                onValueChange = { raw ->
+                                    val next = if (isWeight) {
+                                        ((raw / 10f).roundToInt() * 10).toFloat().coerceIn(minimum, maximum)
+                                    } else {
+                                        raw.coerceIn(minimum, maximum)
+                                    }
+                                    onAxis(axis.tag, next)
+                                },
+                                enabled = enabled,
+                                valueRange = minimum..maximum,
+                            )
+                            Row(Modifier.fillMaxWidth()) {
+                                Text(
+                                    text = fontAxisValueLabel(minimum),
+                                    color = colors.onSurfaceSecondary,
+                                    fontSize = 10.sp,
+                                )
+                                Spacer(Modifier.weight(1f))
+                                Text(
+                                    text = "默认 ${fontAxisValueLabel(axis.default)}",
+                                    color = colors.primary,
+                                    fontSize = 10.sp,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                                Spacer(Modifier.weight(1f))
+                                Text(
+                                    text = fontAxisValueLabel(maximum),
+                                    color = colors.onSurfaceSecondary,
+                                    fontSize = 10.sp,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        fontStaticWeights(font).size >= 2 -> {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                fontStaticWeights(font).forEach { option ->
+                    if (option == weight) {
+                        Button(
+                            onClick = { onWeight(option) },
+                            enabled = enabled,
+                        ) {
+                            Text(fontWeightName(option), fontWeight = FontWeight.Bold)
+                        }
+                    } else {
+                        TextButton(
+                            text = fontWeightName(option),
+                            enabled = enabled,
+                            onClick = { onWeight(option) },
+                        )
+                    }
+                }
+            }
+        }
+        else -> {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                BasicComponent(
+                    title = "固定字重",
+                    summary = "${fontWeightName(fontFixedWeight(font))} · 没有可调设计轴",
+                )
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/StudioRestoreNoticeMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/StudioRestoreNoticeMiuix.kt
@@ -1,0 +1,29 @@
+package io.github.xgl34222220.luoshu.ui.studio
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.overlay.OverlayDialog
+
+@Composable
+internal fun StudioRestoreNoticeMiuix(
+    message: String,
+    onDismiss: () -> Unit,
+) {
+    OverlayDialog(
+        title = "备份恢复结果",
+        summary = message,
+        show = true,
+        onDismissRequest = onDismiss,
+    ) {
+        Button(
+            onClick = onDismiss,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("完成", fontWeight = FontWeight.Bold)
+        }
+    }
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/StudioToolLauncherMiuix.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/studio/StudioToolLauncherMiuix.kt
@@ -1,0 +1,124 @@
+package io.github.xgl34222220.luoshu.ui.studio
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AutoAwesome
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.ListAlt
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.Button
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.overlay.OverlayDialog
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+
+@Composable
+internal fun StudioToolLauncherMiuix(
+    enabled: Boolean,
+    onPreview: () -> Unit,
+    onProfile: () -> Unit,
+    onGlyphs: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var menuVisible by remember { mutableStateOf(false) }
+
+    Button(
+        onClick = { menuVisible = true },
+        enabled = enabled,
+        modifier = modifier,
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.AutoAwesome,
+            contentDescription = null,
+            modifier = Modifier.size(21.dp),
+        )
+        Text(
+            text = "工具",
+            modifier = Modifier.padding(start = 7.dp),
+            fontWeight = FontWeight.Bold,
+        )
+    }
+
+    if (menuVisible) {
+        OverlayDialog(
+            title = "组合工具",
+            summary = "预览、方案管理与字形浏览",
+            show = true,
+            onDismissRequest = { menuVisible = false },
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    MiuixStudioToolItem(
+                        label = "最终组合预览",
+                        description = "对照系统字体并切换混排、正文、界面和金额场景",
+                        icon = Icons.Rounded.AutoAwesome,
+                        onClick = {
+                            menuVisible = false
+                            onPreview()
+                        },
+                    )
+                    MiuixStudioToolItem(
+                        label = "方案管理",
+                        description = "导入、导出和恢复三个槽位的组合配置",
+                        icon = Icons.Rounded.Description,
+                        onClick = {
+                            menuVisible = false
+                            onProfile()
+                        },
+                    )
+                    MiuixStudioToolItem(
+                        label = "字形浏览",
+                        description = "浏览中文、拉丁、数字、标点和 Unicode 码位",
+                        icon = Icons.Rounded.ListAlt,
+                        onClick = {
+                            menuVisible = false
+                            onGlyphs()
+                        },
+                    )
+                }
+                Button(
+                    onClick = { menuVisible = false },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("关闭", fontWeight = FontWeight.Bold)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MiuixStudioToolItem(
+    label: String,
+    description: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+) {
+    BasicComponent(
+        title = label,
+        summary = description,
+        startAction = {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MiuixTheme.colorScheme.primary,
+                modifier = Modifier.padding(end = 16.dp).size(24.dp),
+            )
+        },
+        onClick = onClick,
+    )
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/theme/LuoShuTheme.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/theme/LuoShuTheme.kt
@@ -143,8 +143,8 @@ private fun LuoShuMaterialTheme(settings: AppearanceSettings, content: @Composab
     val pureBlack = dark && settings.amoledBlack
     DynamicMaterialTheme(
         seedColor = resolveSeedColor(settings),
-        useDarkTheme = dark,
-        withAmoled = pureBlack,
+        isDark = dark,
+        isAmoled = pureBlack,
         style = settings.kolorStyle.toPaletteStyle(),
         shapes = UnifiedMaterialShapes,
         typography = UnifiedTypography,
@@ -207,8 +207,8 @@ private fun LuoShuMiuixTheme(settings: AppearanceSettings, content: @Composable 
     // have their dedicated MIUIX implementation.
     DynamicMaterialTheme(
         seedColor = seed,
-        useDarkTheme = dark,
-        withAmoled = pureBlack,
+        isDark = dark,
+        isAmoled = pureBlack,
         style = settings.kolorStyle.toPaletteStyle(),
         shapes = UnifiedMiuixShapes,
         typography = UnifiedTypography,

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/theme/LuoShuTheme.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/theme/LuoShuTheme.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalResources
@@ -24,13 +25,16 @@ import io.github.xgl34222220.luoshu.ui.appearance.KolorStyle
 import io.github.xgl34222220.luoshu.ui.appearance.LocalAppearanceSettings
 import io.github.xgl34222220.luoshu.ui.appearance.ThemeMode
 import io.github.xgl34222220.luoshu.ui.appearance.UiStyle
+import top.yukonga.miuix.kmp.theme.ColorSchemeMode
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+import top.yukonga.miuix.kmp.theme.ThemeController
+import top.yukonga.miuix.kmp.theme.ThemePaletteStyle
 
 /**
- * Unified visual tokens shared by every LuoShu business screen.
+ * Semantic tokens shared by LuoShu business features.
  *
- * Business composables should consume these semantic values instead of inventing page-local
- * colors, spacing or corner radii. This keeps the Miuix and Material 3 skins on one information
- * architecture while still allowing their controls to look native to each style.
+ * The two visual engines render their own native components. These tokens only carry business
+ * colors and spacing so state/data code does not need to know which UI library is active.
  */
 @Immutable
 data class LuoShuTokens(
@@ -151,12 +155,12 @@ private fun LuoShuMaterialTheme(settings: AppearanceSettings, content: @Composab
             pageBackground = when {
                 pureBlack -> Color.Black
                 dark -> Color(0xFF11131A)
-                else -> Color(0xFFECEBFA)
+                else -> scheme.background
             },
             surface = when {
                 pureBlack -> Color(0xFF0C0C0D)
                 dark -> Color(0xFF1B1E28)
-                else -> scheme.surfaceContainerLowest.copy(alpha = .98f)
+                else -> scheme.surfaceContainerLowest
             },
             surfaceAlt = when {
                 pureBlack -> Color(0xFF171719)
@@ -183,8 +187,26 @@ private fun LuoShuMaterialTheme(settings: AppearanceSettings, content: @Composab
 private fun LuoShuMiuixTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
     val dark = resolveDark(settings.themeMode)
     val pureBlack = dark && settings.amoledBlack
+    val seed = resolveSeedColor(settings)
+    val colorMode = when (settings.themeMode) {
+        ThemeMode.SYSTEM -> ColorSchemeMode.MonetSystem
+        ThemeMode.LIGHT -> ColorSchemeMode.MonetLight
+        ThemeMode.DARK -> ColorSchemeMode.MonetDark
+    }
+    val controller = remember(colorMode, seed, settings.kolorStyle, dark) {
+        ThemeController(
+            colorSchemeMode = colorMode,
+            keyColor = seed,
+            paletteStyle = settings.kolorStyle.toMiuixPaletteStyle(),
+            isDark = dark,
+        )
+    }
+
+    // Temporary compatibility provider for legacy screens still being migrated. New MIUIX screens
+    // consume only Miuix components and MiuixTheme values; the bridge is removed after all routes
+    // have their dedicated MIUIX implementation.
     DynamicMaterialTheme(
-        seedColor = resolveSeedColor(settings),
+        seedColor = seed,
         useDarkTheme = dark,
         withAmoled = pureBlack,
         style = settings.kolorStyle.toPaletteStyle(),
@@ -192,61 +214,62 @@ private fun LuoShuMiuixTheme(settings: AppearanceSettings, content: @Composable 
         typography = UnifiedTypography,
         animate = true,
     ) {
-        val scheme = MaterialTheme.colorScheme
-        val page = when {
-            pureBlack -> Color.Black
-            dark -> Color(0xFF11131A)
-            else -> Color(0xFFECEBFA)
+        MiuixTheme(controller = controller) {
+            val page = when {
+                pureBlack -> Color.Black
+                dark -> Color(0xFF11131A)
+                else -> Color(0xFFF0F0FC)
+            }
+            val surface = when {
+                pureBlack -> Color(0xFF0C0C0D)
+                dark -> Color(0xFF1B1E28)
+                else -> Color(0xFFF9F8FE)
+            }
+            val surfaceAlt = when {
+                pureBlack -> Color(0xFF171719)
+                dark -> Color(0xFF252937)
+                else -> Color(0xFFF4F3FA)
+            }
+            val elevated = when {
+                pureBlack -> Color(0xFF171719)
+                dark -> Color(0xFF222632)
+                else -> Color.White
+            }
+            val primaryText = when {
+                pureBlack -> Color(0xFFF4F4F5)
+                dark -> Color(0xFFF2F4F8)
+                else -> Color(0xFF171923)
+            }
+            val secondaryText = when {
+                pureBlack -> Color(0xFFB6B6BC)
+                dark -> Color(0xFFB9BECA)
+                else -> Color(0xFF666B7A)
+            }
+            val miuixTokens = MiuixTokens(
+                pageBackground = page,
+                cardBackground = surface,
+                elevatedCardBackground = elevated,
+                textPrimary = primaryText,
+                textSecondary = secondaryText,
+            )
+            val unifiedTokens = LuoShuTokens(
+                pageBackground = page,
+                surface = surface,
+                surfaceAlt = surfaceAlt,
+                surfaceElevated = elevated,
+                textPrimary = primaryText,
+                textSecondary = secondaryText,
+                outline = Color.Transparent,
+                success = Color(0xFF0AA45B),
+                warning = Color(0xFFB87300),
+                danger = Color(0xFFD83A3A),
+            )
+            CompositionLocalProvider(
+                LocalMiuixTokens provides miuixTokens,
+                LocalLuoShuTokens provides unifiedTokens,
+                content = content,
+            )
         }
-        val surface = when {
-            pureBlack -> Color(0xFF0C0C0D)
-            dark -> Color(0xFF1B1E28)
-            else -> Color(0xFFF8F7FD)
-        }
-        val surfaceAlt = when {
-            pureBlack -> Color(0xFF171719)
-            dark -> Color(0xFF252937)
-            else -> Color(0xFFF2F0FA)
-        }
-        val elevated = when {
-            pureBlack -> Color(0xFF171719)
-            dark -> scheme.surfaceContainerHigh
-            else -> Color.White
-        }
-        val primaryText = when {
-            pureBlack -> Color(0xFFF4F4F5)
-            dark -> Color(0xFFF2F4F8)
-            else -> Color(0xFF171923)
-        }
-        val secondaryText = when {
-            pureBlack -> Color(0xFFB6B6BC)
-            dark -> Color(0xFFB9BECA)
-            else -> Color(0xFF666B7A)
-        }
-        val miuixTokens = MiuixTokens(
-            pageBackground = page,
-            cardBackground = surface,
-            elevatedCardBackground = elevated,
-            textPrimary = primaryText,
-            textSecondary = secondaryText,
-        )
-        val unifiedTokens = LuoShuTokens(
-            pageBackground = page,
-            surface = surface,
-            surfaceAlt = surfaceAlt,
-            surfaceElevated = elevated,
-            textPrimary = primaryText,
-            textSecondary = secondaryText,
-            outline = if (dark) Color.White.copy(alpha = .10f) else Color(0x1F171923),
-            success = Color(0xFF0AA45B),
-            warning = Color(0xFFB87300),
-            danger = Color(0xFFD83A3A),
-        )
-        CompositionLocalProvider(
-            LocalMiuixTokens provides miuixTokens,
-            LocalLuoShuTokens provides unifiedTokens,
-            content = content,
-        )
     }
 }
 
@@ -271,4 +294,10 @@ private fun KolorStyle.toPaletteStyle(): PaletteStyle = when (this) {
     KolorStyle.SOFT -> PaletteStyle.TonalSpot
     KolorStyle.VIBRANT -> PaletteStyle.Vibrant
     KolorStyle.NEUTRAL -> PaletteStyle.Neutral
+}
+
+private fun KolorStyle.toMiuixPaletteStyle(): ThemePaletteStyle = when (this) {
+    KolorStyle.SOFT -> ThemePaletteStyle.TonalSpot
+    KolorStyle.VIBRANT -> ThemePaletteStyle.Vibrant
+    KolorStyle.NEUTRAL -> ThemePaletteStyle.Neutral
 }

--- a/scripts/font_library_ui_layout_test.sh
+++ b/scripts/font_library_ui_layout_test.sh
@@ -24,10 +24,14 @@ COMPONENTS="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/
 UTIL="$ROOT/common/util_functions.sh"
 CACHE="$ROOT/common/device_font_cache.sh"
 
-# Legacy style screens stay available as a rollback path while the routes use the
-# shared compact hierarchy.
-grep -q 'private fun MiuixCapabilityStrip' "$MIUIX"
-grep -q 'private fun MaterialCapabilityStrip' "$MATERIAL"
+# Font library now has two independent render trees. The Miuix implementation
+# must use native Miuix controls and must not import Material 3 components.
+grep -q 'top.yukonga.miuix.kmp.basic.BasicComponent' "$MIUIX"
+grep -q 'top.yukonga.miuix.kmp.basic.TextField' "$MIUIX"
+grep -q 'top.yukonga.miuix.kmp.theme.MiuixTheme' "$MIUIX"
+! grep -q 'androidx.compose.material3' "$MIUIX"
+grep -q 'UiStyle.MIUIX -> FontLibraryScreenMiuix' "$ROUTE"
+grep -q 'UiStyle.MATERIAL -> FontLibraryScreenCompact' "$ROUTE"
 grep -q 'FontLibraryScreenCompact' "$ROUTE"
 grep -q 'HomeScreenCompact' "$HOME_ROUTE"
 grep -q 'LogsScreenCompact' "$LOGS_ROUTE"
@@ -40,6 +44,10 @@ grep -q 'CompactFontRow' "$COMPACT"
 grep -q 'NativeFontPreview' "$COMPACT"
 grep -q 'clickable(onClick = onDetails)' "$COMPACT"
 ! grep -q 'height(102.dp)' "$COMPACT"
+grep -q 'var showTools by rememberSaveable' "$MIUIX"
+grep -q '导入与管理' "$MIUIX"
+grep -q 'MiuixFontFamilyCard' "$MIUIX"
+grep -q 'NativeFontPreview' "$MIUIX"
 
 # Home: one dynamic next action replaces duplicate navigation shortcuts and the
 # trust chip participates in normal layout rather than using a fixed 108 dp offset.
@@ -108,8 +116,8 @@ grep -q 'padding(bottom = dockClearance)' "$SHELL"
 grep -q 'RoundedCornerShape(22.dp)' "$STUDIO_MIUIX"
 grep -q 'RoundedCornerShape(22.dp)' "$STUDIO_MATERIAL"
 
-# Unified design system: business pages consume semantic tokens and shared
-# components instead of maintaining separate visual constants.
+# Unified design system remains available to legacy Material pages while the
+# Miuix pages migrate to their own native component tree.
 grep -q 'data class LuoShuTokens' "$THEME"
 grep -q 'pageBackground = Color(0xFFECEBFA)' "$THEME"
 grep -q 'dark -> Color(0xFF11131A)' "$THEME"
@@ -164,4 +172,4 @@ grep -q 'embedded = true' "$SHELL"
 grep -q 'dockClearance' "$SHELL"
 ! grep -q 'if (page == AppPage.Studio)' "$SHELL"
 
-echo 'LuoShu unified V1.1 UI layout regression passed.'
+echo 'LuoShu separate Miuix and Material UI layout regression passed.'

--- a/scripts/mix_finalize_performance_test.sh
+++ b/scripts/mix_finalize_performance_test.sh
@@ -78,4 +78,7 @@ grep -q 'top.yukonga.miuix.kmp.basic.LinearProgressIndicator' "$IMPORT_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$IMPORT_MIUIX"
 ! grep -q 'androidx.compose.material3' "$IMPORT_MIUIX"
 
+# The full UI separation contract is mandatory for every source check.
+sh "$ROOT/scripts/ui_theme_separation_test.sh"
+
 echo 'Mix finalization uses metadata-only validation, one Mono build, real progress stages, and separate import UIs.'

--- a/scripts/mix_finalize_performance_test.sh
+++ b/scripts/mix_finalize_performance_test.sh
@@ -65,9 +65,17 @@ grep -q "mix_stage manifest '正在生成安全启动清单' 98" "$ROOT/common/f
 grep -q '_progress_message=' "$ROOT/common/weighted_mix_task.sh"
 grep -q '完整复合字体后台进程已退出' "$ROOT/common/weighted_mix_task.sh"
 
-# The import action must fit the full Chinese label on one line.
-grep -q 'else -> 148.dp' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt"
-grep -q 'softWrap = false' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt"
-grep -q 'modifier = modifier.fillMaxWidth()' "$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt"
+# Import routing owns state only; each theme renders its own action and progress UI.
+IMPORT_ROUTE="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlay.kt"
+IMPORT_MATERIAL="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlayMaterial.kt"
+IMPORT_MIUIX="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu/NativeImportOverlayMiuix.kt"
+grep -q 'UiStyle.MIUIX -> NativeImportOverlayMiuix' "$IMPORT_ROUTE"
+grep -q 'UiStyle.MATERIAL -> NativeImportOverlayMaterial' "$IMPORT_ROUTE"
+grep -q 'else -> 148.dp' "$IMPORT_MATERIAL"
+grep -q 'softWrap = false' "$IMPORT_MATERIAL"
+grep -q 'modifier.fillMaxWidth().height(height)' "$IMPORT_MATERIAL"
+grep -q 'top.yukonga.miuix.kmp.basic.LinearProgressIndicator' "$IMPORT_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$IMPORT_MIUIX"
+! grep -q 'androidx.compose.material3' "$IMPORT_MIUIX"
 
-echo 'Mix finalization uses metadata-only validation, one Mono build, and real progress stages.'
+echo 'Mix finalization uses metadata-only validation, one Mono build, real progress stages, and separate import UIs.'

--- a/scripts/ui_startup_smoke.sh
+++ b/scripts/ui_startup_smoke.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+APK=${1:-android-app/app/build/outputs/apk/release/app-release.apk}
+PACKAGE=${2:-io.github.xgl34222220.luoshu}
+DIAGNOSTICS=${3:-dist/startup-smoke}
+
+mkdir -p "$DIAGNOSTICS"
+adb install -r "$APK" > "$DIAGNOSTICS/install.txt" 2>&1
+adb shell am force-stop "$PACKAGE"
+adb logcat -c
+adb shell am start -W -n "$PACKAGE/.MainActivity" > "$DIAGNOSTICS/am-start.txt" 2>&1 || true
+sleep 8
+adb shell pidof "$PACKAGE" > "$DIAGNOSTICS/pid.txt" 2>&1 || true
+adb logcat -d -v threadtime > "$DIAGNOSTICS/logcat.txt"
+
+if grep -nE 'FATAL EXCEPTION|AndroidRuntime.*Process: io\.github\.xgl34222220\.luoshu' "$DIAGNOSTICS/logcat.txt"; then
+  echo 'LuoShu crashed during cold start.' >&2
+  exit 1
+fi
+
+if [ ! -s "$DIAGNOSTICS/pid.txt" ]; then
+  echo 'LuoShu process did not survive cold start.' >&2
+  exit 1
+fi
+
+printf 'LuoShu cold start survived with PID %s\n' "$(cat "$DIAGNOSTICS/pid.txt")"

--- a/scripts/ui_theme_separation_test.sh
+++ b/scripts/ui_theme_separation_test.sh
@@ -19,6 +19,12 @@ STUDIO_NOTICE_MIUIX="$APP/ui/studio/StudioRestoreNoticeMiuix.kt"
 SETTINGS_ROUTE="$APP/ui/settings/AppearanceSettingsScreen.kt"
 SETTINGS_MIUIX="$APP/ui/settings/AppearanceSettingsMiuix.kt"
 SETTINGS_MATERIAL="$APP/ui/settings/AppearanceSettingsScreen.kt"
+LOGS_ROUTE="$APP/ui/logs/LogsRoute.kt"
+LOGS_MIUIX="$APP/ui/logs/LogsScreenMiuix.kt"
+LOGS_MATERIAL="$APP/ui/logs/LogsScreenCompact.kt"
+LOGS_OVERLAYS_MIUIX="$APP/ui/logs/LogsMiuixOverlays.kt"
+IMPORT_CONTROLS_MATERIAL="$APP/ui/logs/ImportTaskControls.kt"
+DIAGNOSTIC_MATERIAL="$APP/ui/logs/DiagnosticExportUi.kt"
 
 # Theme routing must be explicit. Shared files own state and actions only.
 grep -q 'UiStyle.MIUIX -> FontLibraryScreenMiuix' "$LIB_ROUTE"
@@ -35,6 +41,12 @@ grep -q 'UiStyle.MATERIAL -> FontStudioScreenMaterial' "$STUDIO_ROUTE"
 grep -q 'UiStyle.MIUIX -> StudioRestoreNoticeMiuix' "$STUDIO_ROUTE"
 grep -q 'UiStyle.MIUIX -> AppearanceSettingsMiuix' "$SETTINGS_ROUTE"
 grep -q 'UiStyle.MATERIAL -> AppearanceSettingsMaterial' "$SETTINGS_ROUTE"
+grep -q 'UiStyle.MIUIX -> LogsScreenMiuix' "$LOGS_ROUTE"
+grep -q 'UiStyle.MATERIAL -> LogsScreenCompact' "$LOGS_ROUTE"
+grep -q 'UiStyle.MIUIX -> ImportTaskControlsMiuix' "$LOGS_ROUTE"
+grep -q 'UiStyle.MATERIAL -> ImportTaskControls' "$LOGS_ROUTE"
+grep -q 'UiStyle.MIUIX -> DiagnosticExportDialogMiuix' "$LOGS_ROUTE"
+grep -q 'UiStyle.MATERIAL -> DiagnosticExportDialog' "$LOGS_ROUTE"
 
 # Native Miuix trees may use Foundation, icons and shared business widgets, but
 # never Material 3 controls or the hand-built LuoShu Material component layer.
@@ -46,7 +58,9 @@ for file in \
     "$STUDIO_AXIS_MIUIX" \
     "$STUDIO_TOOLS_MIUIX" \
     "$STUDIO_NOTICE_MIUIX" \
-    "$SETTINGS_MIUIX"; do
+    "$SETTINGS_MIUIX" \
+    "$LOGS_MIUIX" \
+    "$LOGS_OVERLAYS_MIUIX"; do
     grep -q 'top.yukonga.miuix.kmp' "$file"
     ! grep -q 'androidx.compose.material3' "$file"
     ! grep -q 'io.github.xgl34222220.luoshu.ui.design.LuoShu' "$file"
@@ -66,11 +80,20 @@ grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$STUDIO_NOTICE_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.preference.SwitchPreference' "$SETTINGS_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.preference.RadioButtonPreference' "$SETTINGS_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.basic.BasicComponent' "$SETTINGS_MIUIX"
+grep -q 'private enum class MiuixLogsTab' "$LOGS_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.basic.BasicComponent' "$LOGS_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.basic.LinearProgressIndicator' "$LOGS_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$LOGS_OVERLAYS_MIUIX"
+grep -q 'ImportTaskControlsMiuix' "$LOGS_OVERLAYS_MIUIX"
+grep -q 'DiagnosticExportDialogMiuix' "$LOGS_OVERLAYS_MIUIX"
 
 # Material implementations remain separate and continue using Material 3.
 grep -q 'androidx.compose.material3' "$LIB_MATERIAL"
 grep -q 'androidx.compose.material3' "$IMPORT_MATERIAL"
 grep -q 'androidx.compose.material3' "$STUDIO_MATERIAL"
 grep -q 'androidx.compose.material3' "$SETTINGS_MATERIAL"
+grep -q 'androidx.compose.material3' "$LOGS_MATERIAL"
+grep -q 'androidx.compose.material3' "$IMPORT_CONTROLS_MATERIAL"
+grep -q 'androidx.compose.material3' "$DIAGNOSTIC_MATERIAL"
 
-echo 'Miuix and Material home, font-library, font-studio and settings render trees are isolated.'
+echo 'Miuix and Material home, font-library, font-studio, settings and task-center render trees are isolated.'

--- a/scripts/ui_theme_separation_test.sh
+++ b/scripts/ui_theme_separation_test.sh
@@ -10,6 +10,12 @@ MANAGE_MIUIX="$APP/ui/library/FontLibraryManagementMiuix.kt"
 IMPORT_ROUTE="$APP/NativeImportOverlay.kt"
 IMPORT_MIUIX="$APP/NativeImportOverlayMiuix.kt"
 IMPORT_MATERIAL="$APP/NativeImportOverlayMaterial.kt"
+STUDIO_ROUTE="$APP/ui/studio/FontStudioRoute.kt"
+STUDIO_MIUIX="$APP/ui/studio/FontStudioScreenMiuixNative.kt"
+STUDIO_MATERIAL="$APP/ui/studio/FontStudioScreenMaterial.kt"
+STUDIO_AXIS_MIUIX="$APP/ui/studio/StudioAxisControlsMiuix.kt"
+STUDIO_TOOLS_MIUIX="$APP/ui/studio/StudioToolLauncherMiuix.kt"
+STUDIO_NOTICE_MIUIX="$APP/ui/studio/StudioRestoreNoticeMiuix.kt"
 
 # Theme routing must be explicit. Shared files own state and actions only.
 grep -q 'UiStyle.MIUIX -> FontLibraryScreenMiuix' "$LIB_ROUTE"
@@ -19,10 +25,22 @@ grep -q 'FontLibraryManagementDialogMiuix' "$LIB_ROUTE"
 grep -q 'style = UiStyle.MATERIAL' "$LIB_ROUTE"
 grep -q 'UiStyle.MIUIX -> NativeImportOverlayMiuix' "$IMPORT_ROUTE"
 grep -q 'UiStyle.MATERIAL -> NativeImportOverlayMaterial' "$IMPORT_ROUTE"
+grep -q 'UiStyle.MIUIX -> StudioToolLauncherMiuix' "$STUDIO_ROUTE"
+grep -q 'UiStyle.MATERIAL -> StudioToolLauncher' "$STUDIO_ROUTE"
+grep -q 'UiStyle.MIUIX -> FontStudioScreenMiuixNative' "$STUDIO_ROUTE"
+grep -q 'UiStyle.MATERIAL -> FontStudioScreenMaterial' "$STUDIO_ROUTE"
+grep -q 'UiStyle.MIUIX -> StudioRestoreNoticeMiuix' "$STUDIO_ROUTE"
 
 # Native Miuix trees may use Foundation, icons and shared business widgets, but
 # never Material 3 controls or the hand-built LuoShu Material component layer.
-for file in "$LIB_MIUIX" "$MANAGE_MIUIX" "$IMPORT_MIUIX"; do
+for file in \
+    "$LIB_MIUIX" \
+    "$MANAGE_MIUIX" \
+    "$IMPORT_MIUIX" \
+    "$STUDIO_MIUIX" \
+    "$STUDIO_AXIS_MIUIX" \
+    "$STUDIO_TOOLS_MIUIX" \
+    "$STUDIO_NOTICE_MIUIX"; do
     grep -q 'top.yukonga.miuix.kmp' "$file"
     ! grep -q 'androidx.compose.material3' "$file"
     ! grep -q 'io.github.xgl34222220.luoshu.ui.design.LuoShu' "$file"
@@ -34,9 +52,15 @@ grep -q 'top.yukonga.miuix.kmp.basic.Checkbox' "$MANAGE_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$MANAGE_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.basic.LinearProgressIndicator' "$IMPORT_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$IMPORT_MIUIX"
+grep -q 'StudioAxisControlsMiuix' "$STUDIO_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.basic.LinearProgressIndicator' "$STUDIO_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.basic.Slider' "$STUDIO_AXIS_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$STUDIO_TOOLS_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$STUDIO_NOTICE_MIUIX"
 
 # Material implementations remain separate and continue using Material 3.
 grep -q 'androidx.compose.material3' "$LIB_MATERIAL"
 grep -q 'androidx.compose.material3' "$IMPORT_MATERIAL"
+grep -q 'androidx.compose.material3' "$STUDIO_MATERIAL"
 
-echo 'Miuix and Material font-library render trees are isolated.'
+echo 'Miuix and Material font-library and font-studio render trees are isolated.'

--- a/scripts/ui_theme_separation_test.sh
+++ b/scripts/ui_theme_separation_test.sh
@@ -16,6 +16,9 @@ STUDIO_MATERIAL="$APP/ui/studio/FontStudioScreenMaterial.kt"
 STUDIO_AXIS_MIUIX="$APP/ui/studio/StudioAxisControlsMiuix.kt"
 STUDIO_TOOLS_MIUIX="$APP/ui/studio/StudioToolLauncherMiuix.kt"
 STUDIO_NOTICE_MIUIX="$APP/ui/studio/StudioRestoreNoticeMiuix.kt"
+SETTINGS_ROUTE="$APP/ui/settings/AppearanceSettingsScreen.kt"
+SETTINGS_MIUIX="$APP/ui/settings/AppearanceSettingsMiuix.kt"
+SETTINGS_MATERIAL="$APP/ui/settings/AppearanceSettingsScreen.kt"
 
 # Theme routing must be explicit. Shared files own state and actions only.
 grep -q 'UiStyle.MIUIX -> FontLibraryScreenMiuix' "$LIB_ROUTE"
@@ -30,6 +33,8 @@ grep -q 'UiStyle.MATERIAL -> StudioToolLauncher' "$STUDIO_ROUTE"
 grep -q 'UiStyle.MIUIX -> FontStudioScreenMiuixNative' "$STUDIO_ROUTE"
 grep -q 'UiStyle.MATERIAL -> FontStudioScreenMaterial' "$STUDIO_ROUTE"
 grep -q 'UiStyle.MIUIX -> StudioRestoreNoticeMiuix' "$STUDIO_ROUTE"
+grep -q 'UiStyle.MIUIX -> AppearanceSettingsMiuix' "$SETTINGS_ROUTE"
+grep -q 'UiStyle.MATERIAL -> AppearanceSettingsMaterial' "$SETTINGS_ROUTE"
 
 # Native Miuix trees may use Foundation, icons and shared business widgets, but
 # never Material 3 controls or the hand-built LuoShu Material component layer.
@@ -40,7 +45,8 @@ for file in \
     "$STUDIO_MIUIX" \
     "$STUDIO_AXIS_MIUIX" \
     "$STUDIO_TOOLS_MIUIX" \
-    "$STUDIO_NOTICE_MIUIX"; do
+    "$STUDIO_NOTICE_MIUIX" \
+    "$SETTINGS_MIUIX"; do
     grep -q 'top.yukonga.miuix.kmp' "$file"
     ! grep -q 'androidx.compose.material3' "$file"
     ! grep -q 'io.github.xgl34222220.luoshu.ui.design.LuoShu' "$file"
@@ -57,10 +63,14 @@ grep -q 'top.yukonga.miuix.kmp.basic.LinearProgressIndicator' "$STUDIO_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.basic.Slider' "$STUDIO_AXIS_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$STUDIO_TOOLS_MIUIX"
 grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$STUDIO_NOTICE_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.preference.SwitchPreference' "$SETTINGS_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.preference.RadioButtonPreference' "$SETTINGS_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.basic.BasicComponent' "$SETTINGS_MIUIX"
 
 # Material implementations remain separate and continue using Material 3.
 grep -q 'androidx.compose.material3' "$LIB_MATERIAL"
 grep -q 'androidx.compose.material3' "$IMPORT_MATERIAL"
 grep -q 'androidx.compose.material3' "$STUDIO_MATERIAL"
+grep -q 'androidx.compose.material3' "$SETTINGS_MATERIAL"
 
-echo 'Miuix and Material font-library and font-studio render trees are isolated.'
+echo 'Miuix and Material home, font-library, font-studio and settings render trees are isolated.'

--- a/scripts/ui_theme_separation_test.sh
+++ b/scripts/ui_theme_separation_test.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+APP="$ROOT/android-app/app/src/main/java/io/github/xgl34222220/luoshu"
+
+LIB_ROUTE="$APP/ui/library/FontLibraryRoute.kt"
+LIB_MIUIX="$APP/ui/library/FontLibraryScreenMiuix.kt"
+LIB_MATERIAL="$APP/ui/library/FontLibraryScreenCompact.kt"
+MANAGE_MIUIX="$APP/ui/library/FontLibraryManagementMiuix.kt"
+IMPORT_ROUTE="$APP/NativeImportOverlay.kt"
+IMPORT_MIUIX="$APP/NativeImportOverlayMiuix.kt"
+IMPORT_MATERIAL="$APP/NativeImportOverlayMaterial.kt"
+
+# Theme routing must be explicit. Shared files own state and actions only.
+grep -q 'UiStyle.MIUIX -> FontLibraryScreenMiuix' "$LIB_ROUTE"
+grep -q 'UiStyle.MATERIAL -> FontLibraryScreenCompact' "$LIB_ROUTE"
+grep -q 'FontLibraryManagementButtonMiuix' "$LIB_ROUTE"
+grep -q 'FontLibraryManagementDialogMiuix' "$LIB_ROUTE"
+grep -q 'style = UiStyle.MATERIAL' "$LIB_ROUTE"
+grep -q 'UiStyle.MIUIX -> NativeImportOverlayMiuix' "$IMPORT_ROUTE"
+grep -q 'UiStyle.MATERIAL -> NativeImportOverlayMaterial' "$IMPORT_ROUTE"
+
+# Native Miuix trees may use Foundation, icons and shared business widgets, but
+# never Material 3 controls or the hand-built LuoShu Material component layer.
+for file in "$LIB_MIUIX" "$MANAGE_MIUIX" "$IMPORT_MIUIX"; do
+    grep -q 'top.yukonga.miuix.kmp' "$file"
+    ! grep -q 'androidx.compose.material3' "$file"
+    ! grep -q 'io.github.xgl34222220.luoshu.ui.design.LuoShu' "$file"
+done
+
+grep -q 'top.yukonga.miuix.kmp.basic.TextField' "$LIB_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.basic.BasicComponent' "$LIB_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.basic.Checkbox' "$MANAGE_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$MANAGE_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.basic.LinearProgressIndicator' "$IMPORT_MIUIX"
+grep -q 'top.yukonga.miuix.kmp.overlay.OverlayDialog' "$IMPORT_MIUIX"
+
+# Material implementations remain separate and continue using Material 3.
+grep -q 'androidx.compose.material3' "$LIB_MATERIAL"
+grep -q 'androidx.compose.material3' "$IMPORT_MATERIAL"
+
+echo 'Miuix and Material font-library render trees are isolated.'


### PR DESCRIPTION
## 目标
洛书保留两套**独立可切换**的 UI 风格，不把 Miuix 与 Material 控件混在同一个页面。

## 双主题架构
### MIUIX 风格
- Miuix Core / UI / Preference / Icons
- Miuix Navigation / Shader / Squircle
- Miuix Blur API 保留；Android 9–12 使用 Haze 兼容模糊
- 页面直接调用 Miuix 原生组件

### Material 风格
- Material 2 / Material 3
- Material Ripple / Icons / Window Size Class
- Material 3 Adaptive / Navigation Suite
- 独立 Material 页面、控件和响应式布局

## 两套主题共享
- 同一套业务逻辑、状态、导航目标与数据模型
- MaterialKolor 4.1.1 提供 Monet 动态取色，并与 Miuix 0.9.3 使用相同的 Material Color Utilities ABI
- Haze 提供低版本玻璃兼容层

## 已完成
- [x] compileSdk 37 / targetSdk 36 / minSdk 28 兼容基线
- [x] 完整 Miuix 与 Material 依赖栈可解析、可打包
- [x] 独立 Miuix ThemeController 与 Material DynamicMaterialTheme
- [x] 首页、字体库、导入、字体管理、字体组合、设置页和任务中心按主题分流
- [x] MIUIX 页面使用原生 Miuix 组件，Material 页面保持独立 Material 实现
- [x] 强制 UI 隔离门禁，禁止 MIUIX 页面重新导入 Material3 控件
- [x] 修复 MaterialKolor 2.0.0 与 Miuix 0.9.3 的 Hct ABI 启动崩溃
- [x] 正式签名 Release APK 在 Android 10（API 29）冷启动通过
- [x] 正式签名 Release APK 在 Android 15（API 35）冷启动通过
- [x] 两轮启动测试均确认进程持续存活且 logcat 无 FATAL EXCEPTION

## 当前限制
- App-only 与完整模块候选仍需刷新仓库内置 APK 后重新通过同步门禁
- 本 PR 继续保持 Draft，真机界面与交互确认前不合并 main

## 下一阶段
- [ ] 真机检查两套主题的尺寸、间距、滚动和弹窗
- [ ] 修正截图反馈中的视觉问题
- [ ] 刷新模块内置 APK，并完成 App-only、R8 与模块候选验证