### PR TITLE
Release LuoShu v3.2.0

### DIFF
--- a/RELEASE_NOTES_v3.2.0.md
+++ b/RELEASE_NOTES_v3.2.0.md
@@ -1,0 +1,37 @@
+# 洛书 v3.2.0
+
+洛书 3.2.0 是基于 v3.1.0 的稳定性、兼容性与性能更新，重点优化九档字体准备开销、真实 ROM XML 覆盖链路和 HyperOS 紧凑行框。字体覆盖仍保持无 Hook 方案。本版本按正式稳定版发布。
+
+## 九档字体准备性能
+- 可变字体的九档字重实例化和名称归一化改为批处理，减少嵌入式 Python 解释器反复冷启动和相同源字体的重复读取。
+- 批处理任务会显式传播失败状态；任一阶段失败时会删除半成品，并自动回退到原有逐字重构建路径，避免产生不完整 payload。
+- 静态字体继续走原直接链接/读取路径，不额外引入实例化开销。
+
+## 真实 ROM XML 兼容
+- 修复 `fonts.xml` / 字体配置中注释、处理指令等非字符串 tag 导致 overlay 遍历异常的问题。
+- XML 辅助逻辑现在会把这类节点视为无本地标签并安全跳过，同时保留 ROM 原有注释，不再因为真实系统配置中的注释节点中断整个无 Hook 覆盖流程。
+
+## 复合字体校验性能
+- 复合字体输出自检改为 lazy 加载，只解析 cmap、maxp 和实际探针字形，不再为了检查少数字形而提前展开完整 CJK 字体。
+- 保留对中文、英文和数字关键探针的输出完整性验证。
+
+## HyperOS 紧凑行框修复
+- HyperOS 物理字体槽正式改用 `font_metrics_normalize.py --compact` 模式。
+- 移除旧的 `_outline_extremes = lambda font: None` monkey-patch 与 0.98em 硬裁切行为；紧凑行框现在会以常用中文、拉丁字母、数字和下伸字形的真实墨迹边界为安全下限。
+- 修复部分字体在 HyperOS 上出现标题压行、上下行互相侵入、下伸部或标签边缘被裁掉的问题，同时避免少见极端字形把普通 UI 行框无谓撑大。
+- 新增紧凑行框专项回归，要求 HyperOS 必须使用 `--compact`，并阻止旧 monkey-patch 回归。
+
+## 回归与 CI
+- 将此前未实际执行的一批字体配置、设备 payload、模板、目标发现等回归重新接入常驻 `scripts/check.sh`。
+- aggregate source checks 在已准备模块内置 Python runtime 时会使用洛书自带的 FontTools，避免 runner 未全局安装 FontTools 导致假失败。
+- v3.2.0 正式发布工作流会重新执行完整源码检查、Android Release Lint、单元测试、固定签名 APK 构建、证书 SHA-256 校验、模块 ZIP/App 字节一致性检查以及发布就绪门禁。
+
+## 版本信息
+- 模块版本：v3.2.0
+- 模块 versionCode：30200
+- App versionCode：3020001
+
+## 发布验证
+ColorOS 16、HyperOS 3、Magisk、APatch 的完整真机设备矩阵仍保持 pending；本次稳定版由维护者明确授权放行，不伪造未执行的真机 PASS。
+
+<!-- release-trigger: v3.2.0 -->

--- a/config/stable_release_authorization.conf
+++ b/config/stable_release_authorization.conf
@@ -1,4 +1,4 @@
-version=v3.1.0
+version=v3.2.0
 scope=stable-release
 allowPendingDeviceMatrix=true
 reason=maintainer-explicit-stable-release

--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v3.1.0
-summary=洛书 3.1 性能更新：复用可变字体静态实例，降低 payload 构建重复 CPU/RSS 开销
-notes=v3.1.0 基于 v3.0.0 继续优化无 Hook 字体构建性能：同一 payload 构建中，相同源字体、face 与字重的可变字体静态实例改为安全复用，避免不同字体槽位重复执行完整 instantiateVariableFont；缓存文件身份同时纳入路径、face、weight、device、inode、size、mtime_ns 与 ctime_ns，防止同路径快速替换后复用旧实例；静态字体继续走原直接读取路径。新增常驻回归覆盖同源同字重复用、不同字重隔离、ctime 失效、源文件重写失效与静态字体绕过缓存。模块 versionCode 30100，App versionCode 3010001。
+version=v3.2.0
+summary=洛书 3.2 稳定性与性能更新：批量准备九档字体、修复真实 ROM XML 注释链路并优化 HyperOS 紧凑行框
+notes=v3.2.0 基于 v3.1.0 继续完善无 Hook 字体引擎：九档可变字体实例化与名称归一化改为批处理，减少嵌入式 Python 冷启动和重复读取；批处理任一阶段失败会清理半成品并回退原逐字重路径；真实 ROM fonts.xml 中的注释与处理指令现在可安全保留和跳过，避免非字符串 tag 导致 overlay 中断；复合字体自检改为 lazy 加载，只展开实际探针字形；HyperOS 物理槽正式改用 --compact 行框模式，以常用中英数 UI 字形真实墨迹为下限，移除旧 _outline_extremes monkey-patch 和 0.98em 硬裁切行为；恢复并接入更多常驻回归，同时让 aggregate source checks 使用模块内置 FontTools。模块 versionCode 30200，App versionCode 3020001。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v3.1.0
-versionCode=30100
+version=v3.2.0
+versionCode=30200
 author=惜故里丶
 description=Android 无 Hook 全局字体引擎：统一系统、OEM、fallback 与 Play/GMS 下载字体链路
 updateJson=https://raw.githubusercontent.com/xgl34222220-ops/LuoShu/main/update.json


### PR DESCRIPTION
Prepare LuoShu v3.2.0 stable release.

- Bump module version to v3.2.0 / versionCode 30200.
- App versionCode resolves to 3020001 from the shared version source.
- Add v3.2.0 release notes covering nine-weight batching, ROM XML comment/PI safety, lazy composite validation, HyperOS compact line-box fixes, restored regressions, and bundled FontTools use in aggregate source checks.
- Update stable-release authorization for v3.2.0 with the device matrix remaining explicitly pending; no device PASS is fabricated.

Merging to main will trigger the signed immutable release workflow, which re-runs full source/module checks, Android release lint/tests/build, fixed-signature certificate verification, ZIP/APK consistency checks, and release readiness before creating tag/release v3.2.0.