### PR TITLE
Release LuoShu v3.2.2

### DIFF
--- a/RELEASE_NOTES_v3.2.2.md
+++ b/RELEASE_NOTES_v3.2.2.md
@@ -1,0 +1,28 @@
+# 洛书 v3.2.2
+
+洛书 3.2.2 是针对 KernelSU 自挂载回滚和 App 状态误判的正式热修版。
+
+## KernelSU 可选分区挂载修复
+- 修复部分 Android 16 / KernelSU 设备不存在 `/system_ext/fonts` 时，洛书把 `system_ext/fonts-target-missing` 当成整笔原子事务失败的问题。
+- 跨 ROM 预置的 `system_ext`、`product` 等可选 OEM/扩展负载，现在只在本机存在真实分区和目录目标时参与挂载；不存在的目标会安全跳过。
+- `/system/fonts` 仍是强制核心组件，继续执行原子提交、PID 1 可见性检查以及失败完整回滚，不降低主字体树安全门禁。
+
+## 状态一致性修复
+- App、状态桥和设备可信页现在统一认可 `verified + mount-confirmed`，不再把已确认的挂载事务显示成“字体未生效”。
+- 本次自挂载明确失败时，旧的 `boot-confirmed` 记录不能再把状态提升为 verified。
+- 自挂载失败会显示可理解的中文说明，不再把 `mount-active-visible-layout-differs` 等内部诊断码直接暴露给用户。
+
+## 回归验证
+- 新增“设备存在 `system_ext` 分区但没有 `system_ext/fonts`”专项回归，确认系统主字体挂载不会被回滚。
+- 新增可选分区根目录缺失、旧启动记录与本次回滚冲突、`mount-confirmed` App 状态解析回归。
+- 正式发布工作流会重新执行完整源码检查、Android Release Lint、单元测试、固定签名 APK 构建、证书 SHA-256 校验、模块 ZIP/App 字节一致性检查以及发布就绪门禁。
+
+## 版本信息
+- 模块版本：v3.2.2
+- 模块 versionCode：30202
+- App versionCode：3020201
+
+## 发布验证
+本热修根据 Android 16 / KernelSU 脱敏诊断报告中的 `system_ext/fonts-target-missing` 完成针对性修复与自动化回归。ColorOS 16、HyperOS 3、Magisk、APatch 的完整真机设备矩阵仍保持 pending；本次稳定版由维护者明确授权放行，不伪造未执行的真机 PASS。
+
+<!-- release-trigger: v3.2.2 -->

