### PR TITLE
Harden XML font family coverage without ui-sans-serif regression

### DIFF
--- a/.github/workflows/font-overlay-regression.yml
+++ b/.github/workflows/font-overlay-regression.yml
@@ -1,0 +1,23 @@
+name: Validate XML font overlay regression
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - common/font_config_overlay.py
+      - scripts/font_config_overlay_test.py
+      - .github/workflows/font-overlay-regression.yml
+permissions:
+  contents: read
+jobs:
+  overlay:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compile and run overlay tests
+        run: |
+          python3 -m py_compile common/font_config_overlay.py scripts/font_config_overlay_test.py
+          python3 scripts/font_config_overlay_test.py

--- a/common/font_config_overlay.py
+++ b/common/font_config_overlay.py
@@ -49,6 +49,13 @@ PROTECTED_COMMON_TOKENS = (
 )
 PROTECTED_UI_FILE_TOKENS = PROTECTED_COMMON_TOKENS + ("mono", "serif")
 PROTECTED_MONO_FILE_TOKENS = PROTECTED_COMMON_TOKENS + ("serif",)
+# `sans` as a whole word anywhere in the family name: sans-serif, misans, hihonor-sans,
+# oneui-sans-condensed, vivo-sans-vf ... but not "sansa" or an unrelated substring.
+SANS_FAMILY_PATTERN = re.compile(r"(?:^|-)(?:[a-z0-9]*sans)(?:$|-)")
+# A serif family must keep its own face. AOSP's sans-serif and ui-sans-serif are UI families
+# despite carrying "serif" in the name; vendor serif faces such as misans-serif stay protected.
+SERIF_FAMILY_PATTERN = re.compile(r"(?:^|-)serif(?:$|-)")
+UI_SANS_SERIF_FAMILIES = ("sans-serif", "ui-sans-serif")
 FONT_SUFFIXES = (".ttf", ".otf", ".ttc")
 WEIGHTS = (100, 200, 300, 400, 500, 600, 700, 800, 900)
 MIN_FONT_BYTES = 1024
@@ -67,12 +74,35 @@ def is_safe_mono_family(name: str) -> bool:
     return bool(normalized) and (normalized in MONO_EXACT_FAMILIES or normalized.startswith(MONO_PREFIXES))
 
 
+def looks_like_sans_family(normalized: str) -> bool:
+    """Recognise a UI text family by shape rather than by vendor name.
+
+    A curated list can only ever name the ROMs that existed when it was written, so every OEM that
+    calls its UI family something new escapes the overlay and silently keeps the stock font. Any
+    family whose name identifies it as a sans / UI text family therefore qualifies, while decorative
+    families keep their own names and are left alone.
+    """
+    if SANS_FAMILY_PATTERN.search(normalized):
+        return True
+    return normalized.endswith(("-ui-font", "-os-ui", "-uifont"))
+
+
 def is_safe_family(name: str) -> bool:
     normalized = normalize_family(name)
     if not normalized or is_safe_mono_family(normalized):
         return False
-    safe = normalized in SAFE_EXACT_FAMILIES or normalized.startswith(SAFE_PREFIXES)
-    return safe and not any(token in normalized for token in PROTECTED_COMMON_TOKENS)
+    if any(token in normalized for token in PROTECTED_COMMON_TOKENS):
+        return False
+    if SERIF_FAMILY_PATTERN.search(normalized) and not (
+        normalized in UI_SANS_SERIF_FAMILIES
+        or any(normalized.startswith(name + "-") for name in UI_SANS_SERIF_FAMILIES)
+    ):
+        return False
+    return (
+        normalized in SAFE_EXACT_FAMILIES
+        or normalized.startswith(SAFE_PREFIXES)
+        or looks_like_sans_family(normalized)
+    )
 
 
 def is_locale_specific_family(family: ET.Element) -> bool:

