### PR TITLE
ops: 验证洛书 v2.3.9 正式发布成品

### DIFF
--- a/.github/release-v239-monitor-trigger
+++ b/.github/release-v239-monitor-trigger
@@ -1,0 +1,1 @@
+Verify the signed LuoShu v2.3.9 formal release and preserve its immutable assets for delivery.


### PR DESCRIPTION
一次性验证任务：等待由提交 `aeeb22c` 触发的正式签名发布流程完成，确认 v2.3.9 为非草稿、非预发行，核对模块 ZIP、正式 APK 及两份 SHA-256 文件，重新下载并校验后保存为 Actions 成品。此 PR 不需要合并。