### PR TITLE
release: LuoShu v2.7.0

### DIFF
--- a/RELEASE_NOTES_v2.7.0.md
+++ b/RELEASE_NOTES_v2.7.0.md
@@ -1,0 +1,42 @@
+# 洛书 v2.7.0
+
+本次正式版在 v2.6.0 的 Liquid Glass 基础上继续打磨 MIUIX 界面，并扩展无 Hook 字体引擎对通用 OEM 字体 XML 的安全覆盖能力。重点不是放宽映射边界，而是在保持图标、Emoji、时钟等 family 安全过滤的前提下，提高不同 ROM 字体配置链路的适配率与失败容错。
+
+## MIUIX 界面继续收口
+- 继续优化 edge-to-edge 页面层级、首页、设置页和任务中心的布局关系，减少多层卡片堆叠与不必要留白。
+- 首页、设置与任务中心统一圆角、间距、分段控件和状态层级，让一级信息更突出、次级操作更克制。
+- 字体库与字体工坊同步悬浮底栏安全区，避免内容与底部导航产生视觉冲突。
+- 保留 v2.6.0 的 Liquid Glass 底栏、真实内容采样、镜面高光、Fresnel 风格边缘光与主题色 caustic。
+- Material 模式继续保持独立实现，不把 MIUIX 控件逻辑混入 Material 页面。
+
+## 通用 OEM 字体 XML 覆盖
+- 在预定义字体配置名单之外，自动发现各字体配置分区中真实存在且符合安全规则的 `*font*.xml`、`*Font*.xml`、`*FONT*.xml`。
+- 静态字体 cache miss 时允许走有界的前台 XML family overlay，减少必须等待后台 aligned cache 的情况。
+- 可变字体继续交给后台 aligned cache，避免在前台执行昂贵实例化；相同源路径只检测一次。
+- `font_config_generate()` 返回成功后必须确认 overlay 已启用、实际 XML 数量匹配且每份 XML 均通过验证，才计为真正 XML 成功。
+- 仅物理字体槽 fallback 不再冒充 XML 成功；XML 失败时仍保留安全 fallback 和后台重建路径。
+- 单个分区 XML 生成失败不会撤销其它已经验证通过的分区，至少一份安全 XML 成功即可提交，其余继续保留原厂配置。
+
+## 动态目标与安全校验
+- 动态字体目标支持真实 partial coverage：分别记录 `targets`、`mapped` 和 `status=full|partial`，不再把部分成功伪装成 100% 覆盖。
+- `mapped=0` 仍然视为硬失败并清理状态，避免发布完全无效的动态目标负载。
+- `targets=0 / mapped=0` 明确视为“设备没有动态目标”的合法状态，不再错误要求 alias manifest。
+- `font_safety`、finalize hotfix 与最终 payload bridge 三层 validator 使用同一套 full/partial 规则，并核对 manifest 数量、目标路径和字体有效性。
+- 继续保留现有 family 安全过滤，不因发现未知 OEM XML 而改写图标、Emoji、时钟或任意厂商私有 family。
+
+## 回归与自动化
+合并前的完整 `main` 基线门禁已全部通过，包括：
+- Validate App-only source
+- Build Test Candidate
+- Android build diagnostic
+- No-Hook font engine tests
+- Device font inventory tests
+- Font engine smoke tests
+- Safety and update feature checks
+- v2.5 feature checks
+- Pre-release Readiness
+
+正式发布工作流还会重新执行完整源码检查、Android Release Lint、单元测试、固定签名 APK 构建与证书校验、模块 ZIP 与内嵌 APK 一致性检查、SHA-256 校验和正式发布就绪门禁。
+
+## 真机状态
+ColorOS 16、HyperOS 3、Magisk、APatch 的完整设备矩阵仍保持 pending。本次稳定版由维护者明确授权放行，不伪造未执行的真机 PASS；自动化和正式签名发布链必须全部通过后才创建不可覆盖的 v2.7.0 Release。

--- a/config/stable_release_authorization.conf
+++ b/config/stable_release_authorization.conf
@@ -1,4 +1,4 @@
-version=v2.6.0
+version=v2.7.0
 scope=stable-release
 allowPendingDeviceMatrix=true
 reason=maintainer-explicit-stable-release

--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v2.6.0
-summary=重做 MIUIX 悬浮底栏为 Liquid Glass 风格并修复真机白块渲染伪影
-notes=v2.6.0 在 v2.5.5 基础上重做 MIUIX 悬浮底栏：降低白色覆盖与噪点、保留页面内容在玻璃后方的透明采样，加入镜面高光、Fresnel 风格边缘光、主题色 caustic 与独立移动的选中透镜；同时针对真机出现的选中项白色矩形伪影，移除 OEM 敏感的 graphicsLayer 缩放与透镜 shadow 合成路径，并用不创建额外离屏图层的按压反馈替代。Material 模式保持原行为，字体引擎、provider bridge、系统/OEM 挂载、事务回滚、字体应用和组合算法不变。模块 versionCode 20600，App versionCode 2060001。
+version=v2.7.0
+summary=完善 MIUIX 界面层级并扩展通用 OEM 字体 XML 安全覆盖
+notes=v2.7.0 在 v2.6.0 基础上继续收口 MIUIX edge-to-edge、首页、设置、任务中心与悬浮底栏安全区，让页面层级、圆角、间距和 Liquid Glass 采样更统一；字体引擎新增安全范围内的通用 OEM 字体 XML 自动发现与有界前台 overlay，严格区分真 XML 成功和 slot fallback，并支持真实 partial dynamic-target coverage。三层 payload validator 统一理解 full/partial，同时正确允许 targets=0 / mapped=0 的无动态目标设备；图标、Emoji、时钟等 family 安全过滤保持不放宽。模块 versionCode 20700，App versionCode 2070001。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v2.6.0
-versionCode=20600
+version=v2.7.0
+versionCode=20700
 author=惜故里丶
 description=Android 无 Hook 全局字体引擎：统一系统、OEM、fallback 与 Play/GMS 下载字体链路
 updateJson=https://raw.githubusercontent.com/xgl34222220-ops/LuoShu/main/update.json


### PR DESCRIPTION
发布洛书 v2.7.0 正式版。

本版本包含：
- MIUIX edge-to-edge、首页、设置、任务中心与悬浮底栏层级继续收口；
- 字体库/字体工坊与 Liquid Glass 底栏安全区统一；
- 通用 OEM `*font*.xml` 安全自动发现；
- 静态字体 cache miss 的有界前台 XML overlay；
- 真 XML 成功与 slot fallback 严格区分；
- dynamic target 真实 partial coverage；
- 三层 payload validator 统一 full/partial 规则；
- 修复 `targets=0 / mapped=0` 无动态目标设备误报；
- 保持图标、Emoji、时钟等 family 安全过滤。

版本：模块 v2.7.0 / versionCode 20700；App versionCode 2070001。

完整设备矩阵仍 pending；维护者已明确授权稳定版放行，不伪造未执行的真机 PASS。合并到 `main` 后由 `Publish signed release` 工作流重新执行正式源码、Lint、单测、签名、模块和 SHA-256 校验，再创建不可覆盖的 v2.7.0 GitHub Release。