### PR TITLE
ops: 添加 v2.3.9 正式签名发布触发器

### DIFF
--- a/.github/workflows/v239-release-dispatcher.yml
+++ b/.github/workflows/v239-release-dispatcher.yml
@@ -1,0 +1,60 @@
+name: Dispatch LuoShu v2.3.9 signed release once
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - .github/release-v239-trigger
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  dispatch:
+    if: github.head_ref == 'ops/v2.3.9-publish-trigger'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create immutable v2.3.9 tag and dispatch signed release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: 0f2952f19e087b53dc28ff97aec85a8dbeb43233
+          TAG: v2.3.9
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; nothing to do."
+            exit 0
+          fi
+
+          current_tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object.sha' 2>/dev/null || true)"
+          if [[ -z "$current_tag_sha" ]]; then
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${TAG}" \
+              -f sha="$RELEASE_SHA" >/dev/null
+            current_tag_sha="$RELEASE_SHA"
+          fi
+
+          [[ "$current_tag_sha" == "$RELEASE_SHA" ]] || {
+            echo "Tag $TAG points to $current_tag_sha, expected $RELEASE_SHA" >&2
+            exit 2
+          }
+
+          python3 - <<'PY' | gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/release.yml/dispatches" \
+            --input -
+          import json
+          print(json.dumps({
+              "ref": "v2.3.9",
+              "inputs": {"tag": "v2.3.9", "prerelease": False},
+          }))
+          PY
+
+          echo "Dispatched signed release workflow for $TAG at $RELEASE_SHA"


### PR DESCRIPTION
一次性发布基础设施：在后续专用触发 PR 打开时，将不可变标签 `v2.3.9` 固定到正式版源码提交 `0f2952f`，再调用现有 `release.yml` 构建正式签名 APK、模块包和 SHA-256 并发布 GitHub Release。发布完成后会删除该触发器。