### PR TITLE
hotfix: make v3.3.0 font apply backend exactly match v3.2.0

### DIFF
--- a/common/rom_adapters.sh
+++ b/common/rom_adapters.sh
@@ -419,7 +419,7 @@ copy_as_coloros() {
     [ "$extra_count" -gt 0 ] && _log_step "  已覆盖 $extra_count 个额外字体文件（数字/英文粗体等）"
 
     # 多字重支持：如果用户字体族提供了 Bold/Medium/Light 等文件，生成对应字重变体
-    if [ "$mode" != quick ] && [ -n "$font_family" ] && type scan_family_weights >/dev/null 2>&1; then
+    if [ -n "$font_family" ] && type scan_family_weights >/dev/null 2>&1; then
         weights=$(scan_family_weights "$font_family")
         weight_base="SysSans-Hant SysSans-Hans SysFont-Static SysFont-Myanmar SysFont-Hant SysFont-Hans SysFont SysSans-En"
         for w in $(echo "$weights" | tr ',' ' '); do
@@ -498,7 +498,7 @@ copy_as_hyperos() {
     # 多字重支持：数字文件（100~900）跟字重数值天然对应，直接精确映射；
     # Roboto 系列按字重名映射；MiSans 那 5 个核心文件本身是变量字体容器/
     # 单一设计，没法按静态字重文件拆分，固定用 Regular（已在上面覆盖过）
-    if [ "$mode" != quick ] && [ -n "$font_family" ] && type scan_family_weights >/dev/null 2>&1; then
+    if [ -n "$font_family" ] && type scan_family_weights >/dev/null 2>&1; then
         weights=$(scan_family_weights "$font_family")
         for w in $(echo "$weights" | tr ',' ' '); do
             [ "$w" = "regular" ] && continue


### PR DESCRIPTION
真机反馈：选择字体后重启仍回到系统默认字体。为先恢复可用性，本 PR 不再保留任何字体应用/ROM 映射层面的性能改动，直接把 common/rom_adapters.sh 恢复为 v3.2.0 的已验证版本。这样 v3.3.0 的字体应用、payload、启动挂载运行时后端与 v3.2.0 保持一致；v3.3.0 仅保留 App/UI/字体库加载类改动。先保证字体能稳定切换并在重启后生效，速度优化后续另做且不触碰生效链。