--- a/scripts/font_config_overlay_test.py
+++ b/scripts/font_config_overlay_test.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "common"))
+import font_config_overlay as overlay
 from font_config_overlay import parse_xml, rewrite_tree
 
 SAMPLE = """<?xml version='1.0' encoding='utf-8'?>
@@ -48,8 +49,6 @@ def main() -> int:
         assert not list(list(sans)[0])
         assert child_text(families["sys-sans-en"]) == ["LuoShu-400.ttf"]
 
-        # Named monospace families use the fixed-width derivative so terminal/install
-        # pages no longer mix LuoShu Chinese with ROM English and digits.
         assert child_text(families["monospace"]) == ["LuoShuMono-400.ttf"]
         assert child_text(families["serif"]) == ["NotoSerif-Regular.ttf"]
         assert child_text(families["material-icons"]) == ["MaterialIcons.ttf"]
@@ -59,6 +58,63 @@ def main() -> int:
         assert child_text(anonymous) == ["NotoNaskhArabic-Regular.ttf"]
         alias = next(element for element in root if element.tag == "alias")
         assert alias.attrib == {"name": "sans", "to": "sans-serif", "weight": "400"}
+
+    # UI text families should not depend exclusively on a vendor allow-list. `ui-sans-serif` is
+    # explicitly included because a naive serif guard would otherwise regress this standard UI name.
+    for name in (
+        "sans-serif", "sans-serif-condensed", "ui-sans-serif", "google-sans-text", "misans",
+        "mipro", "sysfont", "op-sans-en", "oplus-os-ui", "harmonyos-sans", "honor-sans",
+        "hihonor-sans", "magic-sans", "vivo-sans", "iqoo-sans", "flyme-sans", "meizu-sans",
+        "nubia-sans", "zte-sans", "redmagic-sans", "lenovo-sans", "motorola-sans", "asus-sans",
+        "sharp-sans", "sony-sans", "tcl-sans", "transsion-sans", "itel-sans", "oneui-sans",
+        "samsung-sans", "nothing-sans", "noto-sans", "noto-sans-cjk", "opposans", "vivosans",
+        "flymesans", "roboto", "system-ui",
+    ):
+        assert overlay.is_safe_family(name), f"UI family not recognised: {name}"
+
+    for name in (
+        "monospace", "roboto-mono", "noto-sans-mono", "droid-sans-mono",
+        "sans-serif-monospace", "ui-monospace",
+    ):
+        assert overlay.is_safe_mono_family(name), f"monospace family not recognised: {name}"
+
+    for name in (
+        "serif", "noto-serif", "source-serif", "serif-condensed", "noto-color-emoji",
+        "material-icons", "material-symbols-outlined", "mitype-clock", "miui-clock", "ndot",
+        "android-clock", "noto-sans-symbols", "noto-sans-math", "noto-emoji", "fallback",
+        "legacy-sans", "misans-serif", "oplus-sans-serif", "honor-serif-display",
+    ):
+        assert not overlay.is_safe_family(name), f"protected family was rewritten: {name}"
+        assert not overlay.is_safe_mono_family(name), f"protected family was rewritten as mono: {name}"
+
+    # TTC-backed UI families can be redirected safely by XML and must lose the collection index;
+    # serif TTC faces remain untouched.
+    with tempfile.TemporaryDirectory() as tmp:
+        ttc_doc = Path(tmp) / "ttc.xml"
+        ttc_doc.write_text(
+            '<familyset>'
+            '<family name="ui-sans-serif">'
+            '<font weight="400" style="normal" index="1">NotoSansCJK-Regular.ttc</font>'
+            '</family>'
+            '<family name="monospace">'
+            '<font weight="400" style="normal">DroidSansMono.ttf</font>'
+            '</family>'
+            '<family name="serif">'
+            '<font weight="400" style="normal" index="0">NotoSerifCJK-Regular.ttc</font>'
+            '</family>'
+            '</familyset>',
+            encoding="utf-8",
+        )
+        tree = parse_xml(ttc_doc)
+        rewrite_tree(tree, "LuoShu", "LuoShuMono")
+        families = {f.attrib.get("name"): f for f in tree.getroot() if f.tag == "family"}
+        sans_font = list(families["ui-sans-serif"])[0]
+        assert sans_font.text == "LuoShu-400.ttf"
+        assert "index" not in sans_font.attrib
+        assert child_text(families["monospace"]) == ["LuoShuMono-400.ttf"]
+        serif_font = list(families["serif"])[0]
+        assert serif_font.text == "NotoSerifCJK-Regular.ttc"
+        assert serif_font.attrib.get("index") == "0"
 
     print("Font configuration overlay tests passed.")
     return 0


### PR DESCRIPTION
## What changed

- broaden `font_config_overlay.py` UI-family detection beyond a fixed OEM allow-list
- keep decorative, emoji, symbol, monospace and real serif families protected
- explicitly preserve `ui-sans-serif` as a UI family so the serif guard does not regress it
- add regression coverage for OEM sans names, mono families, vendor serif faces and TTC index removal
- add a focused GitHub Actions check for the XML overlay path, which the current aggregate check does not yet execute

## Why

The uploaded test/coverage patch correctly identified that the XML overlay allow-list misses new OEM family names, but its serif exception covered only `sans-serif`. That would incorrectly reject the existing `ui-sans-serif` safe family. This PR applies the behavior fix with that regression corrected first.

## Validation

The PR-specific workflow compiles the overlay implementation and test, then runs `scripts/font_config_overlay_test.py` on Ubuntu/Python 3.12. Existing repository checks also run on the PR.