### PR TITLE
release: trigger guarded v3.3.0 replacement

### DIFF
--- a/RELEASE_NOTES_v3.3.0.md
+++ b/RELEASE_NOTES_v3.3.0.md
@@ -33,4 +33,4 @@
 
 ColorOS 16、HyperOS 3、Magisk、APatch 的完整真机矩阵仍保持 pending；本次稳定版由维护者明确授权放行，不伪造未执行的真机 PASS。
 
-<!-- release-trigger: replacement-v3.3.0-final -->
+<!-- release-trigger: replacement-v3.3.0-pr-merge -->


### PR DESCRIPTION
通过正常 PR merge 触发 `Publish signed release` 的最终 v3.3.0 替换流程。当前 main 已设置一次性强校验：仅允许旧标签 `d20db1d3a44657a112dc1bfa1c8e88af6eaa5c31` 被替换为已验证发布源 `0b05b6955bc6f49b4556189622302f5dcccfda02`。签名、完整源码检查、APK 证书、模块/App 一致性与发布就绪门禁全部通过后，最终发布步骤才删除旧 Release+Tag 并立即创建新的 v3.3.0。