### PR TITLE
ops: 触发洛书 v2.3.9 正式签名发布

### DIFF
--- a/.github/release-v239-trigger
+++ b/.github/release-v239-trigger
@@ -1,1 +1,2 @@
 Dispatch the verified LuoShu v2.3.9 signed stable release from commit 0f2952f19e087b53dc28ff97aec85a8dbeb43233.
+Retry after correcting the missing-tag API handling.

--- a/.github/release-v239-trigger
+++ b/.github/release-v239-trigger
@@ -1,0 +1,1 @@
+Dispatch the verified LuoShu v2.3.9 signed stable release from commit 0f2952f19e087b53dc28ff97aec85a8dbeb43233.

--- a/.github/release-v239-trigger
+++ b/.github/release-v239-trigger
@@ -1,2 +1,3 @@
 Dispatch the verified LuoShu v2.3.9 signed stable release from commit 0f2952f19e087b53dc28ff97aec85a8dbeb43233.
 Retry after correcting the missing-tag API handling.
+Monitor the signed release workflow through publication and verify all four immutable assets.


### PR DESCRIPTION
打开此同仓库 PR 后，由已合入 main 的一次性工作流创建不可变 `v2.3.9` 标签，并调用现有正式签名发布流程。目标源码固定为已通过全部 CI 的提交 `0f2952f19e087b53dc28ff97aec85a8dbeb43233`。该 PR 不需要合并，发布完成后关闭并清理触发器。