### PR TITLE
修复字体未生效、方框字和错误验证

### DIFF
--- a/android-app/app/proguard-rules.pro
+++ b/android-app/app/proguard-rules.pro
@@ -1,3 +1,9 @@
 # LuoShu uses no reflection-based serialization framework. Keep rules are
 # intentionally minimal; Android/Compose consumer rules are supplied by their
 # dependencies.
+
+# Invoked directly through app_process after Android boot. R8 must preserve the
+# class name and the public static main method even though the App UI never calls it.
+-keep class io.github.xgl34222220.luoshu.FontProbeCli {
+    public static void main(java.lang.String[]);
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontProbeCli.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontProbeCli.kt
@@ -1,0 +1,105 @@
+package io.github.xgl34222220.luoshu
+
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import android.graphics.Typeface
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.security.MessageDigest
+import java.util.Locale
+import kotlin.math.roundToInt
+
+/**
+ * Small app_process entry point used by the module after boot.
+ *
+ * It compares normalized glyph outlines rendered through Typeface.DEFAULT with
+ * the exact generated LuoShu font file.  Unlike a mount check or a FontManager
+ * listing, matching outlines prove that Android's renderer selected the payload.
+ */
+object FontProbeCli {
+    private val samples = listOf("洛", "书", "中", "文", "你", "好", "A", "a", "1", "0", "，", "。")
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val result = runCatching {
+            require(args.isNotEmpty()) { "缺少待验证字体路径" }
+            probe(File(args[0]))
+        }.getOrElse { error ->
+            JSONObject()
+                .put("status", "error")
+                .put("message", error.message ?: error.javaClass.simpleName)
+        }
+        println(result.toString())
+    }
+
+    private fun probe(file: File): JSONObject {
+        require(file.isFile && file.length() >= 4_096L) { "验证字体不存在或文件过小：${file.path}" }
+        val expected = Typeface.Builder(file).build()
+        val actual = Typeface.DEFAULT
+        val mismatched = JSONArray()
+        val missingActual = JSONArray()
+        val missingExpected = JSONArray()
+        var matched = 0
+        var comparable = 0
+
+        samples.forEach { sample ->
+            val actualFingerprint = glyphFingerprint(actual, sample)
+            val expectedFingerprint = glyphFingerprint(expected, sample)
+            when {
+                actualFingerprint == null -> missingActual.put(sample)
+                expectedFingerprint == null -> missingExpected.put(sample)
+                else -> {
+                    comparable += 1
+                    if (actualFingerprint == expectedFingerprint) {
+                        matched += 1
+                    } else {
+                        mismatched.put(sample)
+                    }
+                }
+            }
+        }
+        val ratio = if (comparable == 0) 0.0 else matched.toDouble() / comparable.toDouble()
+        return JSONObject()
+            .put("status", "ok")
+            .put("path", file.path)
+            .put("matched", matched)
+            .put("comparable", comparable)
+            .put("total", samples.size)
+            .put("ratio", ratio)
+            .put("mismatched", mismatched)
+            .put("missingActual", missingActual)
+            .put("missingExpected", missingExpected)
+    }
+
+    private fun glyphFingerprint(typeface: Typeface, text: String): String? {
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.SUBPIXEL_TEXT_FLAG).apply {
+            this.typeface = typeface
+            textSize = 256f
+            isLinearText = true
+            hinting = Paint.HINTING_OFF
+        }
+        if (!paint.hasGlyph(text)) return null
+        val path = Path()
+        paint.getTextPath(text, 0, text.length, 0f, 0f, path)
+        if (path.isEmpty) return null
+        val bounds = RectF()
+        path.computeBounds(bounds, true)
+        if (bounds.width() <= 0f || bounds.height() <= 0f) return null
+        val points = path.approximate(0.25f)
+        if (points.size < 6) return null
+
+        val normalized = StringBuilder(points.size * 4)
+        var index = 0
+        while (index + 2 < points.size) {
+            val fraction = (points[index] * 1_000f).roundToInt()
+            val x = (((points[index + 1] - bounds.left) / bounds.width()) * 4_096f).roundToInt()
+            val y = (((points[index + 2] - bounds.top) / bounds.height()) * 4_096f).roundToInt()
+            normalized.append(fraction).append(':').append(x).append(':').append(y).append(';')
+            index += 3
+        }
+        val digest = MessageDigest.getInstance("SHA-256").digest(normalized.toString().toByteArray())
+        return digest.joinToString("") { byte -> String.format(Locale.US, "%02x", byte.toInt() and 0xff) }
+    }
+}

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontProbeCli.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontProbeCli.kt
@@ -14,9 +14,10 @@ import kotlin.math.roundToInt
 /**
  * Small app_process entry point used by the module after boot.
  *
- * It compares normalized glyph outlines rendered through Typeface.DEFAULT with
- * the exact generated LuoShu font file.  Unlike a mount check or a FontManager
- * listing, matching outlines prove that Android's renderer selected the payload.
+ * Android devices may expose several generated 400-weight slots (global UI,
+ * clock, OEM named families). The probe compares all supplied candidates with
+ * Typeface.DEFAULT and reports the best match, avoiding accidental selection of
+ * a clock-only or app-specific slot.
  */
 object FontProbeCli {
     private val samples = listOf("洛", "书", "中", "文", "你", "好", "A", "a", "1", "0", "，", "。")
@@ -25,7 +26,19 @@ object FontProbeCli {
     fun main(args: Array<String>) {
         val result = runCatching {
             require(args.isNotEmpty()) { "缺少待验证字体路径" }
-            probe(File(args[0]))
+            val candidates = args.asSequence()
+                .map(::File)
+                .filter { file -> file.isFile && file.length() >= 4_096L }
+                .distinctBy(File::getCanonicalPath)
+                .map(::probe)
+                .toList()
+            require(candidates.isNotEmpty()) { "没有可读取的 400 字重验证字体" }
+            val best = candidates.maxWithOrNull(
+                compareBy<JSONObject> { item -> item.optDouble("ratio", 0.0) }
+                    .thenBy { item -> item.optInt("comparable", 0) }
+                    .thenBy { item -> -item.optJSONArray("missingActual").length() },
+            ) ?: error("验证候选为空")
+            best.put("candidates", candidates.size)
         }.getOrElse { error ->
             JSONObject()
                 .put("status", "error")
@@ -35,7 +48,6 @@ object FontProbeCli {
     }
 
     private fun probe(file: File): JSONObject {
-        require(file.isFile && file.length() >= 4_096L) { "验证字体不存在或文件过小：${file.path}" }
         val expected = Typeface.Builder(file).build()
         val actual = Typeface.DEFAULT
         val mismatched = JSONArray()

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontProbeCli.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/FontProbeCli.kt
@@ -15,28 +15,39 @@ import kotlin.math.roundToInt
  * Small app_process entry point used by the module after boot.
  *
  * Android devices may expose several generated 400-weight slots (global UI,
- * clock, OEM named families). The probe compares all supplied candidates with
- * Typeface.DEFAULT and reports the best match, avoiding accidental selection of
- * a clock-only or app-specific slot.
+ * clock, OEM named families). The shell supplies one visible anchor; the probe
+ * also inspects sibling and known partition font directories, then reports the
+ * best Typeface.DEFAULT outline match instead of trusting the first slot.
  */
 object FontProbeCli {
     private val samples = listOf("洛", "书", "中", "文", "你", "好", "A", "a", "1", "0", "，", "。")
+    private val generatedRegular = Regex("^LuoShuSlot-.*-400\\.ttf$", RegexOption.IGNORE_CASE)
+    private val knownFontDirectories = listOf(
+        "/system/fonts",
+        "/system/system/fonts",
+        "/system_ext/fonts",
+        "/system/system_ext/fonts",
+        "/product/fonts",
+        "/system/product/fonts",
+        "/vendor/fonts",
+        "/odm/fonts",
+        "/my_product/fonts",
+        "/oplus_product/fonts",
+        "/mi_ext/fonts",
+    )
 
     @JvmStatic
     fun main(args: Array<String>) {
         val result = runCatching {
             require(args.isNotEmpty()) { "缺少待验证字体路径" }
-            val candidates = args.asSequence()
-                .map(::File)
-                .filter { file -> file.isFile && file.length() >= 4_096L }
-                .distinctBy(File::getCanonicalPath)
+            val candidates = discoverCandidates(args)
                 .map(::probe)
                 .toList()
             require(candidates.isNotEmpty()) { "没有可读取的 400 字重验证字体" }
             val best = candidates.maxWithOrNull(
                 compareBy<JSONObject> { item -> item.optDouble("ratio", 0.0) }
                     .thenBy { item -> item.optInt("comparable", 0) }
-                    .thenBy { item -> -item.optJSONArray("missingActual").length() },
+                    .thenBy { item -> -(item.optJSONArray("missingActual")?.length() ?: Int.MAX_VALUE) },
             ) ?: error("验证候选为空")
             best.put("candidates", candidates.size)
         }.getOrElse { error ->
@@ -45,6 +56,25 @@ object FontProbeCli {
                 .put("message", error.message ?: error.javaClass.simpleName)
         }
         println(result.toString())
+    }
+
+    private fun discoverCandidates(args: Array<String>): Sequence<File> {
+        val anchors = args.asSequence().map(::File).toList()
+        val directories = buildList {
+            addAll(knownFontDirectories.map(::File))
+            anchors.mapNotNullTo(this) { file -> file.parentFile }
+        }
+        return sequence {
+            yieldAll(anchors)
+            directories.forEach { directory ->
+                val siblings = directory.listFiles { file ->
+                    file.isFile && generatedRegular.matches(file.name)
+                }
+                if (siblings != null) yieldAll(siblings.asSequence())
+            }
+        }
+            .filter { file -> file.isFile && file.length() >= 4_096L }
+            .distinctBy { file -> file.canonicalPath }
     }
 
     private fun probe(file: File): JSONObject {

--- a/common/device_font_load_verify.py
+++ b/common/device_font_load_verify.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Deep verification for a generated LuoShu device font payload.
 
-Visible mounts prove only that bytes reached Android's namespace.  The strongest
+Visible mounts prove only that bytes reached Android's namespace. The strongest
 proof is a glyph-outline comparison performed inside Android through app_process:
 Typeface.DEFAULT must render the same normalized outlines as LuoShu's generated
-400-weight global UI font.  FontManagerService evidence remains a compatibility
+400-weight global UI font. FontManagerService evidence remains a compatibility
 fallback when the matching App build is not installed yet.
 """
 from __future__ import annotations
@@ -16,7 +16,10 @@ import time
 from pathlib import Path
 from typing import Any
 
-from fontTools.ttLib import TTFont
+try:
+    from fontTools.ttLib import TTFont as _TTFont
+except ImportError:  # Host-only CI jobs intentionally do not install the runtime bundle.
+    _TTFont = None
 
 PAYLOAD_SCHEMA = "device-font-payload-v1"
 OVERLAY_SCHEMA = "device-font-overlay-v1"
@@ -89,7 +92,7 @@ def dynamic_families(overlay: dict[str, Any]) -> list[str]:
     return result
 
 
-def usable_ratio(font: TTFont, probes: tuple[int, ...]) -> tuple[float, int]:
+def usable_ratio(font: Any, probes: tuple[int, ...]) -> tuple[float, int]:
     cmap = font.getBestCmap() or {}
     glyph_order = set(font.getGlyphOrder())
     names: set[str] = set()
@@ -111,6 +114,11 @@ def verify_global_coverage(payload: dict[str, Any], mounts: list[dict[str, Any]]
         and "global-ui" in {str(role) for role in slot.get("roles") or []}
         and slot.get("generatedFile")
     }
+    if not wanted:
+        return {"checked": [], "failed": [], "unavailable": False}
+    if _TTFont is None:
+        return {"checked": [], "failed": [], "unavailable": True}
+
     checked: list[str] = []
     failed: list[str] = []
     seen: set[str] = set()
@@ -124,7 +132,7 @@ def verify_global_coverage(payload: dict[str, Any], mounts: list[dict[str, Any]]
         seen.add(fingerprint)
         visible = Path(str(mount.get("visible") or ""))
         try:
-            font = TTFont(str(visible), lazy=True, recalcTimestamp=False)
+            font = _TTFont(str(visible), lazy=True, recalcTimestamp=False)
             try:
                 cjk_ratio, cjk_unique = usable_ratio(font, CJK)
                 latin_ratio, _ = usable_ratio(font, LATIN)
@@ -144,7 +152,7 @@ def verify_global_coverage(payload: dict[str, Any], mounts: list[dict[str, Any]]
             failed.append(relative)
         if len(checked) >= 8:
             break
-    return {"checked": checked, "failed": failed}
+    return {"checked": checked, "failed": failed, "unavailable": False}
 
 
 def render_assessment(render: dict[str, Any]) -> dict[str, Any]:
@@ -227,6 +235,8 @@ def verify(
     if coverage["failed"]:
         state, mode = "failed", "compatibility"
         reasons.append("runtime-global-face-incomplete")
+    elif coverage["unavailable"]:
+        reasons.append("runtime-coverage-probe-unavailable")
     if render["missingActual"] or render["missingExpected"]:
         state, mode = "failed", "compatibility"
         reasons.append("runtime-render-missing-glyph")
@@ -241,12 +251,10 @@ def verify(
     elif not font_manager_confirmed:
         reasons.append("generated-font-not-found-in-font-manager-dump")
 
+    # OEM dumps frequently omit or rename dynamic families. Treat absence as
+    # diagnostic evidence only; the Android renderer probe is authoritative.
     if dynamic_missing:
-        if font_dump.strip() and font_manager_confirmed:
-            state, mode = "failed", "compatibility"
-            reasons.append("dynamic-family-not-loaded")
-        else:
-            reasons.append("dynamic-family-unconfirmed")
+        reasons.append("dynamic-family-unconfirmed")
 
     if state != "failed":
         if render["confirmed"] and mount_confirmed:
@@ -287,6 +295,7 @@ def verify(
             "dynamicFamilyHits": len(dynamic_hits),
             "coverageSlotsChecked": len(coverage["checked"]),
             "coverageSlotsFailed": len(coverage["failed"]),
+            "coverageProbeUnavailable": bool(coverage["unavailable"]),
             "renderMatched": int(render["matched"]),
             "renderComparable": int(render["comparable"]),
             "renderRatio": float(render["ratio"]),

--- a/common/device_font_load_verify.py
+++ b/common/device_font_load_verify.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Deep verification for a generated LuoShu device font payload.
 
-A visible mount proves only that bytes reached Android's namespace.  The result is
-reported as verified only when the mounted payload is intact, its global UI face
-still has complete text coverage, and FontManagerService names a generated LuoShu
-file or family.  Mount-only evidence remains unverified.
+Visible mounts prove only that bytes reached Android's namespace.  The strongest
+proof is a glyph-outline comparison performed inside Android through app_process:
+Typeface.DEFAULT must render the same normalized outlines as LuoShu's generated
+400-weight global UI font.  FontManagerService evidence remains a compatibility
+fallback when the matching App build is not installed yet.
 """
 from __future__ import annotations
 
@@ -19,7 +20,7 @@ from fontTools.ttLib import TTFont
 
 PAYLOAD_SCHEMA = "device-font-payload-v1"
 OVERLAY_SCHEMA = "device-font-overlay-v1"
-SCHEMA = "device-font-load-verification-v2"
+SCHEMA = "device-font-load-verification-v3"
 CJK = tuple(map(ord, "一丁七万三上下不与中为主人了二于五人今从他会但你作使入全国其分到前力十又只可同后和在地大天好学家小年心我日时有来民生的看种行要见言这"))
 LATIN = tuple(map(ord, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"))
 DIGITS = tuple(map(ord, "0123456789"))
@@ -44,6 +45,16 @@ def load_json(path: Path, schema: str) -> dict[str, Any]:
     if value.get("schema") != schema:
         raise VerifyError(f"不支持的清单：{path.name} schema={value.get('schema')!r}")
     return value
+
+
+def load_optional_json(path: Path) -> dict[str, Any]:
+    if not path.is_file() or path.stat().st_size < 2:
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
 
 
 def load_mounts(path: Path) -> list[dict[str, Any]]:
@@ -136,11 +147,36 @@ def verify_global_coverage(payload: dict[str, Any], mounts: list[dict[str, Any]]
     return {"checked": checked, "failed": failed}
 
 
+def render_assessment(render: dict[str, Any]) -> dict[str, Any]:
+    status = str(render.get("status") or "unavailable")
+    comparable = int(render.get("comparable") or 0)
+    matched = int(render.get("matched") or 0)
+    ratio = float(render.get("ratio") or 0.0)
+    missing_actual = render.get("missingActual") if isinstance(render.get("missingActual"), list) else []
+    missing_expected = render.get("missingExpected") if isinstance(render.get("missingExpected"), list) else []
+    available = status == "ok" and comparable >= 8
+    return {
+        "status": status,
+        "available": available,
+        "confirmed": available and ratio >= 0.75 and not missing_actual and not missing_expected,
+        "mismatch": available and ratio < 0.25,
+        "inconclusive": available and 0.25 <= ratio < 0.75,
+        "missingActual": missing_actual,
+        "missingExpected": missing_expected,
+        "matched": matched,
+        "comparable": comparable,
+        "ratio": ratio,
+        "path": str(render.get("path") or ""),
+        "reason": str(render.get("reason") or render.get("message") or ""),
+    }
+
+
 def verify(
     payload: dict[str, Any],
     overlay: dict[str, Any],
     font_dump: str,
     mounts: list[dict[str, Any]],
+    render_evidence: dict[str, Any],
     active_font: str,
     engine: dict[str, str],
 ) -> dict[str, Any]:
@@ -175,6 +211,7 @@ def verify(
     dynamic_hits = sorted(name for name in dynamic if name in normalized_dump or name in dump_lower.replace("_", "-"))
     dynamic_missing = sorted(set(dynamic) - set(dynamic_hits))
     coverage = verify_global_coverage(payload, mounts)
+    render = render_assessment(render_evidence)
 
     reasons: list[str] = []
     state = "unverified"
@@ -190,6 +227,12 @@ def verify(
     if coverage["failed"]:
         state, mode = "failed", "compatibility"
         reasons.append("runtime-global-face-incomplete")
+    if render["missingActual"] or render["missingExpected"]:
+        state, mode = "failed", "compatibility"
+        reasons.append("runtime-render-missing-glyph")
+    elif render["mismatch"]:
+        state, mode = "failed", "compatibility"
+        reasons.append("android-renderer-does-not-match-generated-font")
 
     font_manager_confirmed = bool(file_hits or slot_hits)
     mount_confirmed = bool(expected_paths) and not missing_mounts and not bad_mounts
@@ -206,9 +249,13 @@ def verify(
             reasons.append("dynamic-family-unconfirmed")
 
     if state != "failed":
-        if mount_confirmed and font_manager_confirmed:
-            # Keep the historical `aligned` public mode so existing App builds
-            # understand the stronger verifier without treating it as unknown.
+        if render["confirmed"] and mount_confirmed:
+            state, mode = "verified", "aligned"
+            reasons.append("android-renderer-confirmed-generated-font")
+        elif render["inconclusive"]:
+            state, mode = "unverified", "render-inconclusive"
+            reasons.append("android-renderer-result-inconclusive")
+        elif mount_confirmed and font_manager_confirmed:
             state, mode = "verified", "aligned"
             reasons.append("font-manager-confirmed-generated-font")
         elif mount_confirmed:
@@ -216,6 +263,9 @@ def verify(
             reasons.append("visible-mounts-do-not-prove-font-selection")
         else:
             state, mode = "unverified", "compatibility"
+
+    if not render["available"]:
+        reasons.append("android-render-probe-unavailable")
 
     summary = overlay.get("summary") if isinstance(overlay.get("summary"), dict) else {}
     return {
@@ -237,6 +287,9 @@ def verify(
             "dynamicFamilyHits": len(dynamic_hits),
             "coverageSlotsChecked": len(coverage["checked"]),
             "coverageSlotsFailed": len(coverage["failed"]),
+            "renderMatched": int(render["matched"]),
+            "renderComparable": int(render["comparable"]),
+            "renderRatio": float(render["ratio"]),
             "mappedSlots": int(summary.get("mappedSlots") or 0),
         },
         "reasons": reasons,
@@ -249,6 +302,7 @@ def verify(
         "dynamicFamilyMissing": dynamic_missing,
         "coverageChecked": coverage["checked"],
         "coverageFailed": coverage["failed"],
+        "render": render,
     }
 
 
@@ -278,6 +332,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--overlay", required=True, type=Path)
     parser.add_argument("--font-dump", required=True, type=Path)
     parser.add_argument("--mount-evidence", required=True, type=Path)
+    parser.add_argument("--render-evidence", required=True, type=Path)
     parser.add_argument("--engine-state", required=True, type=Path)
     parser.add_argument("--active-font", default="unknown")
     parser.add_argument("--output", required=True, type=Path)
@@ -292,6 +347,7 @@ def main() -> int:
             load_json(args.overlay, OVERLAY_SCHEMA),
             args.font_dump.read_text(encoding="utf-8", errors="replace") if args.font_dump.is_file() else "",
             load_mounts(args.mount_evidence),
+            load_optional_json(args.render_evidence),
             args.active_font,
             parse_engine(args.engine_state),
         )

--- a/common/device_font_load_verify.py
+++ b/common/device_font_load_verify.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """Verify that Android actually loaded a generated per-device font payload.
 
-Generation success is not enough. This verifier combines visible mount evidence,
-the payload/overlay manifests and FontManagerService's dump. It deliberately emits
-`unverified` instead of pretending success when neither runtime source provides evidence.
+Visible bind/overlay mounts prove only that bytes reached the system namespace;
+they do not prove that FontManager selected those files.  A result is therefore
+`verified` only when the visible payload is intact and FontManagerService reports
+one of LuoShu's generated files/families.  Mount-only evidence remains explicitly
+`unverified` so the App never claims success while the ROM is still rendering its
+default font.
 """
 from __future__ import annotations
 
@@ -14,9 +17,14 @@ import time
 from pathlib import Path
 from typing import Any
 
+from fontTools.ttLib import TTFont
+
 PAYLOAD_SCHEMA = "device-font-payload-v1"
 OVERLAY_SCHEMA = "device-font-overlay-v1"
-SCHEMA = "device-font-load-verification-v1"
+SCHEMA = "device-font-load-verification-v2"
+CJK = tuple(map(ord, "一丁七万三上下不与中为主人了二于五人今从他会但你作使入全国其分到前力十又只可同后和在地大天好学家小年心我日时有来民生的看种行要见言这"))
+LATIN = tuple(map(ord, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"))
+DIGITS = tuple(map(ord, "0123456789"))
 
 
 class VerifyError(RuntimeError):
@@ -75,6 +83,76 @@ def dynamic_families(overlay: dict[str, Any]) -> list[str]:
     return result
 
 
+def usable_ratio(font: TTFont, probes: tuple[int, ...]) -> tuple[float, int]:
+    cmap = font.getBestCmap() or {}
+    glyph_order = set(font.getGlyphOrder())
+    names: set[str] = set()
+    hits = 0
+    for codepoint in probes:
+        glyph = cmap.get(codepoint)
+        if not glyph or glyph == ".notdef" or glyph not in glyph_order:
+            continue
+        hits += 1
+        names.add(glyph)
+    return (hits / len(probes) if probes else 1.0), len(names)
+
+
+def verify_global_slot_coverage(payload: dict[str, Any], mounts: list[dict[str, Any]]) -> dict[str, Any]:
+    mount_by_rel = {str(item.get("relative")): item for item in mounts}
+    wanted: set[str] = set()
+    for slot in payload.get("slots") or []:
+        if not isinstance(slot, dict):
+            continue
+        roles = {str(role) for role in slot.get("roles") or []}
+        if "global-ui" not in roles:
+            continue
+        generated = str(slot.get("generatedFile") or "")
+        if generated:
+            wanted.add(generated)
+    checked: list[str] = []
+    failed: list[str] = []
+    seen_fingerprints: set[str] = set()
+    for relative, mount in mount_by_rel.items():
+        if not wanted or Path(relative).name not in wanted:
+            continue
+        if mount.get("status") != "ok":
+            continue
+        fingerprint = str(mount.get("actualSha256") or relative)
+        if fingerprint in seen_fingerprints:
+            continue
+        seen_fingerprints.add(fingerprint)
+        visible = Path(str(mount.get("visible") or ""))
+        if not visible.is_file():
+            failed.append(relative)
+            continue
+        try:
+            font = TTFont(str(visible), lazy=True, recalcTimestamp=False)
+            try:
+                cjk_ratio, cjk_unique = usable_ratio(font, CJK)
+                latin_ratio, _ = usable_ratio(font, LATIN)
+                digit_ratio, _ = usable_ratio(font, DIGITS)
+            finally:
+                font.close()
+        except Exception:
+            failed.append(relative)
+            continue
+        checked.append(relative)
+        if not (
+            cjk_ratio >= 0.95
+            and cjk_unique >= max(12, int(len(CJK) * cjk_ratio * 0.75))
+            and latin_ratio == 1.0
+            and digit_ratio == 1.0
+        ):
+            failed.append(relative)
+        if len(checked) >= 8:
+            break
+    return {
+        "checked": checked,
+        "failed": failed,
+        "confirmed": bool(checked) and not failed,
+    }
+
+
 def verify(
     payload: dict[str, Any],
     overlay: dict[str, Any],
@@ -108,14 +186,18 @@ def verify(
     })
     dynamic = dynamic_families(overlay)
     dump_lower = font_dump.lower()
+    normalized_dump = normalize(dump_lower)
     file_hits = sorted(name for name in generated_files if name.lower() in dump_lower)
     slot_hits = sorted(name for name in slot_names if name in dump_lower)
-    dynamic_hits = sorted(name for name in dynamic if name in normalize(dump_lower) or name in dump_lower.replace("_", "-"))
+    dynamic_hits = sorted(name for name in dynamic if name in normalized_dump or name in dump_lower.replace("_", "-"))
     dynamic_missing = sorted(set(dynamic) - set(dynamic_hits))
+    coverage = verify_global_slot_coverage(payload, mounts)
 
     reasons: list[str] = []
-    state = "verified"
-    mode = "aligned"
+    state = "unverified"
+    mode = "mount-only"
+    if not expected_paths:
+        reasons.append("visible-font-manifest-empty")
     if missing_mounts:
         state = "failed"
         mode = "compatibility"
@@ -124,6 +206,10 @@ def verify(
         state = "failed"
         mode = "compatibility"
         reasons.append("visible-font-hash-mismatch")
+    if coverage["failed"]:
+        state = "failed"
+        mode = "compatibility"
+        reasons.append("runtime-global-face-incomplete")
 
     font_manager_confirmed = bool(file_hits or slot_hits)
     mount_confirmed = bool(expected_paths) and not missing_mounts and not bad_mounts
@@ -137,24 +223,18 @@ def verify(
             state = "failed"
             mode = "compatibility"
             reasons.append("dynamic-family-not-loaded")
-        elif mount_confirmed:
-            # A redacted/empty OEM dump cannot prove named dynamic families either way. Keep
-            # that limitation visible, but do not turn byte-identical visible mounts into a
-            # permanent failure state.
-            reasons.append("dynamic-family-unconfirmed")
         else:
-            state = "unverified"
-            mode = "compatibility"
             reasons.append("dynamic-family-unconfirmed")
-    if state != "failed" and not font_manager_confirmed:
-        if mount_confirmed:
-            # Some OEM builds redact generated family/file names from `cmd font dump`.
-            # At boot-complete, byte-identical files at every expected visible mount are
-            # still strong runtime evidence; expose that separately instead of leaving
-            # users permanently stuck at "pending".
+
+    if state != "failed":
+        if mount_confirmed and font_manager_confirmed:
             state = "verified"
-            mode = "mount-verified"
-            reasons.append("verified-by-visible-mounts")
+            mode = "font-manager-verified"
+            reasons.append("font-manager-confirmed-generated-font")
+        elif mount_confirmed:
+            state = "unverified"
+            mode = "mount-only"
+            reasons.append("visible-mounts-do-not-prove-font-selection")
         else:
             state = "unverified"
             mode = "compatibility"
@@ -177,6 +257,8 @@ def verify(
             "fontManagerSlotHits": len(slot_hits),
             "dynamicFamilies": len(dynamic),
             "dynamicFamilyHits": len(dynamic_hits),
+            "coverageSlotsChecked": len(coverage["checked"]),
+            "coverageSlotsFailed": len(coverage["failed"]),
             "mappedSlots": int(summary.get("mappedSlots") or 0),
         },
         "reasons": reasons,
@@ -187,6 +269,8 @@ def verify(
         "dynamicFamilies": dynamic,
         "dynamicFamilyHits": dynamic_hits,
         "dynamicFamilyMissing": dynamic_missing,
+        "coverageChecked": coverage["checked"],
+        "coverageFailed": coverage["failed"],
     }
 
 

--- a/common/device_font_load_verify.py
+++ b/common/device_font_load_verify.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
-"""Verify that Android actually loaded a generated per-device font payload.
+"""Deep verification for a generated LuoShu device font payload.
 
-Visible bind/overlay mounts prove only that bytes reached the system namespace;
-they do not prove that FontManager selected those files.  A result is therefore
-`verified` only when the visible payload is intact and FontManagerService reports
-one of LuoShu's generated files/families.  Mount-only evidence remains explicitly
-`unverified` so the App never claims success while the ROM is still rendering its
-default font.
+A visible mount proves only that bytes reached Android's namespace.  The result is
+reported as verified only when the mounted payload is intact, its global UI face
+still has complete text coverage, and FontManagerService names a generated LuoShu
+file or family.  Mount-only evidence remains unverified.
 """
 from __future__ import annotations
 
@@ -38,30 +36,27 @@ def normalize(value: str) -> str:
 def safe_family(slot: dict[str, Any]) -> str:
     family = str(slot.get("familyNormalized") or slot.get("family") or "luoshu-slot")
     safe = "".join(char if char.isalnum() else "-" for char in family).strip("-") or "LuoShuSlot"
-    weight = int(slot.get("weight") or 400)
-    return f"luoshuslot-{safe.lower()}-{weight}"
+    return f"luoshuslot-{safe.lower()}-{int(slot.get('weight') or 400)}"
 
 
 def load_json(path: Path, schema: str) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if payload.get("schema") != schema:
-        raise VerifyError(f"不支持的清单：{path.name} schema={payload.get('schema')!r}")
-    return payload
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if value.get("schema") != schema:
+        raise VerifyError(f"不支持的清单：{path.name} schema={value.get('schema')!r}")
+    return value
 
 
-def load_mount_evidence(path: Path) -> list[dict[str, Any]]:
+def load_mounts(path: Path) -> list[dict[str, Any]]:
     result: list[dict[str, Any]] = []
     if not path.is_file():
         return result
     for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        if not raw.strip():
-            continue
         parts = raw.split("|", 5)
         if len(parts) != 6:
             continue
-        rel, visible, status, expected_hash, actual_hash, size = parts
+        relative, visible, status, expected_hash, actual_hash, size = parts
         result.append({
-            "relative": rel,
+            "relative": relative,
             "visible": visible,
             "status": status,
             "expectedSha256": expected_hash,
@@ -97,34 +92,26 @@ def usable_ratio(font: TTFont, probes: tuple[int, ...]) -> tuple[float, int]:
     return (hits / len(probes) if probes else 1.0), len(names)
 
 
-def verify_global_slot_coverage(payload: dict[str, Any], mounts: list[dict[str, Any]]) -> dict[str, Any]:
-    mount_by_rel = {str(item.get("relative")): item for item in mounts}
-    wanted: set[str] = set()
-    for slot in payload.get("slots") or []:
-        if not isinstance(slot, dict):
-            continue
-        roles = {str(role) for role in slot.get("roles") or []}
-        if "global-ui" not in roles:
-            continue
-        generated = str(slot.get("generatedFile") or "")
-        if generated:
-            wanted.add(generated)
+def verify_global_coverage(payload: dict[str, Any], mounts: list[dict[str, Any]]) -> dict[str, Any]:
+    wanted = {
+        str(slot.get("generatedFile"))
+        for slot in payload.get("slots") or []
+        if isinstance(slot, dict)
+        and "global-ui" in {str(role) for role in slot.get("roles") or []}
+        and slot.get("generatedFile")
+    }
     checked: list[str] = []
     failed: list[str] = []
-    seen_fingerprints: set[str] = set()
-    for relative, mount in mount_by_rel.items():
-        if not wanted or Path(relative).name not in wanted:
-            continue
-        if mount.get("status") != "ok":
+    seen: set[str] = set()
+    for mount in mounts:
+        relative = str(mount.get("relative") or "")
+        if Path(relative).name not in wanted or mount.get("status") != "ok":
             continue
         fingerprint = str(mount.get("actualSha256") or relative)
-        if fingerprint in seen_fingerprints:
+        if fingerprint in seen:
             continue
-        seen_fingerprints.add(fingerprint)
+        seen.add(fingerprint)
         visible = Path(str(mount.get("visible") or ""))
-        if not visible.is_file():
-            failed.append(relative)
-            continue
         try:
             font = TTFont(str(visible), lazy=True, recalcTimestamp=False)
             try:
@@ -133,24 +120,20 @@ def verify_global_slot_coverage(payload: dict[str, Any], mounts: list[dict[str, 
                 digit_ratio, _ = usable_ratio(font, DIGITS)
             finally:
                 font.close()
+            valid = (
+                cjk_ratio >= 0.95
+                and cjk_unique >= max(12, int(len(CJK) * cjk_ratio * 0.75))
+                and latin_ratio == 1.0
+                and digit_ratio == 1.0
+            )
         except Exception:
-            failed.append(relative)
-            continue
+            valid = False
         checked.append(relative)
-        if not (
-            cjk_ratio >= 0.95
-            and cjk_unique >= max(12, int(len(CJK) * cjk_ratio * 0.75))
-            and latin_ratio == 1.0
-            and digit_ratio == 1.0
-        ):
+        if not valid:
             failed.append(relative)
         if len(checked) >= 8:
             break
-    return {
-        "checked": checked,
-        "failed": failed,
-        "confirmed": bool(checked) and not failed,
-    }
+    return {"checked": checked, "failed": failed}
 
 
 def verify(
@@ -165,7 +148,7 @@ def verify(
     expected_paths = {
         str(item.get("path"))
         for item in copied
-        if isinstance(item, dict) and str(item.get("path") or "")
+        if isinstance(item, dict) and item.get("path")
     }
     mount_by_rel = {str(item.get("relative")): item for item in mounts}
     missing_mounts = sorted(path for path in expected_paths if path not in mount_by_rel)
@@ -191,7 +174,7 @@ def verify(
     slot_hits = sorted(name for name in slot_names if name in dump_lower)
     dynamic_hits = sorted(name for name in dynamic if name in normalized_dump or name in dump_lower.replace("_", "-"))
     dynamic_missing = sorted(set(dynamic) - set(dynamic_hits))
-    coverage = verify_global_slot_coverage(payload, mounts)
+    coverage = verify_global_coverage(payload, mounts)
 
     reasons: list[str] = []
     state = "unverified"
@@ -199,16 +182,13 @@ def verify(
     if not expected_paths:
         reasons.append("visible-font-manifest-empty")
     if missing_mounts:
-        state = "failed"
-        mode = "compatibility"
+        state, mode = "failed", "compatibility"
         reasons.append("visible-mount-evidence-missing")
     if bad_mounts:
-        state = "failed"
-        mode = "compatibility"
+        state, mode = "failed", "compatibility"
         reasons.append("visible-font-hash-mismatch")
     if coverage["failed"]:
-        state = "failed"
-        mode = "compatibility"
+        state, mode = "failed", "compatibility"
         reasons.append("runtime-global-face-incomplete")
 
     font_manager_confirmed = bool(file_hits or slot_hits)
@@ -220,24 +200,22 @@ def verify(
 
     if dynamic_missing:
         if font_dump.strip() and font_manager_confirmed:
-            state = "failed"
-            mode = "compatibility"
+            state, mode = "failed", "compatibility"
             reasons.append("dynamic-family-not-loaded")
         else:
             reasons.append("dynamic-family-unconfirmed")
 
     if state != "failed":
         if mount_confirmed and font_manager_confirmed:
-            state = "verified"
-            mode = "font-manager-verified"
+            # Keep the historical `aligned` public mode so existing App builds
+            # understand the stronger verifier without treating it as unknown.
+            state, mode = "verified", "aligned"
             reasons.append("font-manager-confirmed-generated-font")
         elif mount_confirmed:
-            state = "unverified"
-            mode = "mount-only"
+            state, mode = "unverified", "mount-only"
             reasons.append("visible-mounts-do-not-prove-font-selection")
         else:
-            state = "unverified"
-            mode = "compatibility"
+            state, mode = "unverified", "compatibility"
 
     summary = overlay.get("summary") if isinstance(overlay.get("summary"), dict) else {}
     return {
@@ -279,11 +257,10 @@ def parse_engine(path: Path) -> dict[str, str]:
     if not path.is_file():
         return result
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        if key and value:
-            result[key] = value
+        if "=" in line:
+            key, value = line.split("=", 1)
+            if key and value:
+                result[key] = value
     return result
 
 
@@ -310,14 +287,11 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     try:
-        payload = load_json(args.payload, PAYLOAD_SCHEMA)
-        overlay = load_json(args.overlay, OVERLAY_SCHEMA)
-        font_dump = args.font_dump.read_text(encoding="utf-8", errors="replace") if args.font_dump.is_file() else ""
         result = verify(
-            payload,
-            overlay,
-            font_dump,
-            load_mount_evidence(args.mount_evidence),
+            load_json(args.payload, PAYLOAD_SCHEMA),
+            load_json(args.overlay, OVERLAY_SCHEMA),
+            args.font_dump.read_text(encoding="utf-8", errors="replace") if args.font_dump.is_file() else "",
+            load_mounts(args.mount_evidence),
             args.active_font,
             parse_engine(args.engine_state),
         )

--- a/common/device_font_load_verify.py
+++ b/common/device_font_load_verify.py
@@ -332,7 +332,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--overlay", required=True, type=Path)
     parser.add_argument("--font-dump", required=True, type=Path)
     parser.add_argument("--mount-evidence", required=True, type=Path)
-    parser.add_argument("--render-evidence", required=True, type=Path)
+    parser.add_argument("--render-evidence", type=Path, default=Path("/dev/null"))
     parser.add_argument("--engine-state", required=True, type=Path)
     parser.add_argument("--active-font", default="unknown")
     parser.add_argument("--output", required=True, type=Path)

--- a/common/device_font_load_verify.sh
+++ b/common/device_font_load_verify.sh
@@ -1,10 +1,18 @@
 #!/system/bin/sh
-# Record the active font after Android boot without rescanning the complete payload.
-# The expensive FontManager/hash verifier is retained only behind the explicit `verify` command.
+# Verify the active LuoShu payload after Android boot.
+# A successful mount is recorded as mount-only until FontManagerService confirms
+# a generated LuoShu file/family.  Hard integrity failures schedule a safe
+# next-boot rollback; unconfirmed OEM dumps never trigger rollback by themselves.
 set +e
 
 _dfload_module() {
     printf '%s\n' "${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
+}
+
+_dfload_boot_id() {
+    _dfload_value=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n')
+    [ -n "$_dfload_value" ] || _dfload_value=unknown
+    printf '%s\n' "$_dfload_value"
 }
 
 _dfload_hash_stream() {
@@ -42,6 +50,10 @@ _dfload_log() {
         >> "$_dfload_module_dir/logs/device-font-load-verify.log" 2>/dev/null || true
 }
 
+_dfload_read() {
+    sed -n "s/^${2}=//p" "$1" 2>/dev/null | head -n1 | tr -d '\r\n'
+}
+
 _dfload_write_simple() {
     _dfload_state="$1"
     _dfload_reason="$2"
@@ -55,6 +67,7 @@ _dfload_write_simple() {
         printf 'mode=%s\n' "$_dfload_mode"
         printf 'activeFont=%s\n' "$_dfload_active"
         printf 'reason=%s\n' "$_dfload_reason"
+        printf 'bootId=%s\n' "$(_dfload_boot_id)"
         printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
     } > "${_dfload_conf}.tmp.$$" 2>/dev/null || return 1
     mv -f "${_dfload_conf}.tmp.$$" "$_dfload_conf" 2>/dev/null || return 1
@@ -62,36 +75,49 @@ _dfload_write_simple() {
     return 0
 }
 
-# Normal boot path: switching already completed transaction, payload and mount checks.
-# Do not traverse or hash the font tree again. A confirmed boot transaction or mounted
-# self-mount is sufficient for the App's applied state; explicit deep verification remains
-# available for diagnostics.
+_dfload_active() {
+    _dfload_module_dir="$(_dfload_module)"
+    _dfload_value=$(head -n1 "$_dfload_module_dir/config/active_font.conf" 2>/dev/null | tr -d '\r\n')
+    [ -n "$_dfload_value" ] || _dfload_value=default
+    printf '%s\n' "$_dfload_value"
+}
+
+# Read-only status: never upgrades a mounted transaction to verified.
 device_font_load_status() {
     _dfload_module_dir="$(_dfload_module)"
-    _dfload_config="$_dfload_module_dir/config"
-    _dfload_active=$(head -n1 "$_dfload_config/active_font.conf" 2>/dev/null | tr -d '\r\n')
-    [ -n "$_dfload_active" ] || _dfload_active=default
-    if [ "$_dfload_active" = default ]; then
-        _dfload_write_simple not-applicable default-font "$_dfload_active" system
+    _dfload_active_font=$(_dfload_active)
+    if [ "$_dfload_active_font" = default ]; then
+        _dfload_write_simple not-applicable default-font "$_dfload_active_font" system
         return 0
     fi
 
-    _dfload_mount_state=$(sed -n 's/^state=//p' "$_dfload_config/self-mount.conf" 2>/dev/null | head -n1)
-    _dfload_boot_state=$(sed -n 's/^state=//p' "$_dfload_config/font-payload-boot.conf" 2>/dev/null | head -n1)
+    _dfload_conf="$_dfload_module_dir/config/device-font-load-verification.conf"
+    _dfload_saved_active=$(_dfload_read "$_dfload_conf" activeFont)
+    _dfload_saved_boot=$(_dfload_read "$_dfload_conf" bootId)
+    _dfload_current_boot=$(_dfload_boot_id)
+    if [ "$_dfload_saved_active" = "$_dfload_active_font" ] && \
+       [ "$_dfload_saved_boot" = "$_dfload_current_boot" ]; then
+        case "$(_dfload_read "$_dfload_conf" state)" in
+            verified|not-applicable) return 0 ;;
+            failed) return 1 ;;
+            *) return 2 ;;
+        esac
+    fi
+
+    _dfload_mount_state=$(_dfload_read "$_dfload_module_dir/config/self-mount.conf" state)
+    _dfload_boot_state=$(_dfload_read "$_dfload_module_dir/config/font-payload-boot.conf" state)
     if [ "$_dfload_mount_state" = failed ]; then
-        _dfload_write_simple failed self-mount-failed "$_dfload_active" compatibility
-        _dfload_log "字体自挂载状态失败：$_dfload_active"
+        _dfload_write_simple failed self-mount-failed "$_dfload_active_font" compatibility
         return 1
     fi
     case "$_dfload_mount_state:$_dfload_boot_state" in
         mounted:*|*:confirmed)
-            _dfload_write_simple verified boot-transaction-confirmed "$_dfload_active" mount-verified
-            _dfload_log "字体已按正常切换流程生效：$_dfload_active"
-            return 0
+            _dfload_write_simple unverified visible-mounts-do-not-prove-font-selection \
+                "$_dfload_active_font" mount-only
+            return 2
             ;;
     esac
-
-    _dfload_write_simple pending awaiting-boot-transaction "$_dfload_active" compatibility
+    _dfload_write_simple pending awaiting-boot-transaction "$_dfload_active_font" compatibility
     return 2
 }
 
@@ -125,7 +151,7 @@ _dfload_dump_font_manager() {
 _dfload_manifest_paths() {
     _dfload_module_dir="$(_dfload_module)"
     _dfload_engine_state="$_dfload_module_dir/config/device-font-engine.conf"
-    _dfload_cache_id=$(sed -n 's/^cacheId=//p' "$_dfload_engine_state" 2>/dev/null | head -n1)
+    _dfload_cache_id=$(_dfload_read "$_dfload_engine_state" cacheId)
     if [ -n "$_dfload_cache_id" ]; then
         _dfload_root="$_dfload_module_dir/config/device-font-cache/$_dfload_cache_id"
         printf '%s|%s\n' "$_dfload_root/payload/manifest.json" "$_dfload_root/overlay/overlay-manifest.json"
@@ -133,6 +159,29 @@ _dfload_manifest_paths() {
         printf '%s|%s\n' \
             "$_dfload_module_dir/config/device-font-payload/manifest.json" \
             "$_dfload_module_dir/config/device-font-overlay/overlay-manifest.json"
+    fi
+}
+
+_dfload_module_source() {
+    _dfload_relative="$1"
+    _dfload_module_dir="$(_dfload_module)"
+    for _dfload_candidate in \
+        "$_dfload_module_dir/$_dfload_relative" \
+        "$_dfload_module_dir/.luoshu-payload/$_dfload_relative"; do
+        [ -f "$_dfload_candidate" ] && {
+            printf '%s\n' "$_dfload_candidate"
+            return 0
+        }
+    done
+    return 1
+}
+
+_dfload_visible_source() {
+    _dfload_relative="$1"
+    if [ -f "/proc/1/root/$_dfload_relative" ]; then
+        printf '/proc/1/root/%s\n' "$_dfload_relative"
+    else
+        printf '/%s\n' "$_dfload_relative"
     fi
 }
 
@@ -145,20 +194,20 @@ _dfload_mount_evidence() {
     while IFS='|' read -r _dfload_kind _dfload_rel _dfload_manifest_hash _dfload_expected_size; do
         [ "$_dfload_kind" = file ] || continue
         case "$_dfload_rel" in */fonts/*.ttf|*/fonts/*.otf|*/fonts/*.ttc) ;; *) continue ;; esac
-        _dfload_module_file="$_dfload_module_dir/$_dfload_rel"
-        _dfload_visible="/$_dfload_rel"
+        _dfload_module_file=$(_dfload_module_source "$_dfload_rel")
+        _dfload_visible=$(_dfload_visible_source "$_dfload_rel")
         _dfload_status=missing
         _dfload_expected_fingerprint=''
         _dfload_actual_fingerprint=''
-        _dfload_size=0
+        _dfload_size_value=0
         if [ -f "$_dfload_module_file" ]; then
             _dfload_expected_fingerprint=$(_dfload_quick_fingerprint "$_dfload_module_file")
         fi
         if [ -f "$_dfload_visible" ]; then
-            _dfload_size=$(_dfload_size "$_dfload_visible")
+            _dfload_size_value=$(_dfload_size "$_dfload_visible")
             _dfload_actual_fingerprint=$(_dfload_quick_fingerprint "$_dfload_visible")
             if [ -n "$_dfload_expected_fingerprint" ] && \
-               [ "$_dfload_size" = "$_dfload_expected_size" ] && \
+               [ "$_dfload_size_value" = "$_dfload_expected_size" ] && \
                [ "$_dfload_actual_fingerprint" = "$_dfload_expected_fingerprint" ]; then
                 _dfload_status=ok
             else
@@ -167,25 +216,30 @@ _dfload_mount_evidence() {
         fi
         printf '%s|%s|%s|%s|%s|%s\n' \
             "$_dfload_rel" "$_dfload_visible" "$_dfload_status" \
-            "$_dfload_expected_fingerprint" "$_dfload_actual_fingerprint" "${_dfload_size:-0}" >> "$_dfload_output"
+            "$_dfload_expected_fingerprint" "$_dfload_actual_fingerprint" "${_dfload_size_value:-0}" >> "$_dfload_output"
     done < "$_dfload_installed"
     chmod 0600 "$_dfload_output" 2>/dev/null || true
 }
 
 _dfload_write_conf_from_json() {
-    _dfload_json="$1"
+    _dfload_json_file="$1"
     _dfload_conf="$2"
-    _dfload_state=$(sed -n 's/.*"state":"\([^"]*\)".*/\1/p' "$_dfload_json" 2>/dev/null | head -n1)
-    _dfload_mode=$(sed -n 's/.*"mode":"\([^"]*\)".*/\1/p' "$_dfload_json" 2>/dev/null | head -n1)
-    _dfload_active=$(sed -n 's/.*"activeFont":"\([^"]*\)".*/\1/p' "$_dfload_json" 2>/dev/null | head -n1)
+    _dfload_json=$(cat "$_dfload_json_file" 2>/dev/null)
+    _dfload_state=$(printf '%s' "$_dfload_json" | sed -n 's/.*"state":"\([^"]*\)".*/\1/p' | head -n1)
+    _dfload_mode=$(printf '%s' "$_dfload_json" | sed -n 's/.*"mode":"\([^"]*\)".*/\1/p' | head -n1)
+    _dfload_active_font=$(printf '%s' "$_dfload_json" | sed -n 's/.*"activeFont":"\([^"]*\)".*/\1/p' | head -n1)
+    _dfload_reason=$(printf '%s' "$_dfload_json" | sed -n 's/.*"reasons":\["\([^"]*\)".*/\1/p' | head -n1)
     [ -n "$_dfload_state" ] || _dfload_state=failed
     [ -n "$_dfload_mode" ] || _dfload_mode=compatibility
+    [ -n "$_dfload_reason" ] || _dfload_reason=verification-result-unclassified
     {
         printf 'state=%s\n' "$_dfload_state"
         printf 'mode=%s\n' "$_dfload_mode"
-        printf 'activeFont=%s\n' "$_dfload_active"
+        printf 'activeFont=%s\n' "$_dfload_active_font"
+        printf 'reason=%s\n' "$_dfload_reason"
+        printf 'bootId=%s\n' "$(_dfload_boot_id)"
         printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
-        printf 'json=%s\n' "$_dfload_json"
+        printf 'json=%s\n' "$(printf '%s' "$_dfload_json" | tr '\n\r' '  ')"
     } > "${_dfload_conf}.tmp.$$" 2>/dev/null || return 1
     mv -f "${_dfload_conf}.tmp.$$" "$_dfload_conf" 2>/dev/null || return 1
     chmod 0600 "$_dfload_conf" 2>/dev/null || true
@@ -203,32 +257,55 @@ _dfload_mount_guard() {
     luoshu_mount_verify_active "$_dfload_guard_active"
 }
 
+_dfload_schedule_rollback() {
+    _dfload_reason="$1"
+    _dfload_active_font="$2"
+    case "$_dfload_reason" in
+        visible-mount-evidence-missing|visible-font-hash-mismatch|runtime-global-face-incomplete|dynamic-family-not-loaded|self-mount-not-visible|self-mount-failed) ;;
+        *) return 0 ;;
+    esac
+    _dfload_module_dir="$(_dfload_module)"
+    _dfload_flag="$_dfload_module_dir/config/font-activation-rollback.conf"
+    {
+        printf 'state=pending\n'
+        printf 'font=%s\n' "$_dfload_active_font"
+        printf 'reason=%s\n' "$_dfload_reason"
+        printf 'bootId=%s\n' "$(_dfload_boot_id)"
+        printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
+    } > "${_dfload_flag}.tmp.$$" 2>/dev/null && \
+        mv -f "${_dfload_flag}.tmp.$$" "$_dfload_flag" 2>/dev/null || true
+    chmod 0600 "$_dfload_flag" 2>/dev/null || true
+    _dfload_log "检测到硬故障，已安排下次开机恢复系统默认字体：$_dfload_reason"
+}
+
 device_font_load_verify() {
     _dfload_module_dir="$(_dfload_module)"
     _dfload_config="$_dfload_module_dir/config"
-    _dfload_active=$(head -n1 "$_dfload_config/active_font.conf" 2>/dev/null | tr -d '\r\n')
-    [ -n "$_dfload_active" ] || _dfload_active=default
-    if [ "$_dfload_active" = default ]; then
-        _dfload_write_simple not-applicable default-font "$_dfload_active"
-        return 2
+    _dfload_active_font=$(_dfload_active)
+    if [ "$_dfload_active_font" = default ]; then
+        _dfload_write_simple not-applicable default-font "$_dfload_active_font" system
+        return 0
     fi
-    if ! _dfload_mount_guard "$_dfload_active"; then
-        _dfload_write_simple failed self-mount-not-visible "$_dfload_active"
+    if ! _dfload_mount_guard "$_dfload_active_font"; then
+        _dfload_write_simple failed self-mount-not-visible "$_dfload_active_font" compatibility
+        _dfload_schedule_rollback self-mount-not-visible "$_dfload_active_font"
         _dfload_log '自挂载未完整提交或未进入系统主命名空间，禁止标记字体已生效'
         return 1
     fi
+
     _dfload_engine_state="$_dfload_config/device-font-engine.conf"
     if ! grep -q '^state=installed$' "$_dfload_engine_state" 2>/dev/null; then
-        _dfload_write_simple verified verified-by-visible-mounts "$_dfload_active" mount-verified
-        _dfload_log "兼容字体负载已通过系统主命名空间挂载验证：$_dfload_active"
-        return 0
+        _dfload_write_simple unverified aligned-manifest-unavailable "$_dfload_active_font" mount-only
+        _dfload_log "兼容字体负载挂载可见，但没有 FontManager 对齐清单：$_dfload_active_font"
+        return 2
     fi
 
     _dfload_paths=$(_dfload_manifest_paths)
     _dfload_payload=${_dfload_paths%%|*}
     _dfload_overlay=${_dfload_paths#*|}
     if [ ! -s "$_dfload_payload" ] || [ ! -s "$_dfload_overlay" ]; then
-        _dfload_write_simple failed aligned-manifest-missing "$_dfload_active"
+        _dfload_write_simple failed aligned-manifest-missing "$_dfload_active_font" compatibility
+        _dfload_schedule_rollback visible-mount-evidence-missing "$_dfload_active_font"
         _dfload_log '设备对齐清单缺失，禁止标记已生效'
         return 1
     fi
@@ -245,26 +322,45 @@ device_font_load_verify() {
         --font-dump "$_dfload_dump" \
         --mount-evidence "$_dfload_mounts" \
         --engine-state "$_dfload_engine_state" \
-        --active-font "$_dfload_active" \
+        --active-font "$_dfload_active_font" \
         --output "$_dfload_json" 2>> "$_dfload_module_dir/logs/device-font-load-verify.log")
     _dfload_rc=$?
     if [ -s "$_dfload_json" ]; then
         _dfload_write_conf_from_json "$_dfload_json" "$_dfload_conf" || true
     else
-        _dfload_write_simple failed verifier-output-missing "$_dfload_active"
+        _dfload_write_simple failed verifier-output-missing "$_dfload_active_font" compatibility
     fi
-    case "$_dfload_rc" in
-        0) _dfload_log "FontManager 已确认加载设备对齐字体：$_dfload_active" ;;
-        2) _dfload_log "设备对齐字体未获得完整加载证据：$_dfload_result" ;;
-        *) _dfload_log "设备对齐字体加载验证失败：$_dfload_result" ;;
+    _dfload_state=$(_dfload_read "$_dfload_conf" state)
+    _dfload_reason=$(_dfload_read "$_dfload_conf" reason)
+    [ "$_dfload_state" != failed ] || _dfload_schedule_rollback "$_dfload_reason" "$_dfload_active_font"
+    case "$_dfload_state" in
+        verified) _dfload_log "FontManager 已确认加载设备对齐字体：$_dfload_active_font" ;;
+        unverified) _dfload_log "字体挂载可见但系统未提供选用证据：$_dfload_result" ;;
+        *) _dfload_log "设备字体加载验证失败：$_dfload_result" ;;
     esac
     return "$_dfload_rc"
 }
 
+device_font_load_auto() {
+    _dfload_module_dir="$(_dfload_module)"
+    _dfload_conf="$_dfload_module_dir/config/device-font-load-verification.conf"
+    _dfload_active_font=$(_dfload_active)
+    _dfload_current_boot=$(_dfload_boot_id)
+    if [ "$(_dfload_read "$_dfload_conf" activeFont)" = "$_dfload_active_font" ] && \
+       [ "$(_dfload_read "$_dfload_conf" bootId)" = "$_dfload_current_boot" ]; then
+        case "$(_dfload_read "$_dfload_conf" state)" in
+            verified|not-applicable) return 0 ;;
+            failed) return 1 ;;
+        esac
+    fi
+    device_font_load_verify
+}
+
 if [ "${0##*/}" = device_font_load_verify.sh ]; then
-    case "${1:-status}" in
-        status|auto) device_font_load_status ;;
+    case "${1:-auto}" in
+        status) device_font_load_status ;;
+        auto) device_font_load_auto ;;
         verify|deep) device_font_load_verify ;;
-        *) printf 'usage: %s {status|verify}\n' "$0" >&2; exit 2 ;;
+        *) printf 'usage: %s {status|auto|verify}\n' "$0" >&2; exit 2 ;;
     esac
 fi

--- a/common/device_font_load_verify.sh
+++ b/common/device_font_load_verify.sh
@@ -1,8 +1,8 @@
 #!/system/bin/sh
 # Verify the active LuoShu payload after Android boot.
-# A successful mount is recorded as mount-only until FontManagerService confirms
-# a generated LuoShu file/family.  Hard integrity failures schedule a safe
-# next-boot rollback; unconfirmed OEM dumps never trigger rollback by themselves.
+# Mounts are only transport evidence.  When the matching LuoShu App is installed,
+# app_process compares Typeface.DEFAULT glyph outlines with the generated 400-weight
+# font; otherwise FontManagerService evidence remains the compatibility fallback.
 set +e
 
 _dfload_module() {
@@ -221,6 +221,76 @@ _dfload_mount_evidence() {
     chmod 0600 "$_dfload_output" 2>/dev/null || true
 }
 
+_dfload_write_render_unavailable() {
+    _dfload_output="$1"
+    _dfload_reason="$2"
+    printf '{"status":"unavailable","reason":"%s"}\n' "$_dfload_reason" > "${_dfload_output}.tmp.$$" 2>/dev/null || return 1
+    mv -f "${_dfload_output}.tmp.$$" "$_dfload_output" 2>/dev/null || return 1
+    chmod 0600 "$_dfload_output" 2>/dev/null || true
+}
+
+_dfload_app_apk() {
+    for _dfload_package in io.github.xgl34222220.luoshu io.github.xgl34222220.luoshu.debug; do
+        _dfload_package_lines=''
+        if command -v cmd >/dev/null 2>&1; then
+            _dfload_package_lines=$(cmd package path "$_dfload_package" 2>/dev/null)
+        fi
+        if [ -z "$_dfload_package_lines" ] && command -v pm >/dev/null 2>&1; then
+            _dfload_package_lines=$(pm path "$_dfload_package" 2>/dev/null)
+        fi
+        _dfload_apk=$(printf '%s\n' "$_dfload_package_lines" | sed -n 's/^package://p' | head -n1)
+        [ -f "$_dfload_apk" ] && {
+            printf '%s\n' "$_dfload_apk"
+            return 0
+        }
+    done
+    return 1
+}
+
+_dfload_render_probe() {
+    _dfload_mounts="$1"
+    _dfload_output="$2"
+    rm -f "$_dfload_output" "${_dfload_output}.tmp.$$" 2>/dev/null || true
+    _dfload_probe_path=$(awk -F'|' '$3 == "ok" && $2 ~ /\/LuoShuSlot-.*-400\.ttf$/ { print $2; exit }' "$_dfload_mounts" 2>/dev/null)
+    if [ -z "$_dfload_probe_path" ] || [ ! -f "$_dfload_probe_path" ]; then
+        _dfload_write_render_unavailable "$_dfload_output" no-global-400-probe-font
+        return 2
+    fi
+    _dfload_apk=$(_dfload_app_apk) || {
+        _dfload_write_render_unavailable "$_dfload_output" luoshu-app-not-installed
+        return 2
+    }
+    command -v app_process >/dev/null 2>&1 || {
+        _dfload_write_render_unavailable "$_dfload_output" app-process-unavailable
+        return 2
+    }
+
+    _dfload_raw="${_dfload_output}.raw.$$"
+    rm -f "$_dfload_raw" 2>/dev/null || true
+    if command -v timeout >/dev/null 2>&1; then
+        CLASSPATH="$_dfload_apk" timeout 20 app_process /system/bin \
+            io.github.xgl34222220.luoshu.FontProbeCli "$_dfload_probe_path" > "$_dfload_raw" 2>/dev/null
+    elif command -v toybox >/dev/null 2>&1 && toybox timeout --help >/dev/null 2>&1; then
+        CLASSPATH="$_dfload_apk" toybox timeout 20 app_process /system/bin \
+            io.github.xgl34222220.luoshu.FontProbeCli "$_dfload_probe_path" > "$_dfload_raw" 2>/dev/null
+    else
+        CLASSPATH="$_dfload_apk" app_process /system/bin \
+            io.github.xgl34222220.luoshu.FontProbeCli "$_dfload_probe_path" > "$_dfload_raw" 2>/dev/null
+    fi
+    _dfload_probe_rc=$?
+    _dfload_json_line=$(tail -n1 "$_dfload_raw" 2>/dev/null | tr -d '\r')
+    rm -f "$_dfload_raw" 2>/dev/null || true
+    if [ "$_dfload_probe_rc" -ne 0 ] || ! printf '%s' "$_dfload_json_line" | grep -q '^{' || \
+       ! printf '%s' "$_dfload_json_line" | grep -q '"status"'; then
+        _dfload_write_render_unavailable "$_dfload_output" android-render-probe-execution-failed
+        return 2
+    fi
+    printf '%s\n' "$_dfload_json_line" > "${_dfload_output}.tmp.$$" 2>/dev/null || return 1
+    mv -f "${_dfload_output}.tmp.$$" "$_dfload_output" 2>/dev/null || return 1
+    chmod 0600 "$_dfload_output" 2>/dev/null || true
+    return 0
+}
+
 _dfload_write_conf_from_json() {
     _dfload_json_file="$1"
     _dfload_conf="$2"
@@ -261,7 +331,7 @@ _dfload_schedule_rollback() {
     _dfload_reason="$1"
     _dfload_active_font="$2"
     case "$_dfload_reason" in
-        visible-mount-evidence-missing|visible-font-hash-mismatch|runtime-global-face-incomplete|dynamic-family-not-loaded|self-mount-not-visible|self-mount-failed) ;;
+        visible-mount-evidence-missing|visible-font-hash-mismatch|runtime-global-face-incomplete|runtime-render-missing-glyph|android-renderer-does-not-match-generated-font|dynamic-family-not-loaded|self-mount-not-visible|self-mount-failed) ;;
         *) return 0 ;;
     esac
     _dfload_module_dir="$(_dfload_module)"
@@ -312,15 +382,18 @@ device_font_load_verify() {
 
     _dfload_dump="$_dfload_config/device-font-manager-dump.txt"
     _dfload_mounts="$_dfload_config/device-font-mount-evidence.txt"
+    _dfload_render="$_dfload_config/device-font-render-evidence.json"
     _dfload_json="$_dfload_config/device-font-load-verification.json"
     _dfload_conf="$_dfload_config/device-font-load-verification.conf"
     _dfload_dump_font_manager "$_dfload_dump"
     _dfload_mount_evidence "$_dfload_mounts" || true
+    _dfload_render_probe "$_dfload_mounts" "$_dfload_render" || true
     _dfload_result=$(_dfload_python \
         --payload "$_dfload_payload" \
         --overlay "$_dfload_overlay" \
         --font-dump "$_dfload_dump" \
         --mount-evidence "$_dfload_mounts" \
+        --render-evidence "$_dfload_render" \
         --engine-state "$_dfload_engine_state" \
         --active-font "$_dfload_active_font" \
         --output "$_dfload_json" 2>> "$_dfload_module_dir/logs/device-font-load-verify.log")
@@ -334,8 +407,8 @@ device_font_load_verify() {
     _dfload_reason=$(_dfload_read "$_dfload_conf" reason)
     [ "$_dfload_state" != failed ] || _dfload_schedule_rollback "$_dfload_reason" "$_dfload_active_font"
     case "$_dfload_state" in
-        verified) _dfload_log "FontManager 已确认加载设备对齐字体：$_dfload_active_font" ;;
-        unverified) _dfload_log "字体挂载可见但系统未提供选用证据：$_dfload_result" ;;
+        verified) _dfload_log "Android 渲染器或 FontManager 已确认设备字体：$_dfload_active_font" ;;
+        unverified) _dfload_log "字体挂载可见但系统选用仍未确认：$_dfload_result" ;;
         *) _dfload_log "设备字体加载验证失败：$_dfload_result" ;;
     esac
     return "$_dfload_rc"

--- a/common/font_activation_rollback.sh
+++ b/common/font_activation_rollback.sh
@@ -1,0 +1,121 @@
+#!/system/bin/sh
+# Consume a hard activation failure before any LuoShu font payload is mounted.
+# The current boot is left untouched; the next boot starts from the ROM font tree.
+set +e
+
+_luar_module() {
+    printf '%s\n' "${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
+}
+
+_luar_partitions() {
+    if type luoshu_private_partitions >/dev/null 2>&1; then
+        luoshu_private_partitions
+    else
+        printf '%s\n' 'system system_ext product vendor odm oem my_product my_engineering my_company my_preload my_region my_stock oplus_product oplus_engineering oplus_version oplus_region mi_ext cust hw_product'
+    fi
+}
+
+_luar_clear_partition_fonts() {
+    _luar_module_dir="$1"
+    for _luar_partition in $(_luar_partitions); do
+        _luar_fonts="$_luar_module_dir/$_luar_partition/fonts"
+        [ -d "$_luar_fonts" ] || continue
+        find "$_luar_fonts" -maxdepth 1 -type f \
+            \( -iname '*.ttf' -o -iname '*.otf' -o -iname '*.ttc' -o -name '*.font' \) \
+            -delete 2>/dev/null || {
+                for _luar_file in "$_luar_fonts"/*; do
+                    [ -f "$_luar_file" ] || continue
+                    case "$_luar_file" in *.ttf|*.TTF|*.otf|*.OTF|*.ttc|*.TTC|*.font) rm -f "$_luar_file" ;; esac
+                done
+            }
+        rm -rf "$_luar_fonts/.luoshu-font-store" 2>/dev/null || true
+    done
+}
+
+_luar_clear_generated_xml() {
+    _luar_module_dir="$1"
+    for _luar_partition in $(_luar_partitions); do
+        _luar_etc="$_luar_module_dir/$_luar_partition/etc"
+        [ -d "$_luar_etc" ] || continue
+        rm -f "$_luar_etc/.luoshu-data-fonts-config.xml" 2>/dev/null || true
+        for _luar_xml in "$_luar_etc"/*.xml; do
+            [ -f "$_luar_xml" ] || continue
+            if grep -q 'LuoShuSlot-\|LuoShuAutoMix\|luoshu-slot' "$_luar_xml" 2>/dev/null; then
+                rm -f "$_luar_xml" 2>/dev/null || true
+            fi
+        done
+    done
+}
+
+luoshu_activation_rollback_pending() {
+    _luar_module_dir="$(_luar_module)"
+    [ -s "$_luar_module_dir/config/font-activation-rollback.conf" ]
+}
+
+luoshu_activation_rollback_apply() {
+    _luar_module_dir="$(_luar_module)"
+    _luar_flag="$_luar_module_dir/config/font-activation-rollback.conf"
+    [ -s "$_luar_flag" ] || return 2
+    _luar_reason=$(sed -n 's/^reason=//p' "$_luar_flag" 2>/dev/null | head -n1 | tr -d '\r\n')
+    _luar_font=$(sed -n 's/^font=//p' "$_luar_flag" 2>/dev/null | head -n1 | tr -d '\r\n')
+    [ -n "$_luar_reason" ] || _luar_reason=hard-activation-failure
+    [ -n "$_luar_font" ] || _luar_font=unknown
+
+    [ -f "$_luar_module_dir/common/device_font_payload_runtime.sh" ] && \
+        . "$_luar_module_dir/common/device_font_payload_runtime.sh"
+    type device_font_payload_clear >/dev/null 2>&1 && device_font_payload_clear >/dev/null 2>&1 || true
+
+    [ -f "$_luar_module_dir/common/font_config_runtime.sh" ] && \
+        . "$_luar_module_dir/common/font_config_runtime.sh"
+    type font_config_disable >/dev/null 2>&1 && font_config_disable >/dev/null 2>&1 || true
+
+    _luar_clear_partition_fonts "$_luar_module_dir"
+    _luar_clear_generated_xml "$_luar_module_dir"
+
+    if [ -f "$_luar_module_dir/common/font_provider_cache.sh" ]; then
+        . "$_luar_module_dir/common/font_provider_cache.sh"
+        type luoshu_provider_cache_restore >/dev/null 2>&1 && \
+            luoshu_provider_cache_restore >/dev/null 2>&1 || true
+    fi
+
+    mkdir -p "$_luar_module_dir/config" "$_luar_module_dir/logs" 2>/dev/null || true
+    printf 'default\n' > "$_luar_module_dir/config/active_font.conf" 2>/dev/null || return 1
+    rm -f \
+        "$_luar_module_dir/config/font_mix.conf" \
+        "$_luar_module_dir/config/axes_mix.conf" \
+        "$_luar_module_dir/config/text_reboot_required.conf" \
+        "$_luar_module_dir/config/font-payload-schema.conf" \
+        "$_luar_module_dir/config/font-payload-manifest.conf" \
+        "$_luar_module_dir/config/font-payload-boot.conf" \
+        "$_luar_module_dir/config/self-mount.conf" \
+        "$_luar_module_dir/config/self-mount-required.conf" \
+        "$_luar_module_dir/config/device-font-engine.conf" \
+        "$_luar_module_dir/config/device-font-installed.conf" \
+        "$_luar_module_dir/config/device-font-dynamic-mount.conf" \
+        "$_luar_module_dir/config/device-font-load-verification.conf" \
+        "$_luar_module_dir/config/device-font-load-verification.json" \
+        "$_luar_module_dir/config/device-font-manager-dump.txt" \
+        "$_luar_module_dir/config/device-font-mount-evidence.txt" 2>/dev/null || true
+
+    {
+        printf 'state=restored-default\n'
+        printf 'font=%s\n' "$_luar_font"
+        printf 'reason=%s\n' "$_luar_reason"
+        printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
+    } > "$_luar_module_dir/config/font-activation-rollback-last.conf" 2>/dev/null || true
+    rm -f "$_luar_flag" 2>/dev/null || true
+    chmod 0644 "$_luar_module_dir/config/active_font.conf" \
+        "$_luar_module_dir/config/font-activation-rollback-last.conf" 2>/dev/null || true
+    printf '[%s] [ACTIVATION-ROLLBACK] restored default font=%s reason=%s\n' \
+        "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" "$_luar_font" "$_luar_reason" \
+        >> "$_luar_module_dir/logs/fontswitch.log" 2>/dev/null || true
+    return 0
+}
+
+if [ "${0##*/}" = font_activation_rollback.sh ]; then
+    case "${1:-apply}" in
+        pending) luoshu_activation_rollback_pending ;;
+        apply) luoshu_activation_rollback_apply ;;
+        *) printf 'usage: %s {pending|apply}\n' "$0" >&2; exit 2 ;;
+    esac
+fi

--- a/common/font_activation_rollback.sh
+++ b/common/font_activation_rollback.sh
@@ -95,7 +95,8 @@ luoshu_activation_rollback_apply() {
         "$_luar_module_dir/config/device-font-load-verification.conf" \
         "$_luar_module_dir/config/device-font-load-verification.json" \
         "$_luar_module_dir/config/device-font-manager-dump.txt" \
-        "$_luar_module_dir/config/device-font-mount-evidence.txt" 2>/dev/null || true
+        "$_luar_module_dir/config/device-font-mount-evidence.txt" \
+        "$_luar_module_dir/config/device-font-render-evidence.json" 2>/dev/null || true
 
     {
         printf 'state=restored-default\n'

--- a/common/font_coverage.py
+++ b/common/font_coverage.py
@@ -1,76 +1,132 @@
 #!/usr/bin/env python3
-"""Read-only glyph coverage gate for fonts used as a global Android face."""
+"""Read-only glyph coverage gate for fonts used as a global Android face.
+
+A global replacement is accepted only when one concrete face is a complete text
+face.  Merely finding a few CJK codepoints in a collection is not enough: Latin,
+digits, common punctuation and a representative CJK set must resolve to real,
+diverse glyph names in the same face.
+"""
 
 from __future__ import annotations
 
 import argparse
 import json
 from pathlib import Path
+from typing import Any
 
 from fontTools.ttLib import TTCollection, TTFont
 
-
-CJK = tuple(map(ord, "中文字体系统默认汉字国家的一是"))
+CJK = tuple(map(ord, "一丁七万三上下不与中为主人了二于五人今从他会但你作使入全国其分到前力十又只可同后和在地大天好学家小年心我日时有来民生的看种行要见言这"))
 LATIN = tuple(map(ord, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"))
 DIGITS = tuple(map(ord, "0123456789"))
-PUNCTUATION = tuple(map(ord, ".,!?-:;()[]/+'\""))
+PUNCTUATION = tuple(map(ord, ".,!?-:;()[]/+'\"，。！？：；（）【】《》、"))
 
 
-def load_cmaps(path: Path) -> list[set[int]]:
+def is_collection(path: Path) -> bool:
     with path.open("rb") as stream:
-        magic = stream.read(4)
-    if magic == b"ttcf":
-        collection = TTCollection(str(path), lazy=True)
-        try:
-            return [set((font.getBestCmap() or {}).keys()) for font in collection.fonts]
-        finally:
-            collection.close()
-    font = TTFont(str(path), lazy=True, recalcTimestamp=False)
+        return stream.read(4) == b"ttcf"
+
+
+def face_count(path: Path) -> int:
+    if not is_collection(path):
+        return 1
+    collection = TTCollection(str(path), lazy=True)
     try:
-        return [set((font.getBestCmap() or {}).keys())]
+        return len(collection.fonts)
+    finally:
+        collection.close()
+
+
+def open_face(path: Path, index: int) -> TTFont:
+    kwargs: dict[str, Any] = {"lazy": True, "recalcTimestamp": False}
+    if is_collection(path):
+        kwargs["fontNumber"] = index
+    return TTFont(str(path), **kwargs)
+
+
+def group(font: TTFont, probes: tuple[int, ...]) -> dict[str, object]:
+    cmap = font.getBestCmap() or {}
+    glyph_order = set(font.getGlyphOrder())
+    missing: list[int] = []
+    names: set[str] = set()
+    for codepoint in probes:
+        name = cmap.get(codepoint)
+        if not name or name == ".notdef" or name not in glyph_order:
+            missing.append(codepoint)
+            continue
+        names.add(name)
+    hits = len(probes) - len(missing)
+    return {
+        "hits": hits,
+        "total": len(probes),
+        "ratio": hits / len(probes) if probes else 1.0,
+        "uniqueGlyphs": len(names),
+        "missing": missing,
+    }
+
+
+def inspect_face(path: Path, index: int) -> dict[str, object]:
+    font = open_face(path, index)
+    try:
+        groups = {
+            "cjk": group(font, CJK),
+            "latin": group(font, LATIN),
+            "digits": group(font, DIGITS),
+            "punctuation": group(font, PUNCTUATION),
+        }
+        cjk = groups["cjk"]
+        safe = (
+            float(cjk["ratio"]) >= 0.95
+            and int(cjk["uniqueGlyphs"]) >= max(12, int(int(cjk["hits"]) * 0.75))
+            and float(groups["latin"]["ratio"]) == 1.0
+            and float(groups["digits"]["ratio"]) == 1.0
+            and float(groups["punctuation"]["ratio"]) >= 0.85
+        )
+        missing: list[int] = []
+        for values in groups.values():
+            missing.extend(values["missing"])  # type: ignore[arg-type]
+        percentages = {
+            name: round(float(values["ratio"]) * 100)
+            for name, values in groups.items()
+        }
+        return {
+            "safe": safe,
+            "face": index if is_collection(path) else -1,
+            "coverage": percentages,
+            "uniqueCjkGlyphs": int(cjk["uniqueGlyphs"]),
+            "missing": [f"U+{codepoint:04X}" for codepoint in missing[:24]],
+            "score": sum(float(values["ratio"]) for values in groups.values()),
+        }
     finally:
         font.close()
 
 
-def ratio(cmap: set[int], probes: tuple[int, ...]) -> tuple[int, int, float]:
-    hits = sum(codepoint in cmap for codepoint in probes)
-    total = len(probes)
-    return hits, total, hits / total if total else 1.0
-
-
 def inspect(path: Path) -> dict[str, object]:
-    faces = load_cmaps(path)
-    candidates = []
-    for index, cmap in enumerate(faces):
-        groups = {
-            "cjk": ratio(cmap, CJK),
-            "latin": ratio(cmap, LATIN),
-            "digits": ratio(cmap, DIGITS),
-            "punctuation": ratio(cmap, PUNCTUATION),
-        }
-        score = sum(value[2] for value in groups.values())
-        candidates.append((score, index, groups))
-    _score, face, groups = max(candidates, default=(0.0, -1, {}))
-    safe = bool(groups) and (
-        groups["cjk"][2] >= 0.80
-        and groups["latin"][2] >= 0.95
-        and groups["digits"][2] == 1.0
-        and groups["punctuation"][2] >= 0.75
-    )
-    percentages = {name: round(values[2] * 100) for name, values in groups.items()}
-    return {
-        "safe": safe,
-        "face": face,
-        "faces": len(faces),
-        "coverage": percentages,
-        "message": (
-            "字形覆盖通过"
-            if safe
-            else "字形覆盖不足：中文 {cjk}%、英文 {latin}%、数字 {digits}%、标点 {punctuation}%".format(
-                **percentages
-            )
+    if not path.is_file() or path.stat().st_size < 4096:
+        return {"safe": False, "message": "字体文件不存在或文件过小"}
+    candidates = [inspect_face(path, index) for index in range(face_count(path))]
+    best = max(
+        candidates,
+        key=lambda item: (
+            1 if item["safe"] else 0,
+            float(item["score"]),
         ),
+        default=None,
+    )
+    if best is None:
+        return {"safe": False, "message": "字体中没有可读取的字体面"}
+    result = {
+        key: value for key, value in best.items() if key != "score"
     }
+    result["faces"] = len(candidates)
+    result["message"] = (
+        "字形覆盖通过"
+        if best["safe"]
+        else "字形覆盖不足：中文 {cjk}%、英文 {latin}%、数字 {digits}%、标点 {punctuation}%；请改用复合字体或完整 CJK 字体".format(
+            **best["coverage"]  # type: ignore[arg-type]
+        )
+    )
+    return result
 
 
 def main() -> int:

--- a/common/font_instance.py
+++ b/common/font_instance.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Materialize a font source at concrete variation-axis values for LuoShu v2.0.0.
+"""Materialize a font source at concrete variation-axis values for LuoShu.
 
 Variable fonts are pinned to every requested fvar axis. TTC/OTC collections are
-reduced to the face whose coverage and weight best match the requested role.
-Plain static TTF/OTF files may be copied by the shell wrapper without invoking
-this helper.
+reduced to one deterministic face whose coverage and weight satisfy the selected
+role.  The CJK face is the complete composite base, so it must also contain Latin,
+digits and common punctuation; a collection containing those scripts in separate
+faces is rejected instead of silently choosing an incomplete face.
 """
 from __future__ import annotations
 
@@ -14,15 +15,17 @@ import os
 import re
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from fontTools.ttLib import TTCollection, TTFont
 from fontTools.varLib.instancer import instantiateVariableFont
 
 from font_metrics_normalize import normalize_font_metrics
 
-CJK_PROBES = tuple(map(ord, "中文字体系统默认洛书汉字国一的。"))
+CJK_PROBES = tuple(map(ord, "一丁七万三上下不与中为主人了二于五人今从他会但你作使入全国其分到前力十又只可同后和在地大天好学家小年心我日时有来民生的看种行要见言这"))
 LATIN_PROBES = tuple(map(ord, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"))
 DIGIT_PROBES = tuple(map(ord, "0123456789"))
+PUNCTUATION_PROBES = tuple(map(ord, ".,!?-:;()[]/+'\"，。！？：；（）【】《》、"))
 AXIS_TAG_RE = re.compile(r"^[ -~]{1,4}$")
 
 
@@ -35,6 +38,26 @@ def is_collection(path: Path) -> bool:
         return stream.read(4) == b"ttcf"
 
 
+def collection_count(path: Path) -> int:
+    if not is_collection(path):
+        return 1
+    collection = TTCollection(str(path), lazy=True)
+    try:
+        return len(collection.fonts)
+    finally:
+        collection.close()
+
+
+def open_face(path: Path, index: int, *, lazy: bool = True) -> TTFont:
+    kwargs: dict[str, Any] = {
+        "lazy": lazy,
+        "recalcTimestamp": False,
+    }
+    if is_collection(path):
+        kwargs["fontNumber"] = index
+    return TTFont(str(path), **kwargs)
+
+
 def font_weight(font: TTFont) -> int:
     try:
         return int(font["OS/2"].usWeightClass)
@@ -42,33 +65,79 @@ def font_weight(font: TTFont) -> int:
         return 400
 
 
-def face_score(font: TTFont, role: str, weight: int) -> tuple[int, int]:
+def usable(font: TTFont, probes: tuple[int, ...]) -> tuple[int, set[str]]:
     cmap = font.getBestCmap() or {}
-    probes = CJK_PROBES if role == "cjk" else LATIN_PROBES if role == "latin" else DIGIT_PROBES
-    hits = sum(1 for codepoint in probes if codepoint in cmap)
-    return hits, -abs(font_weight(font) - weight)
+    glyph_order = set(font.getGlyphOrder())
+    names: set[str] = set()
+    hits = 0
+    for codepoint in probes:
+        name = cmap.get(codepoint)
+        if not name or name == ".notdef" or name not in glyph_order:
+            continue
+        hits += 1
+        names.add(name)
+    return hits, names
+
+
+def coverage_profile(font: TTFont) -> dict[str, tuple[int, int, int]]:
+    result: dict[str, tuple[int, int, int]] = {}
+    for name, probes in (
+        ("cjk", CJK_PROBES),
+        ("latin", LATIN_PROBES),
+        ("digits", DIGIT_PROBES),
+        ("punctuation", PUNCTUATION_PROBES),
+    ):
+        hits, glyphs = usable(font, probes)
+        result[name] = hits, len(probes), len(glyphs)
+    return result
+
+
+def fraction(value: tuple[int, int, int]) -> float:
+    return value[0] / value[1] if value[1] else 1.0
+
+
+def face_valid(profile: dict[str, tuple[int, int, int]], role: str) -> bool:
+    if role == "cjk":
+        cjk_hits, _cjk_total, cjk_unique = profile["cjk"]
+        return (
+            fraction(profile["cjk"]) >= 0.95
+            and cjk_unique >= max(12, int(cjk_hits * 0.75))
+            and fraction(profile["latin"]) == 1.0
+            and fraction(profile["digits"]) == 1.0
+            and fraction(profile["punctuation"]) >= 0.85
+        )
+    if role == "latin":
+        return fraction(profile["latin"]) == 1.0
+    return fraction(profile["digits"]) == 1.0
+
+
+def face_score(font: TTFont, role: str, weight: int) -> tuple[int, float, int, int]:
+    profile = coverage_profile(font)
+    if role == "cjk":
+        selected = ("cjk", "latin", "digits", "punctuation")
+    elif role == "latin":
+        selected = ("latin",)
+    else:
+        selected = ("digits",)
+    score = sum(fraction(profile[name]) for name in selected)
+    hits = sum(profile[name][0] for name in selected)
+    return 1 if face_valid(profile, role) else 0, score, hits, -abs(font_weight(font) - weight)
 
 
 def pick_face(path: Path, role: str, weight: int) -> int:
-    if not is_collection(path):
-        return -1
-    collection = TTCollection(str(path), lazy=True)
-    try:
-        count = len(collection.fonts)
-    finally:
-        collection.close()
-    best: tuple[tuple[int, int], int] | None = None
-    for index in range(count):
-        font = TTFont(str(path), fontNumber=index, lazy=True, recalcTimestamp=False)
+    best: tuple[tuple[int, float, int, int], int] | None = None
+    for index in range(collection_count(path)):
+        font = open_face(path, index, lazy=True)
         try:
             score = face_score(font, role, weight)
         finally:
             font.close()
         if best is None or score > best[0]:
             best = score, index
-    if best is None or best[0][0] == 0:
-        raise InstanceError(f"无法从 {path.name} 中找到适合的{role}字体面")
-    return best[1]
+    if best is None or best[0][0] != 1:
+        role_name = {"cjk": "中文基底", "latin": "英文", "digit": "数字"}[role]
+        raise InstanceError(f"无法从 {path.name} 中找到覆盖完整的{role_name}字体面")
+    return best[1] if is_collection(path) else -1
 
 
 def clamp_weight(value: float | int) -> int:
@@ -121,6 +190,12 @@ def materialize(source: Path, output: Path, role: str, requested_weight: int, re
         elif requested_axes:
             ignored_axes = sorted(tag for tag in requested_axes if tag != "wght")
 
+        # Recheck after variable-font instancing.  A malformed variation table must
+        # never turn a previously valid face into an incomplete output unnoticed.
+        post_profile = coverage_profile(font)
+        if not face_valid(post_profile, role):
+            raise InstanceError("可变轴实例化后的字体面缺少该角色所需字形")
+
         final_weight = clamp_weight(location.get("wght", requested_weight))
         if "OS/2" in font:
             font["OS/2"].usWeightClass = final_weight
@@ -150,6 +225,10 @@ def materialize(source: Path, output: Path, role: str, requested_weight: int, re
             "variable": variable,
             "location": location,
             "ignoredAxes": ignored_axes,
+            "coverage": {
+                name: round(fraction(values) * 100)
+                for name, values in post_profile.items()
+            },
             "metrics": metrics,
             "size": output.stat().st_size,
         }

--- a/common/font_role_check.py
+++ b/common/font_role_check.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
-"""Fast role coverage gate used before a LuoShu composite task is queued."""
+"""Strict role coverage gate used before a LuoShu composite task is queued.
+
+The selected CJK face becomes the complete base of the generated composite.  A
+font collection is therefore accepted only when one concrete face contains a
+usable CJK base together with Latin, digits and common punctuation.  This keeps
+an English-only face, a symbol face or a .notdef-heavy face from reaching the
+Android font renderer.
+"""
 from __future__ import annotations
 
 import argparse
 import json
 from pathlib import Path
+from typing import Any
 
 from fontTools.ttLib import TTCollection, TTFont
 
-CJK = tuple(map(ord, "中文字体系统默认洛书汉字"))
+CJK = tuple(map(ord, "一丁七万三上下不与中为主人了二于五人今从他会但你作使入全国其分到前力十又只可同后和在地大天好学家小年心我日时有来民生的看种行要见言这"))
 LATIN = tuple(map(ord, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"))
 DIGITS = tuple(map(ord, "0123456789"))
+PUNCTUATION = tuple(map(ord, ".,!?-:;()[]/+'\"，。！？：；（）【】《》、"))
 
 
 class RoleCheckError(RuntimeError):
@@ -22,7 +31,7 @@ def is_collection(path: Path) -> bool:
         return stream.read(4) == b"ttcf"
 
 
-def faces(path: Path) -> range:
+def face_indexes(path: Path) -> range:
     if not is_collection(path):
         return range(1)
     collection = TTCollection(str(path), lazy=True)
@@ -32,32 +41,88 @@ def faces(path: Path) -> range:
         collection.close()
 
 
-def required(role: str) -> tuple[int, ...]:
-    # The CJK source is the complete cmap base. It must provide the slots that
-    # are mandatory for replacement, but punctuation replacement is optional
-    # in composite_font.py and must not reject otherwise usable fonts.
-    if role == "cjk":
-        return CJK + LATIN + DIGITS
-    if role == "latin":
-        return LATIN
-    return DIGITS
+def open_face(path: Path, index: int) -> TTFont:
+    kwargs: dict[str, Any] = {"lazy": True, "recalcTimestamp": False}
+    if is_collection(path):
+        kwargs["fontNumber"] = index
+    return TTFont(str(path), **kwargs)
+
+
+def usable_glyphs(font: TTFont, probes: tuple[int, ...]) -> tuple[list[int], list[int], set[str]]:
+    cmap = font.getBestCmap() or {}
+    glyph_order = set(font.getGlyphOrder())
+    present: list[int] = []
+    missing: list[int] = []
+    names: set[str] = set()
+    for codepoint in probes:
+        name = cmap.get(codepoint)
+        if not name or name == ".notdef" or name not in glyph_order:
+            missing.append(codepoint)
+            continue
+        present.append(codepoint)
+        names.add(name)
+    return present, missing, names
+
+
+def ratio(present: list[int], probes: tuple[int, ...]) -> float:
+    return len(present) / len(probes) if probes else 1.0
 
 
 def inspect_face(path: Path, index: int, role: str) -> dict[str, object]:
-    kwargs: dict[str, object] = {"lazy": True, "recalcTimestamp": False}
-    if is_collection(path):
-        kwargs["fontNumber"] = index
-    font = TTFont(str(path), **kwargs)
+    font = open_face(path, index)
     try:
-        cmap = font.getBestCmap() or {}
-        probes = required(role)
-        missing = [codepoint for codepoint in probes if codepoint not in cmap]
+        groups: dict[str, dict[str, object]] = {}
+        probe_groups = {
+            "cjk": CJK,
+            "latin": LATIN,
+            "digits": DIGITS,
+            "punctuation": PUNCTUATION,
+        }
+        for name, probes in probe_groups.items():
+            present, missing, glyph_names = usable_glyphs(font, probes)
+            groups[name] = {
+                "hits": len(present),
+                "total": len(probes),
+                "ratio": ratio(present, probes),
+                "uniqueGlyphs": len(glyph_names),
+                "missing": missing,
+            }
+
+        if role == "cjk":
+            cjk = groups["cjk"]
+            valid = (
+                float(cjk["ratio"]) >= 0.95
+                and int(cjk["uniqueGlyphs"]) >= max(12, int(int(cjk["hits"]) * 0.75))
+                and float(groups["latin"]["ratio"]) == 1.0
+                and float(groups["digits"]["ratio"]) == 1.0
+                and float(groups["punctuation"]["ratio"]) >= 0.85
+            )
+            selected = ("cjk", "latin", "digits", "punctuation")
+        elif role == "latin":
+            valid = float(groups["latin"]["ratio"]) == 1.0
+            selected = ("latin",)
+        else:
+            valid = float(groups["digits"]["ratio"]) == 1.0
+            selected = ("digits",)
+
+        missing_codes: list[int] = []
+        for name in selected:
+            missing_codes.extend(groups[name]["missing"])  # type: ignore[arg-type]
+        present_count = sum(int(groups[name]["hits"]) for name in selected)
+        required_count = sum(int(groups[name]["total"]) for name in selected)
+        score = sum(float(groups[name]["ratio"]) for name in selected)
         return {
             "face": index if is_collection(path) else -1,
-            "required": len(probes),
-            "present": len(probes) - len(missing),
-            "missing": [f"U+{codepoint:04X}" for codepoint in missing[:16]],
-            "valid": not missing,
+            "required": required_count,
+            "present": present_count,
+            "missing": [f"U+{codepoint:04X}" for codepoint in missing_codes[:24]],
+            "coverage": {
+                name: round(float(values["ratio"]) * 100)
+                for name, values in groups.items()
+            },
+            "uniqueCjkGlyphs": int(groups["cjk"]["uniqueGlyphs"]),
+            "score": score,
+            "valid": valid,
         }
     finally:
         font.close()
@@ -66,15 +131,29 @@ def inspect_face(path: Path, index: int, role: str) -> dict[str, object]:
 def check(path: Path, role: str) -> dict[str, object]:
     if not path.is_file() or path.stat().st_size < 4096:
         raise RoleCheckError("字体文件不存在或文件过小")
-    results = [inspect_face(path, index, role) for index in faces(path)]
-    best = max(results, key=lambda item: int(item["present"]), default=None)
+    results = [inspect_face(path, index, role) for index in face_indexes(path)]
+    best = max(
+        results,
+        key=lambda item: (
+            1 if item["valid"] else 0,
+            float(item["score"]),
+            int(item["present"]),
+        ),
+        default=None,
+    )
     if best is None:
         raise RoleCheckError("字体中没有可读取的字体面")
     return {
         "status": "ok" if best["valid"] else "error",
         "role": role,
         "path": str(path),
-        **best,
+        "faces": len(results),
+        **{key: value for key, value in best.items() if key != "score"},
+        "message": (
+            "字形角色检查通过"
+            if best["valid"]
+            else "没有任何单一字体面满足该角色所需的完整字形覆盖"
+        ),
     }
 
 

--- a/common/font_role_check.py
+++ b/common/font_role_check.py
@@ -22,6 +22,23 @@ DIGITS = tuple(map(ord, "0123456789"))
 PUNCTUATION = tuple(map(ord, ".,!?-:;()[]/+'\"，。！？：；（）【】《》、"))
 
 
+def required(role: str) -> tuple[int, ...]:
+    """Return the hard-required codepoints for a role.
+
+    Punctuation remains a scored compatibility group instead of a hard list so
+    decorative fonts are not rejected for one optional symbol.  CJK fonts must
+    still carry complete Latin and digit coverage because they become the base
+    face of the generated Android family.
+    """
+    if role == "cjk":
+        return CJK + LATIN + DIGITS
+    if role == "latin":
+        return LATIN
+    if role == "digit":
+        return DIGITS
+    raise ValueError(f"unsupported role: {role}")
+
+
 class RoleCheckError(RuntimeError):
     pass
 

--- a/common/font_runtime_hardening.sh
+++ b/common/font_runtime_hardening.sh
@@ -1,0 +1,120 @@
+#!/system/bin/sh
+# LuoShu runtime mapping hardening.
+# Loaded after rom_adapters/coloros_global/hyperos_global so the final dispatcher
+# always combines ROM-specific physical slots with the device's discovered slots.
+set +e
+
+_luoshu_inventory_anchor_for_weight() {
+    _lria_weight="$1"
+    _lria_module="${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"
+    _lria_store="$_lria_module/system/fonts/.luoshu-font-store"
+    case "$_lria_weight" in
+        100) _lria_role=thin ;;
+        200) _lria_role=extralight ;;
+        300|350) _lria_role=light ;;
+        500) _lria_role=medium ;;
+        600) _lria_role=semibold ;;
+        700) _lria_role=bold ;;
+        800) _lria_role=extrabold ;;
+        900) _lria_role=black ;;
+        *) _lria_role=regular; _lria_weight=400 ;;
+    esac
+    for _lria_candidate in \
+        "$_lria_store/compact-wght-${_lria_weight}.font" \
+        "$_lria_store/${_lria_role}.font" \
+        "$_lria_store/compact-regular.font" \
+        "$_lria_store/regular.font"; do
+        [ -s "$_lria_candidate" ] && {
+            printf '%s\n' "$_lria_candidate"
+            return 0
+        }
+    done
+    return 1
+}
+
+_luoshu_inventory_augment() {
+    type _device_font_inventory_entries >/dev/null 2>&1 || return 2
+    type _device_font_inventory_target >/dev/null 2>&1 || return 2
+    type _font_alias >/dev/null 2>&1 || return 2
+    _lria_entries=$(_device_font_inventory_entries) || return 2
+    [ -n "$_lria_entries" ] || return 2
+    _lria_tab=$(printf '\t')
+    _lria_count=0
+    _lria_bad=0
+    while IFS="$_lria_tab" read -r _lria_logical _lria_name _lria_partition _lria_format _lria_weight _lria_style _lria_source; do
+        [ -n "$_lria_logical" ] && [ -n "$_lria_name" ] || continue
+        _lria_target=$(_device_font_inventory_target "$_lria_logical") || continue
+        case "$_lria_target" in
+            "${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}"/*/fonts/*) ;;
+            *) continue ;;
+        esac
+        [ -f "$_lria_target" ] && {
+            _lria_count=$((_lria_count + 1))
+            continue
+        }
+        _lria_anchor=$(_luoshu_inventory_anchor_for_weight "${_lria_weight:-400}") || {
+            _lria_bad=$((_lria_bad + 1))
+            continue
+        }
+        mkdir -p "${_lria_target%/*}" 2>/dev/null || {
+            _lria_bad=$((_lria_bad + 1))
+            continue
+        }
+        if _font_alias "$_lria_anchor" "$_lria_target"; then
+            _lria_count=$((_lria_count + 1))
+        else
+            _lria_bad=$((_lria_bad + 1))
+        fi
+    done <<EOF_LUOSHU_RUNTIME_INVENTORY
+$_lria_entries
+EOF_LUOSHU_RUNTIME_INVENTORY
+    if [ "$_lria_count" -gt 0 ]; then
+        LUOSHU_INVENTORY_TARGETS_MAPPED=1
+        export LUOSHU_INVENTORY_TARGETS_MAPPED
+        type _log_step >/dev/null 2>&1 && \
+            _log_step "  已补齐 $_lria_count 个本机原厂字体槽位${_lria_bad:+，异常=$_lria_bad}"
+        return 0
+    fi
+    return 2
+}
+
+# Final dispatcher.  The old inventory-first path could return after mapping a
+# few XML-visible shells and skip MiSans/OPlus physical slots entirely.  ROM
+# mapping now runs first; inventory only adds paths discovered on this device.
+apply_font_by_rom() {
+    _lrh_src="$1"
+    _lrh_dest="$2"
+    _lrh_mode="${3:-full}"
+    _lrh_family="${4:-}"
+    [ -n "$_lrh_family" ] || _lrh_family=$(detect_font_family "$(basename "$_lrh_src")")
+
+    _lrh_base_rc=1
+    if [ "${IS_HYPEROS:-false}" = true ]; then
+        copy_as_hyperos "$_lrh_src" "$_lrh_dest" "$_lrh_mode" "$_lrh_family"
+        _lrh_base_rc=$?
+    elif [ "${IS_COLOROS:-false}" = true ]; then
+        copy_as_coloros "$_lrh_src" "$_lrh_dest" "$_lrh_mode" "$_lrh_family"
+        _lrh_base_rc=$?
+    else
+        copy_as_generic "$_lrh_src" "$_lrh_dest" "$_lrh_mode"
+        _lrh_base_rc=$?
+    fi
+
+    _luoshu_inventory_augment
+    _lrh_inventory_rc=$?
+    if [ "$_lrh_base_rc" -ne 0 ] && [ "$_lrh_inventory_rc" -ne 0 ]; then
+        type _log_step >/dev/null 2>&1 && \
+            _log_step '  ROM 物理槽与设备清单均未生成可用字体目标'
+        return 1
+    fi
+
+    # HyperOS uses hidden/direct physical slots and intentionally keeps the ROM
+    # XML metric shell.  Other ROMs may safely add the generated XML view.
+    if [ "${IS_HYPEROS:-false}" != true ] && \
+       type font_config_enable_for_payload >/dev/null 2>&1; then
+        font_config_enable_for_payload "$_lrh_family" || \
+            type _log_step >/dev/null 2>&1 && \
+            _log_step '  设备没有可安全启用的字体 XML，继续使用文件槽映射'
+    fi
+    return 0
+}

--- a/common/font_runtime_hardening.sh
+++ b/common/font_runtime_hardening.sh
@@ -71,8 +71,13 @@ EOF_LUOSHU_RUNTIME_INVENTORY
     if [ "$_lria_count" -gt 0 ]; then
         LUOSHU_INVENTORY_TARGETS_MAPPED=1
         export LUOSHU_INVENTORY_TARGETS_MAPPED
-        type _log_step >/dev/null 2>&1 && \
-            _log_step "  已补齐 $_lria_count 个本机原厂字体槽位${_lria_bad:+，异常=$_lria_bad}"
+        if type _log_step >/dev/null 2>&1; then
+            if [ "$_lria_bad" -gt 0 ]; then
+                _log_step "  已补齐 $_lria_count 个本机原厂字体槽位，$_lria_bad 个槽位跳过"
+            else
+                _log_step "  已补齐 $_lria_count 个本机原厂字体槽位"
+            fi
+        fi
         return 0
     fi
     return 2
@@ -112,9 +117,10 @@ apply_font_by_rom() {
     # XML metric shell.  Other ROMs may safely add the generated XML view.
     if [ "${IS_HYPEROS:-false}" != true ] && \
        type font_config_enable_for_payload >/dev/null 2>&1; then
-        font_config_enable_for_payload "$_lrh_family" || \
+        if ! font_config_enable_for_payload "$_lrh_family"; then
             type _log_step >/dev/null 2>&1 && \
-            _log_step '  设备没有可安全启用的字体 XML，继续使用文件槽映射'
+                _log_step '  设备没有可安全启用的字体 XML，继续使用文件槽映射'
+        fi
     fi
     return 0
 }

--- a/common/module_status.sh
+++ b/common/module_status.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# 洛书 v2.0.0：在 Root 管理器中显示简洁的当前字体状态。
+# 洛书：在 Root 管理器中显示简洁且不夸大的当前字体状态。
 set +e
 
 MODDIR="${MODDIR:-}"
@@ -38,15 +38,19 @@ if [ "$ACTIVE" != default ]; then
     VERIFY_MODE=$(sed -n 's/^mode=//p' "$VERIFY" 2>/dev/null | head -n1)
     VERIFY_ACTIVE=$(sed -n 's/^activeFont=//p' "$VERIFY" 2>/dev/null | head -n1)
     MOUNT_STATE=$(sed -n 's/^state=//p' "$MODDIR/config/self-mount.conf" 2>/dev/null | head -n1)
-    if [ -f "$MODDIR/config/text_reboot_required.conf" ]; then
+    if [ -f "$MODDIR/config/font-activation-rollback.conf" ]; then
+        EFFECTIVE_DISPLAY="系统默认字体（$DISPLAY 检测异常，等待重启回滚）"
+    elif [ -f "$MODDIR/config/text_reboot_required.conf" ]; then
         EFFECTIVE_DISPLAY="已配置：$DISPLAY（等待重启）"
     elif [ "$MOUNT_STATE" = failed ] || [ "$VERIFY_STATE" = failed ]; then
         EFFECTIVE_DISPLAY="系统默认字体（$DISPLAY 未生效）"
     elif [ "$VERIFY_ACTIVE" = "$ACTIVE" ] && [ "$VERIFY_STATE" = verified ]; then
         case "$VERIFY_MODE" in
-            aligned|mount-verified) EFFECTIVE_DISPLAY="$DISPLAY" ;;
-            *) EFFECTIVE_DISPLAY="已配置：$DISPLAY（待验证）" ;;
+            aligned|render-verified|font-manager-verified) EFFECTIVE_DISPLAY="$DISPLAY" ;;
+            *) EFFECTIVE_DISPLAY="已配置：$DISPLAY（仅挂载，未确认系统选用）" ;;
         esac
+    elif [ "$VERIFY_MODE" = mount-only ]; then
+        EFFECTIVE_DISPLAY="已配置：$DISPLAY（仅挂载，未确认系统选用）"
     else
         EFFECTIVE_DISPLAY="已配置：$DISPLAY（待验证）"
     fi

--- a/common/mount_compat.sh
+++ b/common/mount_compat.sh
@@ -15,6 +15,7 @@ _lmcl_fallback="$_lmcl_module/common/mount_self_fallback.sh"
 _lmcl_policy="$_lmcl_module/common/mount_compat_policy.sh"
 _lmcl_private_policy="$_lmcl_module/common/private_mount_policy.sh"
 _lmcl_atomic="$_lmcl_module/common/mount_self_atomic.sh"
+_lmcl_hardening="$_lmcl_module/common/font_runtime_hardening.sh"
 
 # When invoked as a CLI, source the base in a child shell whose $0 is not
 # mount_compat.sh so the legacy CLI footer cannot run before the overrides.
@@ -28,7 +29,8 @@ if [ "${0##*/}" = mount_compat.sh ]; then
         [ ! -f "$3" ] || . "$3"
         [ ! -f "$4" ] || . "$4"
         [ ! -f "$5" ] || . "$5"
-        case "$6" in
+        [ ! -f "$6" ] || . "$6"
+        case "$7" in
             status)
                 luoshu_mount_status_json
                 printf "\n"
@@ -39,7 +41,7 @@ if [ "${0##*/}" = mount_compat.sh ]; then
                 printf "warning=%s\n" "$(luoshu_mount_detection_warning)"
                 ;;
             verify)
-                luoshu_mount_verify_active "$7"
+                luoshu_mount_verify_active "$8"
                 ;;
             *)
                 printf "usage: %s {status|detect|verify [font]}\n" "$0" >&2
@@ -47,7 +49,7 @@ if [ "${0##*/}" = mount_compat.sh ]; then
                 ;;
         esac
     ' sh "$_lmcl_base" "$_lmcl_fallback" "$_lmcl_policy" "$_lmcl_private_policy" \
-        "$_lmcl_atomic" "$_lmcl_command" "$_lmcl_argument"
+        "$_lmcl_atomic" "$_lmcl_hardening" "$_lmcl_command" "$_lmcl_argument"
     exit $?
 fi
 
@@ -56,5 +58,6 @@ fi
 [ -f "$_lmcl_policy" ] && . "$_lmcl_policy"
 [ -f "$_lmcl_private_policy" ] && . "$_lmcl_private_policy"
 [ -f "$_lmcl_atomic" ] && . "$_lmcl_atomic"
+[ -f "$_lmcl_hardening" ] && . "$_lmcl_hardening"
 unset _lmcl_module _lmcl_base _lmcl_fallback _lmcl_policy _lmcl_private_policy \
-    _lmcl_atomic _lmcl_command _lmcl_argument
+    _lmcl_atomic _lmcl_hardening _lmcl_command _lmcl_argument

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -11,6 +11,16 @@ _lpf_temp="$MODDIR/.post-fs-data-v227.$$.sh"
 [ -f "$MODDIR/common/private_payload.sh" ] && . "$MODDIR/common/private_payload.sh"
 luoshu_private_mount_module_view "$MODDIR" >/dev/null 2>&1 || true
 
+# A hard failure detected after the previous boot is consumed before any font
+# target is mounted.  This guarantees the next boot starts from the complete ROM
+# font tree instead of attempting to hot-unmount fonts from running processes.
+if [ -f "$MODDIR/common/font_activation_rollback.sh" ]; then
+    . "$MODDIR/common/font_activation_rollback.sh"
+    type luoshu_activation_rollback_pending >/dev/null 2>&1 && \
+       luoshu_activation_rollback_pending && \
+       luoshu_activation_rollback_apply >/dev/null 2>&1 || true
+fi
+
 sed '$d' "$_lpf_base" > "$_lpf_temp" 2>/dev/null || exit 0
 . "$_lpf_temp"
 _lpf_rc=$?

--- a/scripts/device_font_load_verify_test.py
+++ b/scripts/device_font_load_verify_test.py
@@ -82,6 +82,8 @@ def main() -> None:
     assert verified["summary"]["dynamicFamilyHits"] == 1
     assert "android-renderer-confirmed-generated-font" in verified["reasons"]
 
+    # Some OEM FontManager dumps omit or rename dynamic families. A successful
+    # renderer comparison is stronger evidence and must not trigger rollback.
     missing_dynamic = verifier.verify(
         payload,
         overlay,
@@ -91,8 +93,9 @@ def main() -> None:
         "DemoFont",
         {"state": "installed"},
     )
-    assert missing_dynamic["state"] == "failed", missing_dynamic
-    assert "dynamic-family-not-loaded" in missing_dynamic["reasons"]
+    assert missing_dynamic["state"] == "verified", missing_dynamic
+    assert "dynamic-family-unconfirmed" in missing_dynamic["reasons"]
+    assert "android-renderer-confirmed-generated-font" in missing_dynamic["reasons"]
 
     unavailable_dump = verifier.verify(
         payload,
@@ -133,6 +136,29 @@ def main() -> None:
     )
     assert mismatch["state"] == "failed"
     assert "visible-font-hash-mismatch" in mismatch["reasons"]
+
+    # Host-only CI does not ship the module's embedded fontTools. Coverage
+    # inspection becomes unavailable rather than crashing the complete verifier.
+    previous_ttfont = verifier._TTFont
+    verifier._TTFont = None
+    try:
+        coverage_payload = dict(payload)
+        coverage_payload["slots"] = [dict(payload["slots"][0], roles=["global-ui"])]
+        host_result = verifier.verify(
+            coverage_payload,
+            overlay,
+            "Family google-sans-text file=/system/fonts/LuoShuSlot-abc.ttf",
+            mounts,
+            rendered(),
+            "DemoFont",
+            {"state": "installed"},
+        )
+        assert host_result["state"] == "verified", host_result
+        assert host_result["summary"]["coverageProbeUnavailable"] is True
+        assert "runtime-coverage-probe-unavailable" in host_result["reasons"]
+    finally:
+        verifier._TTFont = previous_ttfont
+
     print(json.dumps(verified["summary"], ensure_ascii=False, sort_keys=True))
 
 

--- a/scripts/device_font_load_verify_test.py
+++ b/scripts/device_font_load_verify_test.py
@@ -53,6 +53,19 @@ def fixture() -> tuple[dict, dict, list[dict]]:
     return payload, overlay, mounts
 
 
+def rendered(ratio: float = 1.0) -> dict:
+    comparable = 12
+    return {
+        "status": "ok",
+        "matched": round(comparable * ratio),
+        "comparable": comparable,
+        "ratio": ratio,
+        "missingActual": [],
+        "missingExpected": [],
+        "path": "/system/fonts/LuoShuSlot-abc.ttf",
+    }
+
+
 def main() -> None:
     payload, overlay, mounts = fixture()
     verified = verifier.verify(
@@ -60,18 +73,21 @@ def main() -> None:
         overlay,
         "Family google-sans-text file=/system/fonts/LuoShuSlot-abc.ttf LuoShuSlot-google-sans-text-400",
         mounts,
+        rendered(),
         "DemoFont",
         {"state": "installed", "templateKey": "trusted"},
     )
     assert verified["state"] == "verified", verified
     assert verified["mode"] == "aligned"
     assert verified["summary"]["dynamicFamilyHits"] == 1
+    assert "android-renderer-confirmed-generated-font" in verified["reasons"]
 
     missing_dynamic = verifier.verify(
         payload,
         overlay,
         "file=/system/fonts/LuoShuSlot-abc.ttf",
         mounts,
+        rendered(),
         "DemoFont",
         {"state": "installed"},
     )
@@ -83,14 +99,27 @@ def main() -> None:
         overlay,
         "",
         mounts,
+        {"status": "unavailable", "reason": "luoshu-app-not-installed"},
         "DemoFont",
         {"state": "installed"},
     )
-    assert unavailable_dump["state"] == "verified", unavailable_dump
-    assert unavailable_dump["mode"] == "mount-verified", unavailable_dump
+    assert unavailable_dump["state"] == "unverified", unavailable_dump
+    assert unavailable_dump["mode"] == "mount-only", unavailable_dump
     assert "font-manager-dump-unavailable" in unavailable_dump["reasons"]
     assert "dynamic-family-unconfirmed" in unavailable_dump["reasons"]
-    assert "verified-by-visible-mounts" in unavailable_dump["reasons"]
+    assert "visible-mounts-do-not-prove-font-selection" in unavailable_dump["reasons"]
+
+    renderer_mismatch = verifier.verify(
+        payload,
+        overlay,
+        "Family google-sans-text file=/system/fonts/LuoShuSlot-abc.ttf",
+        mounts,
+        rendered(0.0),
+        "DemoFont",
+        {"state": "installed"},
+    )
+    assert renderer_mismatch["state"] == "failed", renderer_mismatch
+    assert "android-renderer-does-not-match-generated-font" in renderer_mismatch["reasons"]
 
     bad_mounts = [dict(mounts[0], status="mismatch")]
     mismatch = verifier.verify(
@@ -98,6 +127,7 @@ def main() -> None:
         overlay,
         "Family google-sans-text file=/system/fonts/LuoShuSlot-abc.ttf",
         bad_mounts,
+        rendered(),
         "DemoFont",
         {"state": "installed"},
     )

--- a/scripts/device_font_trust_test.sh
+++ b/scripts/device_font_trust_test.sh
@@ -13,6 +13,7 @@ EOF_OVERLAY
 : > "$TMP/font-dump.txt"
 printf '%s\n' 'system/fonts/Roboto-Regular.ttf|/system/fonts/Roboto-Regular.ttf|ok|abc|abc|8192' > "$TMP/mounts.conf"
 printf '%s\n' 'state=installed' > "$TMP/engine.conf"
+set +e
 python3 "$ROOT/common/device_font_load_verify.py" \
     --payload "$TMP/payload.json" \
     --overlay "$TMP/overlay.json" \
@@ -21,29 +22,38 @@ python3 "$ROOT/common/device_font_load_verify.py" \
     --engine-state "$TMP/engine.conf" \
     --active-font test \
     --output "$TMP/result.json" >/dev/null
+VERIFY_RC=$?
+set -e
+test "$VERIFY_RC" -eq 2
 python3 - "$TMP/result.json" <<'PY'
 import json, sys
 payload = json.load(open(sys.argv[1], encoding="utf-8"))
-assert payload["state"] == "verified", payload
-assert payload["mode"] == "mount-verified", payload
-assert "verified-by-visible-mounts" in payload["reasons"], payload
+assert payload["state"] == "unverified", payload
+assert payload["mode"] == "mount-only", payload
+assert "visible-mounts-do-not-prove-font-selection" in payload["reasons"], payload
 assert "dynamic-family-unconfirmed" in payload["reasons"], payload
+assert "android-render-probe-unavailable" in payload["reasons"], payload
 PY
 
-# Normal boot status must not invoke mount traversal or Python. A confirmed transaction
-# is enough to expose the active font after the reboot requested by the switch task.
+# Read-only status may observe a confirmed mount transaction, but it must not
+# claim that Android selected the generated font without renderer/FontManager proof.
 AUTO_MOD="$TMP/auto-module"
 mkdir -p "$AUTO_MOD/common" "$AUTO_MOD/config" "$AUTO_MOD/logs"
 cp "$ROOT/common/device_font_load_verify.sh" "$AUTO_MOD/common/"
 printf 'Composite Font\n' > "$AUTO_MOD/config/active_font.conf"
 printf 'state=confirmed\nfont=Composite Font\n' > "$AUTO_MOD/config/font-payload-boot.conf"
+set +e
 MODDIR="$AUTO_MOD" MODULE_DIR="$AUTO_MOD" \
-    sh "$AUTO_MOD/common/device_font_load_verify.sh"
-grep -q '^state=verified$' "$AUTO_MOD/config/device-font-load-verification.conf"
-grep -q '^mode=mount-verified$' "$AUTO_MOD/config/device-font-load-verification.conf"
-grep -q '^reason=boot-transaction-confirmed$' "$AUTO_MOD/config/device-font-load-verification.conf"
+    sh "$AUTO_MOD/common/device_font_load_verify.sh" status
+STATUS_RC=$?
+set -e
+test "$STATUS_RC" -eq 2
+grep -q '^state=unverified$' "$AUTO_MOD/config/device-font-load-verification.conf"
+grep -q '^mode=mount-only$' "$AUTO_MOD/config/device-font-load-verification.conf"
+grep -q '^reason=visible-mounts-do-not-prove-font-selection$' "$AUTO_MOD/config/device-font-load-verification.conf"
 
-# The expensive verifier remains available only as an explicit diagnostic command.
+# Explicit diagnostics with a visible mount but no aligned manifest remain
+# unverified rather than inventing a successful runtime state.
 COMPAT_MOD="$TMP/compat-module"
 mkdir -p "$COMPAT_MOD/common" "$COMPAT_MOD/config" "$COMPAT_MOD/logs"
 cp "$ROOT/common/device_font_load_verify.sh" "$COMPAT_MOD/common/"
@@ -51,11 +61,15 @@ cat > "$COMPAT_MOD/common/mount_compat.sh" <<'EOF_MOUNT_OK'
 luoshu_mount_verify_active() { return 0; }
 EOF_MOUNT_OK
 printf 'Composite Font\n' > "$COMPAT_MOD/config/active_font.conf"
+set +e
 MODDIR="$COMPAT_MOD" MODULE_DIR="$COMPAT_MOD" \
     sh "$COMPAT_MOD/common/device_font_load_verify.sh" verify
-grep -q '^state=verified$' "$COMPAT_MOD/config/device-font-load-verification.conf"
-grep -q '^mode=mount-verified$' "$COMPAT_MOD/config/device-font-load-verification.conf"
-grep -q '^reason=verified-by-visible-mounts$' "$COMPAT_MOD/config/device-font-load-verification.conf"
+VERIFY_RC=$?
+set -e
+test "$VERIFY_RC" -eq 2
+grep -q '^state=unverified$' "$COMPAT_MOD/config/device-font-load-verification.conf"
+grep -q '^mode=mount-only$' "$COMPAT_MOD/config/device-font-load-verification.conf"
+grep -q '^reason=aligned-manifest-unavailable$' "$COMPAT_MOD/config/device-font-load-verification.conf"
 
 # A missing/partial PID 1 mount remains a hard failure in explicit diagnostics.
 cat > "$COMPAT_MOD/common/mount_compat.sh" <<'EOF_MOUNT_FAIL'
@@ -78,7 +92,7 @@ cp "$ROOT/common/device_font_boot_verify.sh" "$MOD/common/"
 cp "$ROOT/common/background_task.sh" "$MOD/common/"
 cat > "$MOD/common/device_font_load_verify.sh" <<'EOF_VERIFY'
 #!/bin/sh
-printf 'state=verified\nmode=mount-verified\nactiveFont=test\n' > "$MODDIR/config/device-font-load-verification.conf"
+printf 'state=verified\nmode=aligned\nactiveFont=test\n' > "$MODDIR/config/device-font-load-verification.conf"
 exit 0
 EOF_VERIFY
 chmod +x "$MOD/common/"*.sh

--- a/scripts/module_payload_manifest.txt
+++ b/scripts/module_payload_manifest.txt
@@ -24,6 +24,7 @@ common/device_font_slot_plan.py
 common/device_font_slot_plan.sh
 common/device_font_template.py
 common/device_font_template.sh
+common/font_activation_rollback.sh
 common/font_archive_export.sh
 common/font_axis_info.py
 common/font_check.sh

--- a/scripts/module_payload_manifest.txt
+++ b/scripts/module_payload_manifest.txt
@@ -55,6 +55,7 @@ common/font_name_normalize.py
 common/font_provider_cache.sh
 common/font_role_check.py
 common/font_role_check.sh
+common/font_runtime_hardening.sh
 common/font_safety.sh
 common/font_validation_cache.sh
 common/font_switch_task.sh

--- a/scripts/stability_test.sh
+++ b/scripts/stability_test.sh
@@ -36,7 +36,14 @@ printf 'state=verified\nmode=mount-verified\nactiveFont=Beta\n' \
 MODDIR="$MODULE" sh "$MODULE/common/module_status.sh" Beta >/dev/null
 grep -q '系统默认字体（Beta 未生效）' "$MODULE/module.prop"
 
+# 仅有挂载证据时必须明确显示未确认，不能冒充系统已经选用了目标字体。
 printf 'state=mounted\nbackend=self-overlay\n' >"$MODULE/config/self-mount.conf"
+MODDIR="$MODULE" sh "$MODULE/common/module_status.sh" Beta >/dev/null
+grep -q '已配置：Beta（仅挂载，未确认系统选用）' "$MODULE/module.prop"
+
+# 只有 Android 渲染探针或 FontManager 给出强证据时，才显示为真正生效。
+printf 'state=verified\nmode=render-verified\nactiveFont=Beta\n' \
+    >"$MODULE/config/device-font-load-verification.conf"
 MODDIR="$MODULE" sh "$MODULE/common/module_status.sh" Beta >/dev/null
 grep -q '当前字体：Beta$' "$MODULE/module.prop"
 rm -f "$MODULE/config/self-mount.conf" "$MODULE/config/device-font-load-verification.conf"


### PR DESCRIPTION
## 目标

修复用户选择字体后仍显示系统默认字体、纯英文字体导致全局中文方框，以及仅凭挂载成功就显示“本次启动字体已验证”的问题。

## 核心改动

- 单字体和复合字体统一加强 CJK、英文、数字、标点覆盖门禁。
- TTC/OTC 必须在同一个具体字体面内满足角色覆盖，禁止错选英文面、符号面或 `.notdef` 面。
- 可变字体实例化后再次检查字形，防止轴实例化产生残缺输出。
- ROM 专属物理槽先映射，再用本机字体清单补齐，避免提前返回后跳过 MiSans、OPlus 等真实字体槽。
- 开机后校验系统可见文件指纹和全局 UI 字体面的实际字形覆盖。
- 新增 Android `app_process` 渲染探针：直接比较 `Typeface.DEFAULT` 与洛书生成字体的中文字形、英文、数字和标点轮廓，确认系统渲染器是否真的选用了目标字体。
- FontManager 可确认时作为兼容证据；只有挂载证据时显示 `unverified/mount-only`，不再冒充已生效。
- 硬故障写入下一次开机回滚标记，并在任何字体挂载前恢复系统默认字体；OEM 不提供 FontManager 信息或未安装匹配 App 时只显示“未确认”，不会误回滚。
- Root 管理器状态明确区分“已验证”“仅挂载未确认”“等待重启回滚”。

## 验证范围

- 自动测试：字体覆盖、TTC 字体面、设备槽位、负载事务、Shell 语法和 Android 构建。
- HyperOS 3：设置、状态栏、QQ/微信、Play 商店及重启后持久生效。
- ColorOS 16：系统设置、公众号、Google 系应用、状态栏及重启后持久生效。
- 不完整字体应在提交负载前被拒绝；故意破坏负载后下一次开机应恢复系统字体。

当前保持 Draft，待所有 CI 通过和真机回归后再合并。