--- a/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/DeviceTrustUi.kt
+++ b/android-app/app/src/main/java/io/github/xgl34222220/luoshu/ui/home/DeviceTrustUi.kt
@@ -80,7 +80,7 @@ internal data class DeviceTrustState(
             activeFont in setOf("", "default") || alignment == "not-applicable" -> DeviceTrustLevel.SYSTEM
             mountState == "failed" -> DeviceTrustLevel.ISSUE
             alignment == "failed" || reason in failedTrustReasons -> DeviceTrustLevel.ISSUE
-            alignment == "verified" && mode in setOf("aligned", "mount-verified") -> DeviceTrustLevel.VERIFIED
+            alignment == "verified" && mode in setOf("aligned", "mount-verified", "mount-confirmed") -> DeviceTrustLevel.VERIFIED
             alignment == "pending" || reason in pendingTrustReasons -> DeviceTrustLevel.PENDING
             alignment == "compatibility" || mode == "compatibility" -> DeviceTrustLevel.COMPATIBILITY
             engine == "installed" -> DeviceTrustLevel.PENDING
@@ -109,9 +109,9 @@ internal suspend fun loadDeviceTrustState(): DeviceTrustState {
         mountState="${'$'}(read_value "${'$'}CFG/self-mount.conf" state)"
         if [ "${'$'}active" != default ]; then
             if [ "${'$'}mountState" = failed ]; then
+                [ "${'$'}alignment" = failed ] || reason=self-mount-failed
                 alignment=failed
                 mode=compatibility
-                [ -n "${'$'}reason" ] || reason=self-mount-failed
             elif [ -n "${'$'}verifiedActive" ] && [ "${'$'}verifiedActive" != "${'$'}active" ]; then
                 alignment=pending
                 mode=unknown
@@ -282,6 +282,12 @@ private fun deviceTrustPresentation(state: DeviceTrustState): DeviceTrustPresent
             Icons.Rounded.CheckCircle,
             scheme.primary,
         )
+        state.level == DeviceTrustLevel.VERIFIED && state.mode == "mount-confirmed" -> DeviceTrustPresentation(
+            "本次启动挂载已确认",
+            "字体事务已完成；系统字体服务暴露的目录布局与负载不同",
+            Icons.Rounded.CheckCircle,
+            scheme.primary,
+        )
         state.level == DeviceTrustLevel.VERIFIED -> DeviceTrustPresentation(
             "本次启动字体已验证",
             "原厂模板、字体事务与本次启动证据一致",
@@ -339,6 +345,8 @@ private fun friendlyTrustReason(value: String): String = when (value) {
     "current-boot-mount-confirmed" -> "本次启动的字体、配置与挂载事务均已确认"
     "dynamic-config-changed" -> "系统在启动后改写了动态字体配置"
     "verified-by-visible-mounts" -> "系统可见字体文件与洛书负载一致"
+    "mount-transaction-active" -> "本次启动的字体挂载事务已确认"
+    "mount-active-visible-layout-differs" -> "字体挂载已确认，系统可见目录布局与模块负载不同"
     else -> value
 }
 
@@ -355,6 +363,7 @@ private fun friendlyTrustValue(value: String): String = when (value) {
     "not-applicable" -> "不适用"
     "aligned" -> "设备对齐"
     "mount-verified" -> "挂载证据"
+    "mount-confirmed" -> "事务确认"
     "compatibility" -> "兼容映射"
     "mounted" -> "完整挂载"
     "idle" -> "未启用"

--- a/android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/home/DeviceTrustUiTest.kt
+++ b/android-app/app/src/test/java/io/github/xgl34222220/luoshu/ui/home/DeviceTrustUiTest.kt
@@ -28,6 +28,25 @@ class DeviceTrustUiTest {
     }
 
     @Test
+    fun mountConfirmedLayoutDifferenceIsVerifiedWhenTransactionMounted() {
+        val state = parseDeviceTrustOutput(
+            """
+                activeFont=custom-font
+                inventory=available
+                engine=installed
+                template=trusted
+                alignment=verified
+                mode=mount-confirmed
+                reason=mount-active-visible-layout-differs
+                mountState=mounted
+                cachePending=no
+            """.trimIndent(),
+        )
+
+        assertEquals(DeviceTrustLevel.VERIFIED, state.level)
+    }
+
+    @Test
     fun restoredSystemFontDoesNotPretendVerificationIsPending() {
         val state = parseDeviceTrustOutput(
             """

--- a/common/app_bridge.sh
+++ b/common/app_bridge.sh
@@ -151,9 +151,14 @@ status_json() {
         # failure, so the only safe effective-font claim is the ROM default.
         _effective_active=default
         _font_effect_state=failed
+        if [ "$_mount_state" = failed ]; then
+            [ "$_verification_state" = failed ] || _verification_reason=self-mount-failed
+            _verification_state=failed
+            _verification_mode=compatibility
+        fi
     elif [ "$_verification_state" = verified ]; then
         case "$_verification_mode" in
-            aligned|mount-verified)
+            aligned|mount-verified|mount-confirmed)
                 _effective_active="$_active"
                 _font_effect_state=verified
                 ;;

--- a/common/device_font_load_verify.sh
+++ b/common/device_font_load_verify.sh
@@ -186,6 +186,9 @@ _dfload_mount_transaction_active() {
     _dfload_boot_state=$(_dfload_state_value "$_dfload_module_dir/config/font-payload-boot.conf" state)
     _dfload_font_count=$(_dfload_manifest_font_count)
     [ "$_dfload_font_count" -gt 0 ] 2>/dev/null || return 1
+    # A stale confirmed boot record must never override an explicit rollback
+    # from the current self-mount transaction.
+    [ "$_dfload_mount_state" != failed ] || return 1
     case "$_dfload_mount_state:$_dfload_boot_state" in
         mounted:*|confirmed:*|*:confirmed|*:booting) return 0 ;;
         *) return 1 ;;
@@ -200,6 +203,12 @@ device_font_load_status() {
         return 0
     fi
 
+    _dfload_mount_state=$(_dfload_state_value "$_dfload_module_dir/config/self-mount.conf" state)
+    if [ "$_dfload_mount_state" = failed ]; then
+        _dfload_write_simple failed self-mount-failed "$_dfload_active" compatibility
+        return 1
+    fi
+
     _dfload_conf="$_dfload_module_dir/config/device-font-load-verification.conf"
     _dfload_verified_state=$(_dfload_state_value "$_dfload_conf" state)
     _dfload_verified_active=$(_dfload_state_value "$_dfload_conf" activeFont)
@@ -212,12 +221,6 @@ device_font_load_status() {
         return 0
     fi
 
-    _dfload_mount_state=$(_dfload_state_value "$_dfload_module_dir/config/self-mount.conf" state)
-    if [ "$_dfload_mount_state" = failed ]; then
-        _dfload_write_simple failed self-mount-failed "$_dfload_active" compatibility
-        return 1
-    fi
-
     _dfload_write_simple pending awaiting-mount-confirmation "$_dfload_active" compatibility
     return 2
 }
@@ -228,6 +231,13 @@ device_font_load_verify() {
     if [ "$_dfload_active" = default ]; then
         _dfload_write_simple not-applicable default-font "$_dfload_active" system
         return 2
+    fi
+
+    _dfload_mount_state=$(_dfload_state_value "$_dfload_module_dir/config/self-mount.conf" state)
+    if [ "$_dfload_mount_state" = failed ]; then
+        _dfload_write_simple failed self-mount-failed "$_dfload_active" compatibility
+        _dfload_log "字体自挂载明确失败；旧启动确认记录不再覆盖本次回滚：$_dfload_active"
+        return 1
     fi
 
     if _dfload_exact_visible_match; then
@@ -246,13 +256,6 @@ device_font_load_verify() {
         _dfload_write_simple verified mount-active-visible-layout-differs "$_dfload_active" mount-confirmed
         _dfload_log "字体挂载事务有效，但系统字体服务暴露的文件布局与负载不同；不再误判失败或恢复默认字体：$_dfload_active"
         return 0
-    fi
-
-    _dfload_mount_state=$(_dfload_state_value "$_dfload_module_dir/config/self-mount.conf" state)
-    if [ "$_dfload_mount_state" = failed ]; then
-        _dfload_write_simple failed self-mount-failed "$_dfload_active" compatibility
-        _dfload_log "字体自挂载明确失败：$_dfload_active"
-        return 1
     fi
 
     _dfload_write_simple pending mount-evidence-pending "$_dfload_active" compatibility

--- a/common/mount_self_atomic.sh
+++ b/common/mount_self_atomic.sh
@@ -23,6 +23,14 @@ _luoshu_atomic_file_optional() {
     esac
 }
 
+# Cross-ROM payloads intentionally contain aliases for partitions that are not
+# present on every device.  Only the primary system font tree is mandatory;
+# an absent OEM/extension partition or subdirectory means there is no device
+# target to replace and must not roll back an otherwise complete transaction.
+_luoshu_atomic_component_required() {
+    [ "${1:-}/${2:-}" = system/fonts ]
+}
+
 _luoshu_atomic_missing_target_allowed() {
     _lsamta_rel="$1"
     _lsamta_mode="${2:-overlay}"
@@ -352,16 +360,25 @@ luoshu_self_mount_ensure() {
         [ "$_lsme_has_payload" -eq 1 ] || continue
 
         _lsme_root=$(_luoshu_partition_root "$_lsme_partition") || {
-            _lsme_failed="$_lsme_partition/root-unavailable"
-            break
+            if [ "$_lsme_partition" = system ]; then
+                _lsme_failed="$_lsme_partition/root-unavailable"
+                break
+            fi
+            _luoshu_self_log "自挂载跳过本机不存在的可选分区：$_lsme_partition"
+            continue
         }
         for _lsme_subdir in fonts etc; do
             _lsme_source="$_lsme_module/$_lsme_partition/$_lsme_subdir"
             [ -d "$_lsme_source" ] && find "$_lsme_source" -type f -print -quit 2>/dev/null | grep -q . || continue
             _lsme_target="$_lsme_root/$_lsme_subdir"
             [ -d "$_lsme_target" ] || {
-                _lsme_failed="$_lsme_partition/$_lsme_subdir-target-missing"
-                break
+                if _luoshu_atomic_component_required "$_lsme_partition" "$_lsme_subdir"; then
+                    _lsme_failed="$_lsme_partition/$_lsme_subdir-target-missing"
+                    break
+                fi
+                _luoshu_self_log \
+                    "自挂载跳过本机不存在的可选目标：$_lsme_partition/$_lsme_subdir"
+                continue
             }
             _lsme_mode=overlay
             if _luoshu_overlay_mount_dir "$_lsme_source" "$_lsme_target" \

--- a/config/stable_release_authorization.conf
+++ b/config/stable_release_authorization.conf
@@ -1,4 +1,4 @@
-version=v3.2.1
+version=v3.2.2
 scope=stable-release
 allowPendingDeviceMatrix=true
 reason=maintainer-explicit-stable-release

--- a/config/version_notes.conf
+++ b/config/version_notes.conf
@@ -1,3 +1,3 @@
-version=v3.2.1
-summary=洛书 3.2.1 稳定性与安全更新：验证 provider 重启链路、恢复中断事务并收紧字体导入与运行时依赖
-notes=v3.2.1 基于 v3.2.0 加固无 Hook 全局字体链路：字体切换后主动失效系统与 provider 字体缓存，并在相关 zygote/provider 重启后再次验证目标进程；为 payload 两阶段提交增加持久事务状态与外层快照恢复，避免强杀或 OOM 留下幽灵中间态；ZIP 导入增加解压后总量、单文件、文件数与规范路径碰撞门禁；复合字体合成增加异常路径资源释放、字重元数据回退和不可靠平底探针保护；内置 CPython、FontTools、Android NDK 与最低 API 统一锁定并输出运行时清单，同时加入依赖审计、合规说明和对应行为回归。模块 versionCode 30201，App versionCode 3020101。
+version=v3.2.2
+summary=洛书 3.2.2 KernelSU 热修：可选字体分区缺失时不再回滚系统主字体挂载
+notes=v3.2.2 修复 KernelSU 设备没有 system_ext/fonts 等可选目录时，跨 ROM 字体负载被误判为 target-missing 并回滚完整 system/fonts 挂载的问题；可选 OEM 与扩展分区现在只在本机存在真实目标时参与原子事务，系统主字体树仍保持强制验证和失败回滚。同步修复 mount-confirmed 被 App 误判为字体未生效、旧 boot-confirmed 记录覆盖本次自挂载失败、内部验证错误码直接显示等状态契约问题。模块 versionCode 30202，App versionCode 3020201。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=LuoShu
 name=洛书
-version=v3.2.1
-versionCode=30201
+version=v3.2.2
+versionCode=30202
 author=惜故里丶
 description=Android 无 Hook 全局字体引擎：统一系统、OEM、fallback 与 Play/GMS 下载字体链路
 updateJson=https://raw.githubusercontent.com/xgl34222220-ops/LuoShu/main/update.json

--- a/scripts/app_bridge_status_test.sh
+++ b/scripts/app_bridge_status_test.sh
@@ -41,8 +41,17 @@ printf 'state=verified\nmode=mount-verified\nreason=\nactiveFont=DemoFont\n' \
     >"$CONFIG/device-font-load-verification.conf"
 assert_status DemoFont verified ''
 
+printf 'state=verified\nmode=mount-confirmed\nreason=mount-active-visible-layout-differs\nactiveFont=DemoFont\n' \
+    >"$CONFIG/device-font-load-verification.conf"
+assert_status DemoFont verified mount-active-visible-layout-differs
+
+# An explicit atomic rollback wins over a stale mount-confirmed record and the
+# App must show the actionable mount failure instead of an internal layout code.
+printf 'state=failed\nbackend=rollback\nfailed=system_ext/fonts-target-missing\n' >"$CONFIG/self-mount.conf"
+assert_status default failed self-mount-failed
+
 printf 'state=failed\nbackend=rollback\nfailed=system/etc\n' >"$CONFIG/self-mount.conf"
-assert_status default failed ''
+assert_status default failed self-mount-failed
 
 printf 'state=mounted\nbackend=self-overlay\n' >"$CONFIG/self-mount.conf"
 printf 'state=verified\nmode=mount-verified\nreason=\nactiveFont=OldFont\n' \

--- a/scripts/device_font_trust_test.sh
+++ b/scripts/device_font_trust_test.sh
@@ -89,6 +89,7 @@ grep -q '^reason=mount-active-visible-layout-differs$' "$COMPAT_MOD/config/devic
 
 # Only an explicit mount failure without stronger visible evidence remains a hard failure.
 printf 'state=failed\n' > "$COMPAT_MOD/config/self-mount.conf"
+printf 'state=confirmed\nfont=Composite Font\n' > "$COMPAT_MOD/config/font-payload-boot.conf"
 set +e
 MODDIR="$COMPAT_MOD" MODULE_DIR="$COMPAT_MOD" LUOSHU_VISIBLE_ROOT="$VISIBLE_ROOT" \
     sh "$COMPAT_MOD/common/device_font_load_verify.sh" verify

--- a/scripts/self_mount_atomic_test.sh
+++ b/scripts/self_mount_atomic_test.sh
@@ -43,16 +43,16 @@ _luoshu_self_state_write() {
 _luoshu_self_state_value() {
     sed -n "s/^${1}=//p" "$MODULE_DIR/config/self-mount.conf" 2>/dev/null | head -n1
 }
-luoshu_payload_partitions() { printf '%s\n' 'system product'; }
+luoshu_payload_partitions() { printf '%s\n' 'system product system_ext'; }
 _luoshu_partition_root() {
     case "$1" in
         system)
             test -d "$LUOSHU_SELF_MOUNT_VISIBLE_ROOT/system" || return 1
             printf '%s/system\n' "$LUOSHU_SELF_MOUNT_VISIBLE_ROOT"
             ;;
-        product)
-            test -d "$LUOSHU_SELF_MOUNT_VISIBLE_ROOT/product" || return 1
-            printf '%s/product\n' "$LUOSHU_SELF_MOUNT_VISIBLE_ROOT"
+        product|system_ext)
+            test -d "$LUOSHU_SELF_MOUNT_VISIBLE_ROOT/$1" || return 1
+            printf '%s/%s\n' "$LUOSHU_SELF_MOUNT_VISIBLE_ROOT" "$1"
             ;;
         *) return 1 ;;
     esac
@@ -135,10 +135,20 @@ mkdir -p "$MODULE_DIR/system/fonts" "$MODULE_DIR/product/etc"
 printf 'new-font\n' > "$MODULE_DIR/system/fonts/Roboto.ttf"
 printf 'stock-font\n' > "$CASE_ROOT/root/system/fonts/Roboto.ttf"
 printf 'product-xml\n' > "$MODULE_DIR/product/etc/fonts.xml"
-if luoshu_self_mount_ensure; then
-    fail 'missing payload partition root was silently skipped'
-fi
-grep -q 'product/root-unavailable' "$MODULE_DIR/config/self-mount.conf" || fail 'missing partition root reason absent'
+luoshu_self_mount_ensure || fail 'missing optional payload partition root rolled back system/fonts'
+grep -q '^state=mounted$' "$MODULE_DIR/config/self-mount.conf" || fail 'optional missing partition was not skipped'
+test "$(wc -l < "$MODULE_DIR/config/self-mount-required.conf" | tr -d ' ')" -eq 1 || fail 'missing optional root entered required manifest'
+
+setup_case missing-optional-target
+mkdir -p "$MODULE_DIR/system/fonts" "$MODULE_DIR/system_ext/fonts" \
+    "$CASE_ROOT/root/system_ext"
+printf 'new-font\n' > "$MODULE_DIR/system/fonts/Roboto.ttf"
+printf 'extension-font\n' > "$MODULE_DIR/system_ext/fonts/Extension.ttf"
+printf 'stock-font\n' > "$CASE_ROOT/root/system/fonts/Roboto.ttf"
+luoshu_self_mount_ensure || fail 'missing optional system_ext/fonts target rolled back system/fonts'
+grep -q '^state=mounted$' "$MODULE_DIR/config/self-mount.conf" || fail 'optional missing target was not skipped'
+grep -q '^failed=$' "$MODULE_DIR/config/self-mount.conf" || fail 'optional missing target was recorded as failure'
+test "$(wc -l < "$MODULE_DIR/config/self-mount-required.conf" | tr -d ' ')" -eq 1 || fail 'missing optional target entered required manifest'
 
 setup_case bind-compatible-alias
 mkdir -p "$MODULE_DIR/system/fonts"


### PR DESCRIPTION
## 根因

Android 16 / KernelSU 脱敏报告显示 `selfMountFailed=system_ext/fonts-target-missing`。设备存在 `system_ext` 分区但没有 `/system_ext/fonts`，原子挂载却把这个跨 ROM 可选目标当成必需组件，导致已成功的 `/system/fonts` 一并回滚。

## 修复

- 缺失的可选 OEM/扩展分区与字体目录安全跳过
- `/system/fonts` 继续作为强制核心组件进行原子提交和 PID 1 验证
- 本次自挂载失败优先于旧 `boot-confirmed` 记录
- App、状态桥和设备可信页统一认可 `mount-confirmed`
- 内部诊断码改为可理解的中文状态
- 版本提升至 v3.2.2 / 30202（App 3020201）

## 验证

- self-mount atomic transaction tests passed
- private self-mount regression checks passed
- device font trust tests passed
- App bridge status tests passed
- module update / system health / transaction guard / font switch tests passed
- pre-release readiness: ready，0 blockers

## 真机状态

修复依据用户设备脱敏报告中的确定故障目标完成。ColorOS 16、HyperOS 3、Magisk、APatch 完整真机矩阵仍为 pending，不伪造未执行的真机 PASS。合并后由正式工作流重新构建签名 APK、模块 ZIP 并校验证书及 SHA-256。