### PR TITLE
fix(hyperos): restore v2.8 dynamic coverage floor

### DIFF
--- a/common/font_config_partitions.sh
+++ b/common/font_config_partitions.sh
@@ -63,7 +63,10 @@ _luoshu_font_config_specs() {
         # Keep the curated list as a stable baseline, then discover vendor-specific font XML that
         # actually exists on this ROM. Unknown OEM names must not silently escape the no-hook path.
         _lfcp_all="$_lfcp_names"
-        for _lfcp_found in             "$_lfcp_real_etc"/*font*.xml             "$_lfcp_real_etc"/*Font*.xml             "$_lfcp_real_etc"/*FONT*.xml; do
+        for _lfcp_found in \
+            "$_lfcp_real_etc"/*font*.xml \
+            "$_lfcp_real_etc"/*Font*.xml \
+            "$_lfcp_real_etc"/*FONT*.xml; do
             [ -f "$_lfcp_found" ] || continue
             _lfcp_base="${_lfcp_found##*/}"
             case " $_lfcp_all " in
@@ -91,6 +94,9 @@ if ! type font_config_prepare_payload_weights >/dev/null 2>&1; then
     [ -f "$_luoshufp_module/common/font_config_weights.sh" ] && . "$_luoshufp_module/common/font_config_weights.sh"
 fi
 [ -f "$_luoshufp_module/common/font_finalize_hotfix.sh" ] && . "$_luoshufp_module/common/font_finalize_hotfix.sh"
+# Loaded after the current dynamic-target implementation so this compatibility layer can preserve
+# the 3.x batch fast path while enforcing the proven v2.8 HyperOS per-document coverage floor.
+[ -f "$_luoshufp_module/common/hyperos_coverage_floor.sh" ] && . "$_luoshufp_module/common/hyperos_coverage_floor.sh"
 
 [ -f "$_luoshufp_module/common/device_font_payload_bridge.sh" ] && . "$_luoshufp_module/common/device_font_payload_bridge.sh"
 [ -f "$_luoshufp_module/common/device_font_dynamic_guard.sh" ] && . "$_luoshufp_module/common/device_font_dynamic_guard.sh"

