### PR TITLE
fix(release): publish v3.3.0 when only the stale tag exists

### DIFF
--- a/.github/workflows/emergency-replace-v3.3.0.yml
+++ b/.github/workflows/emergency-replace-v3.3.0.yml
@@ -133,7 +133,15 @@ jobs:
           printf '%s\n' "$marker" | grep -qx 'status=pending'
           printf '%s\n' "$marker" | grep -qx "expectedOldTagSha=$OLD_TAG_SHA"
           printf '%s\n' "$marker" | grep -qx "releaseSourceSha=$SOURCE_SHA"
-          gh release delete "$TAG" --cleanup-tag --yes
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" --cleanup-tag --yes
+          else
+            git push origin ":refs/tags/$TAG"
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Old tag still exists after cleanup: $TAG" >&2
+            exit 5
+          fi
           gh release create "$TAG" \
             dist/LuoShu-v3.3.0.zip \
             dist/LuoShu-v3.3.0.zip.sha256 \


### PR DESCRIPTION
修复紧急 v3.3.0 发布事务：当旧标签存在、GitHub Release 不存在时，不再因 `gh release delete` 返回 `release not found` 直接失败；改为删除旧远程标签、确认标签已清理，再创建正式 Release。此前签名 APK、模块 ZIP、内嵌 APK 一致性与 SHA-256 校验均已通过。