### PR TITLE
fix(ui): eliminate font details sheet jitter

### DIFF
--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontDetailsDialog.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/library/FontDetailsDialog.kt
@@ -6,9 +6,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -80,12 +80,14 @@ internal fun FontDetailsDialogRoute(
     val primaryText = if (miuix) tokens.textPrimary else scheme.onSurface
     val secondaryText = if (miuix) tokens.textSecondary else scheme.onSurfaceVariant
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val detailScrollState = rememberScrollState()
     var deepMetadata by remember(font.id) { mutableStateOf<FontDeepMetadata?>(null) }
     var deepLoading by remember(font.id) { mutableStateOf(true) }
     var metadataExpanded by rememberSaveable(font.id) { mutableStateOf(false) }
     var previewMode by remember(font.id) { mutableStateOf(FontPreviewMode.Mixed) }
 
     LaunchedEffect(font.id) {
+        detailScrollState.scrollTo(0)
         deepLoading = true
         deepMetadata = loadFontDeepMetadata(font)
         deepLoading = false
@@ -113,22 +115,17 @@ internal fun FontDetailsDialogRoute(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
+        sheetGesturesEnabled = false,
         shape = RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp),
         containerColor = container,
-        dragHandle = {
-            Surface(
-                modifier = Modifier.padding(top = 10.dp).width(36.dp).height(4.dp),
-                shape = RoundedCornerShape(999.dp),
-                color = secondaryText.copy(alpha = .24f),
-            ) {}
-        },
+        dragHandle = null,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(max = 760.dp)
-                .verticalScroll(rememberScrollState())
-                .padding(start = 20.dp, end = 20.dp, bottom = 28.dp),
+                .fillMaxHeight(0.94f)
+                .verticalScroll(detailScrollState)
+                .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 28.dp),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
修复 v2.5.4 字体详情 Bottom Sheet 真机上下抽动问题。

改动：
- 关闭 ModalBottomSheet 自身纵向拖拽，避免与详情内部 verticalScroll 竞争手势；
- 将详情可视高度固定为屏幕可用高度的 94%，避免内容/元数据变化反复重算 Sheet anchor；
- 每次切换字体详情时把内部滚动位置复位到顶部；
- 去掉不可拖拽状态下会误导用户的 drag handle。

该改动只影响字体详情 UI，不修改字体引擎、挂载、provider bridge 或字体应用逻辑。