--- a/common/hyperos_coverage_floor.sh
+++ b/common/hyperos_coverage_floor.sh
@@ -1,0 +1,219 @@
+#!/system/bin/sh
+# LuoShu HyperOS coverage floor.
+# Keep the batched scanner as the fast path, then union it with the v2.8 per-document scan on
+# HyperOS. The per-document result is authoritative for scan health, so batch protocol/path
+# regressions cannot silently reduce the set of physical UI font slots that gets materialized.
+set +e
+
+_luoshu_hcf_font_ok() {
+    _hcf_file="$1"
+    if type _luoshu_fast_font_ok >/dev/null 2>&1; then
+        _luoshu_fast_font_ok "$_hcf_file"
+        return $?
+    fi
+    [ -s "$_hcf_file" ] || return 1
+    if type _luoshu_filesize >/dev/null 2>&1; then
+        _hcf_size=$(_luoshu_filesize "$_hcf_file")
+        case "$_hcf_size" in ''|*[!0-9]*) return 1 ;; esac
+        [ "$_hcf_size" -ge 1024 ]
+        return $?
+    fi
+    return 0
+}
+
+luoshu_dynamic_targets_apply() {
+    _ldt_module="$(_luoshu_safety_module)"
+    _ldt_config="$(_luoshu_safety_config)"
+    _ldt_backup="$_ldt_config/font-config-source"
+    _ldt_tool="$_ldt_module/common/font_config_targets.py"
+    _ldt_manifest_tmp="$_ldt_config/font-target-aliases.conf.tmp.$$"
+    _ldt_coverage_tmp="$_ldt_config/font-target-coverage.conf.tmp.$$"
+    _ldt_records="$_ldt_config/.font-target-records.$$"
+    _ldt_seen="$_ldt_config/.font-target-seen.$$"
+    _ldt_jobs="$_ldt_config/.font-target-jobs.$$"
+    _ldt_map="$_ldt_config/.font-target-map.$$"
+    _ldt_out="$_ldt_config/.font-targets.$$.txt"
+    [ -f "$_ldt_tool" ] && type _luoshu_font_config_exec >/dev/null 2>&1 || return 2
+    type font_config_capture_original >/dev/null 2>&1 && font_config_capture_original >/dev/null 2>&1 || true
+
+    luoshu_dynamic_targets_clear
+    mkdir -p "$_ldt_config" 2>/dev/null || return 1
+    : > "$_ldt_manifest_tmp" 2>/dev/null || return 1
+    : > "$_ldt_records" 2>/dev/null || return 1
+    : > "$_ldt_seen" 2>/dev/null || return 1
+    : > "$_ldt_jobs" 2>/dev/null || return 1
+    : > "$_ldt_map" 2>/dev/null || return 1
+
+    _ldt_batch_configs=0
+    _ldt_batch_scan_failed=0
+    _ldt_v28_configs=0
+    _ldt_v28_scan_failed=0
+    _ldt_v28_extra=0
+
+    # 3.x fast path: scan every captured XML in one interpreter and normalize the batch protocol
+    # into a common record stream. Any TARGET whose document cannot be resolved back to its
+    # partition is counted as a batch failure rather than disappearing from coverage accounting.
+    while IFS='|' read -r _ldt_key _ldt_real _ldt_overlay _ldt_font_dir; do
+        _ldt_input="$_ldt_backup/$_ldt_key"
+        [ -s "$_ldt_input" ] || continue
+        printf '%s\n' "$_ldt_input" >> "$_ldt_jobs"
+        printf '%s\t%s\t%s\n' "$_ldt_input" "$_ldt_key" "$_ldt_font_dir" >> "$_ldt_map"
+    done <<EOF_LUOSHU_HCF_BATCH
+$(_luoshu_font_config_specs)
+EOF_LUOSHU_HCF_BATCH
+
+    : > "$_ldt_out"
+    if [ -s "$_ldt_jobs" ]; then
+        _luoshu_font_config_exec "$_ldt_tool" --batch "$_ldt_jobs" > "$_ldt_out" 2>/dev/null || \
+            _ldt_batch_scan_failed=$((_ldt_batch_scan_failed + 1))
+    fi
+
+    _ldt_cur=''
+    _ldt_key=''
+    _ldt_font_dir=''
+    while IFS="$(printf '\t')" read -r _ldt_tag _ldt_input _ldt_a _ldt_b _ldt_c; do
+        case "$_ldt_tag" in
+            DOC)
+                if [ "$_ldt_a" = ok ]; then
+                    _ldt_batch_configs=$((_ldt_batch_configs + 1))
+                else
+                    _ldt_batch_scan_failed=$((_ldt_batch_scan_failed + 1))
+                fi
+                continue
+                ;;
+            TARGET) ;;
+            *) continue ;;
+        esac
+        if [ "$_ldt_input" != "$_ldt_cur" ]; then
+            _ldt_cur="$_ldt_input"
+            _ldt_key=$(awk -F'\t' -v k="$_ldt_input" '$1 == k { print $2; exit }' "$_ldt_map" 2>/dev/null)
+            _ldt_font_dir=$(awk -F'\t' -v k="$_ldt_input" '$1 == k { print $3; exit }' "$_ldt_map" 2>/dev/null)
+        fi
+        if [ -z "$_ldt_key" ] || [ -z "$_ldt_font_dir" ]; then
+            _ldt_batch_scan_failed=$((_ldt_batch_scan_failed + 1))
+            continue
+        fi
+        printf '%s\t%s\t%s\t%s\t%s\tbatch\n' \
+            "$_ldt_key" "$_ldt_font_dir" "$_ldt_a" "$_ldt_b" "$_ldt_c" >> "$_ldt_records"
+    done < "$_ldt_out"
+
+    # HyperOS coverage floor: replay the v2.8 per-document protocol and union its targets with the
+    # fast-path records. This intentionally costs a few extra interpreter starts on HyperOS only;
+    # it is the compatibility backstop for OEM XML/partition layouts that the batch protocol loses.
+    if [ "${IS_HYPEROS:-false}" = true ]; then
+        while IFS='|' read -r _ldt_key _ldt_real _ldt_overlay _ldt_font_dir; do
+            _ldt_input="$_ldt_backup/$_ldt_key"
+            [ -s "$_ldt_input" ] || continue
+            _ldt_legacy_out="$_ldt_config/.font-target-v28.$$.txt"
+            rm -f "$_ldt_legacy_out" 2>/dev/null || true
+            if ! _luoshu_font_config_exec "$_ldt_tool" --input "$_ldt_input" > "$_ldt_legacy_out" 2>/dev/null; then
+                _ldt_v28_scan_failed=$((_ldt_v28_scan_failed + 1))
+                rm -f "$_ldt_legacy_out" 2>/dev/null || true
+                continue
+            fi
+            _ldt_v28_configs=$((_ldt_v28_configs + 1))
+            while IFS='|' read -r _ldt_file _ldt_weight _ldt_family; do
+                [ -n "$_ldt_file" ] || continue
+                printf '%s\t%s\t%s\t%s\t%s\tv28\n' \
+                    "$_ldt_key" "$_ldt_font_dir" "$_ldt_file" "$_ldt_weight" "$_ldt_family" >> "$_ldt_records"
+            done < "$_ldt_legacy_out"
+            rm -f "$_ldt_legacy_out" 2>/dev/null || true
+        done <<EOF_LUOSHU_HCF_V28
+$(_luoshu_font_config_specs)
+EOF_LUOSHU_HCF_V28
+        _ldt_configs="$_ldt_v28_configs"
+        _ldt_scan_failed="$_ldt_v28_scan_failed"
+        _ldt_mode='hyperos-v28-union'
+    else
+        _ldt_configs="$_ldt_batch_configs"
+        _ldt_scan_failed="$_ldt_batch_scan_failed"
+        _ldt_mode='batch'
+    fi
+
+    # Materialize the union once. De-duplicate by final module-relative slot so batch + v2.8
+    # discovery never double-counts the same physical target.
+    _ldt_targets=0
+    _ldt_mapped=0
+    while IFS="$(printf '\t')" read -r _ldt_key _ldt_font_dir _ldt_file _ldt_weight _ldt_family _ldt_origin; do
+        [ -n "$_ldt_font_dir" ] && [ -n "$_ldt_file" ] || continue
+        case "$_ldt_file" in
+            */*|*'..'*|LuoShu-*.ttf|LuoShuMono-*.ttf) continue ;;
+            *.ttf|*.otf|*.ttc) ;;
+            *) continue ;;
+        esac
+        case "$_ldt_weight" in 100|200|300|400|500|600|700|800|900) ;; *) _ldt_weight=400 ;; esac
+        _ldt_rel="${_ldt_font_dir#$_ldt_module/}/$_ldt_file"
+        grep -Fqx "$_ldt_rel" "$_ldt_seen" 2>/dev/null && continue
+        printf '%s\n' "$_ldt_rel" >> "$_ldt_seen"
+        _ldt_targets=$((_ldt_targets + 1))
+        [ "$_ldt_origin" != v28 ] || _ldt_v28_extra=$((_ldt_v28_extra + 1))
+
+        _ldt_source="$_ldt_module/system/fonts/LuoShu-${_ldt_weight}.ttf"
+        _ldt_dest="$_ldt_font_dir/$_ldt_file"
+        _luoshu_hcf_font_ok "$_ldt_source" || continue
+        mkdir -p "$_ldt_font_dir" 2>/dev/null || continue
+        rm -f "$_ldt_dest" 2>/dev/null || true
+        if ln "$_ldt_source" "$_ldt_dest" 2>/dev/null || cp -f "$_ldt_source" "$_ldt_dest" 2>/dev/null; then
+            chmod 0644 "$_ldt_dest" 2>/dev/null || true
+            if _luoshu_hcf_font_ok "$_ldt_dest"; then
+                printf '%s|%s|%s|%s\n' "$_ldt_rel" "$_ldt_key" "$_ldt_weight" "$_ldt_family" >> "$_ldt_manifest_tmp"
+                _ldt_mapped=$((_ldt_mapped + 1))
+            else
+                rm -f "$_ldt_dest" 2>/dev/null || true
+            fi
+        fi
+    done < "$_ldt_records"
+
+    rm -f "$_ldt_jobs" "$_ldt_map" "$_ldt_out" "$_ldt_records" "$_ldt_seen" 2>/dev/null || true
+
+    if [ "$_ldt_mapped" -eq 0 ]; then
+        while IFS='|' read -r _ldt_rel _ldt_rest; do
+            rm -f "$_ldt_module/$_ldt_rel" 2>/dev/null || true
+        done < "$_ldt_manifest_tmp"
+        rm -f "$_ldt_manifest_tmp" "$_ldt_coverage_tmp" 2>/dev/null || true
+        _luoshu_safety_log ERROR "动态字体目标映射失败：mode=$_ldt_mode targets=$_ldt_targets mapped=0 scanFailed=$_ldt_scan_failed"
+        return 1
+    fi
+
+    if [ "$_ldt_mapped" -eq "$_ldt_targets" ] && [ "$_ldt_scan_failed" -eq 0 ]; then
+        _ldt_coverage_status=full
+    else
+        _ldt_coverage_status=partial
+    fi
+
+    {
+        printf 'configs=%s\n' "$_ldt_configs"
+        printf 'discovered=%s\n' "$_ldt_targets"
+        printf 'targets=%s\n' "$_ldt_targets"
+        printf 'mapped=%s\n' "$_ldt_mapped"
+        printf 'status=%s\n' "$_ldt_coverage_status"
+        printf 'scanFailed=%s\n' "$_ldt_scan_failed"
+        printf 'mode=%s\n' "$_ldt_mode"
+        printf 'batchConfigs=%s\n' "$_ldt_batch_configs"
+        printf 'batchScanFailed=%s\n' "$_ldt_batch_scan_failed"
+        printf 'v28Configs=%s\n' "$_ldt_v28_configs"
+        printf 'v28ScanFailed=%s\n' "$_ldt_v28_scan_failed"
+        printf 'fallbackAdded=%s\n' "$_ldt_v28_extra"
+        printf 'time=%s\n' "$(date +%s)"
+    } > "$_ldt_coverage_tmp" 2>/dev/null || return 1
+    mv -f "$_ldt_manifest_tmp" "$_ldt_config/font-target-aliases.conf" 2>/dev/null || return 1
+    mv -f "$_ldt_coverage_tmp" "$_ldt_config/font-target-coverage.conf" 2>/dev/null || return 1
+    chmod 0644 "$_ldt_config/font-target-aliases.conf" "$_ldt_config/font-target-coverage.conf" 2>/dev/null || true
+
+    [ "$_ldt_targets" -gt 0 ] || return 2
+    if [ "$_ldt_coverage_status" = full ]; then
+        if [ "${IS_HYPEROS:-false}" = true ]; then
+            _luoshu_safety_log INFO "HyperOS 已按 2.8 覆盖下限完整映射 $_ldt_mapped/$_ldt_targets 个 UI 字体目标（fallbackAdded=$_ldt_v28_extra）"
+        else
+            _luoshu_safety_log INFO "已按设备真实 XML 完整映射 $_ldt_mapped/$_ldt_targets 个 UI 字体目标"
+        fi
+        return 0
+    fi
+
+    if [ "${IS_HYPEROS:-false}" = true ]; then
+        _luoshu_safety_log ERROR "HyperOS 覆盖未达到 2.8 下限：targets=$_ldt_targets mapped=$_ldt_mapped scanFailed=$_ldt_scan_failed；拒绝把 partial 当成功"
+        return 1
+    fi
+    _luoshu_safety_log WARN "已按设备真实 XML 部分映射 $_ldt_mapped/$_ldt_targets 个 UI 字体目标"
+    return 0
+}

--- a/scripts/generic_xml_partial_coverage_test.sh
+++ b/scripts/generic_xml_partial_coverage_test.sh
@@ -24,6 +24,7 @@ CONFIG_DIR="$MOD/config"
 export MODULE_DIR MODDIR CONFIG_DIR
 
 . "$ROOT/common/font_safety.sh"
+. "$ROOT/common/hyperos_coverage_floor.sh"
 set -eu
 
 _luoshu_font_real_path() {
@@ -39,8 +40,8 @@ _luoshu_font_config_specs() {
 
 font_config_capture_original() { :; }
 
-# The scanner now runs as a single batch over every document, so the stub speaks the batch
-# protocol: one TARGET line per discovered slot, then one DOC status line per document.
+# Generic ROMs retain the existing batch behavior: one TARGET line per discovered slot, then one
+# DOC status line per document. Partial physical-slot installation is still reported honestly.
 _luoshu_font_config_exec() {
     _stub_jobs=''
     while [ "$#" -gt 0 ]; do
@@ -56,8 +57,10 @@ _luoshu_font_config_exec() {
 }
 
 _luoshu_safety_log() { :; }
+IS_HYPEROS=false
+export IS_HYPEROS
 
-# Deliberately make only Bad.ttf fail. Good.ttf must still commit as partial coverage.
+# Deliberately make only Bad.ttf fail. Good.ttf must still commit as partial coverage on generic ROMs.
 ln() {
     case "$2" in *Bad.ttf) return 1 ;; esac
     command ln "$@"
@@ -75,6 +78,7 @@ grep -qx 'discovered=2' "$MOD/config/font-target-coverage.conf"
 grep -qx 'targets=2' "$MOD/config/font-target-coverage.conf"
 grep -qx 'mapped=1' "$MOD/config/font-target-coverage.conf"
 grep -qx 'status=partial' "$MOD/config/font-target-coverage.conf"
+grep -qx 'mode=batch' "$MOD/config/font-target-coverage.conf"
 # scanFailed tracks XML discovery/parser failures, not target install failures.
 grep -qx 'scanFailed=0' "$MOD/config/font-target-coverage.conf"
 test "$(awk 'NF { n++ } END { print n+0 }' "$MOD/config/font-target-aliases.conf")" -eq 1
@@ -90,4 +94,71 @@ fi
 test ! -e "$MOD/config/font-target-coverage.conf"
 test ! -e "$MOD/config/font-target-aliases.conf"
 
-printf 'Generic XML partial coverage tests passed.\n'
+# HyperOS regression: simulate the 2.9+ batch protocol losing one otherwise valid UI target. The
+# v2.8 per-document path must be replayed, union the missing slot, and finish as full coverage.
+dd if=/dev/zero of="$MOD/system/fonts/LuoShu-400.ttf" bs=2048 count=1 2>/dev/null
+rm -f "$MOD/system/fonts/Good.ttf" "$MOD/system/fonts/Bad.ttf" "$MOD/system/fonts/Recovered.ttf"
+IS_HYPEROS=true
+export IS_HYPEROS
+
+ln() { command ln "$@"; }
+cp() { command cp "$@"; }
+
+_luoshu_font_config_exec() {
+    _stub_mode=''
+    _stub_value=''
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --batch) _stub_mode=batch; _stub_value="$2"; shift 2 ;;
+            --input) _stub_mode=input; _stub_value="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    case "$_stub_mode" in
+        batch)
+            while IFS= read -r _stub_input; do
+                [ -n "$_stub_input" ] || continue
+                printf 'TARGET\t%s\tGood.ttf\t400\tsans-serif\n' "$_stub_input"
+                printf 'DOC\t%s\tok\t1\t\n' "$_stub_input"
+            done < "$_stub_value"
+            ;;
+        input)
+            printf 'Good.ttf|400|sans-serif\n'
+            printf 'Recovered.ttf|400|sans-serif\n'
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+luoshu_dynamic_targets_apply
+
+grep -qx 'discovered=2' "$MOD/config/font-target-coverage.conf"
+grep -qx 'targets=2' "$MOD/config/font-target-coverage.conf"
+grep -qx 'mapped=2' "$MOD/config/font-target-coverage.conf"
+grep -qx 'status=full' "$MOD/config/font-target-coverage.conf"
+grep -qx 'scanFailed=0' "$MOD/config/font-target-coverage.conf"
+grep -qx 'mode=hyperos-v28-union' "$MOD/config/font-target-coverage.conf"
+grep -qx 'fallbackAdded=1' "$MOD/config/font-target-coverage.conf"
+test -s "$MOD/system/fonts/Good.ttf"
+test -s "$MOD/system/fonts/Recovered.ttf"
+
+# HyperOS must never silently accept partial coverage. If one union target cannot be installed, the
+# function returns failure and leaves status=partial diagnostics for the surrounding transaction.
+ln() {
+    case "$2" in *Recovered.ttf) return 1 ;; esac
+    command ln "$@"
+}
+cp() {
+    case "${3:-}" in *Recovered.ttf) return 1 ;; esac
+    command cp "$@"
+}
+if luoshu_dynamic_targets_apply; then
+    echo 'HyperOS partial coverage unexpectedly succeeded' >&2
+    exit 1
+fi
+grep -qx 'targets=2' "$MOD/config/font-target-coverage.conf"
+grep -qx 'mapped=1' "$MOD/config/font-target-coverage.conf"
+grep -qx 'status=partial' "$MOD/config/font-target-coverage.conf"
+grep -qx 'mode=hyperos-v28-union' "$MOD/config/font-target-coverage.conf"
+
+printf 'Generic XML partial coverage and HyperOS v2.8 floor tests passed.\n'

--- a/scripts/module_payload_manifest.txt
+++ b/scripts/module_payload_manifest.txt
@@ -68,6 +68,7 @@ common/font_runtime_policy.sh
 common/font_safety.sh
 common/font_validation_cache.sh
 common/font_switch_task.sh
+common/hyperos_coverage_floor.sh
 common/hyperos_global.sh
 common/luoshu_cli.sh
 common/luoshu_composite.sh


### PR DESCRIPTION
## 问题
HyperOS 在 v2.8.0 之后可能出现应用内字体覆盖不完整：2.9+ 将动态字体目标发现改为 batch 协议后，部分 XML/分区目标可能在 batch 解析或 input→font_dir 映射中丢失，而 partial coverage 仍可能沿后续链路继续。

## 修复
- 保留 3.x batch 扫描作为快路径。
- HyperOS 额外执行 v2.8 的逐 XML `--input` 扫描，并与 batch 结果取并集。
- 以最终模块相对字体槽位去重，避免重复映射/重复计数。
- HyperOS 的扫描健康度以 v2.8 逐 XML 路径为权威；batch 失败可被兼容路径恢复。
- 新增 `mode=hyperos-v28-union`、`batchScanFailed`、`v28ScanFailed`、`fallbackAdded` 诊断字段。
- HyperOS 最终若仍为 `partial`，直接返回失败，不再把不完整覆盖当成功。
- 不回退 v3.2.0 的 `--compact` 行框、九档字重、缓存和其它性能优化。

## 回归
扩展现有 `generic_xml_partial_coverage_test.sh`：
1. 非 HyperOS 保持原有 partial 语义；
2. 模拟 batch 少发现一个 HyperOS UI 槽位，验证 v2.8 路径补齐并得到 2/2 full；
3. 模拟 HyperOS 某槽位无法安装，验证 partial 必须返回失败。

`generic_xml_partial_coverage_test.sh` 已在 `scripts/check.sh` 常驻执行。