### PR TITLE
fix: make v4.0.0 font apply and update safe

### DIFF
--- a/.github/workflows/runtime-update-safety.yml
+++ b/.github/workflows/runtime-update-safety.yml
@@ -29,10 +29,7 @@ jobs:
         run: sh scripts/v4_update_preserve_test.sh
       - name: Bounded 94 percent validation
         run: sh scripts/v4_fast_validate_test.sh
+      - name: Prepare bundled composite runtime
+        run: sh scripts/prepare_composite_runtime.sh
       - name: Complete repository source checks
-        run: |
-          if ! sh scripts/check.sh; then
-            echo 'source checks failed; rerunning with shell trace'
-            sh -x scripts/check.sh
-            exit 1
-          fi
+        run: sh scripts/check.sh

--- a/.github/workflows/runtime-update-safety.yml
+++ b/.github/workflows/runtime-update-safety.yml
@@ -30,4 +30,9 @@ jobs:
       - name: Bounded 94 percent validation
         run: sh scripts/v4_fast_validate_test.sh
       - name: Complete repository source checks
-        run: sh scripts/check.sh
+        run: |
+          if ! sh scripts/check.sh; then
+            echo 'source checks failed; rerunning with shell trace'
+            sh -x scripts/check.sh
+            exit 1
+          fi

--- a/.github/workflows/runtime-update-safety.yml
+++ b/.github/workflows/runtime-update-safety.yml
@@ -1,0 +1,33 @@
+name: Runtime update safety
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'common/**'
+      - 'customize.sh'
+      - 'scripts/**'
+      - '.github/workflows/runtime-update-safety.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-safety:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Shell syntax
+        run: |
+          sh -n common/font_validate_fast_v4.sh
+          sh -n common/module_update_hotfix_v4.sh
+          sh -n customize.sh
+          sh -n scripts/v4_update_preserve_test.sh
+          sh -n scripts/v4_fast_validate_test.sh
+      - name: Preserve selected font across update
+        run: sh scripts/v4_update_preserve_test.sh
+      - name: Bounded 94 percent validation
+        run: sh scripts/v4_fast_validate_test.sh
+      - name: Complete repository source checks
+        run: sh scripts/check.sh

--- a/common/font_config_partitions.sh
+++ b/common/font_config_partitions.sh
@@ -103,4 +103,6 @@ fi
 [ -f "$_luoshufp_module/common/mount_self_fallback.sh" ] && . "$_luoshufp_module/common/mount_self_fallback.sh"
 [ -f "$_luoshufp_module/common/mount_compat_policy.sh" ] && . "$_luoshufp_module/common/mount_compat_policy.sh"
 [ -f "$_luoshufp_module/common/device_font_payload_policy.sh" ] && . "$_luoshufp_module/common/device_font_payload_policy.sh"
+# Must load last: device_font_payload_policy.sh also overrides the validator.
+[ -f "$_luoshufp_module/common/font_validate_fast_v4.sh" ] && . "$_luoshufp_module/common/font_validate_fast_v4.sh"
 unset _luoshufp_module

--- a/common/font_validate_fast_v4.sh
+++ b/common/font_validate_fast_v4.sh
@@ -1,0 +1,157 @@
+#!/system/bin/sh
+# v4.0.0 foreground validation hotfix.
+# Keep the transactional/boot manifest safety contract, but do not re-run
+# embedded-Python validation for every XML and every hard-linked alias at 94%.
+set +e
+
+_luoshu_v4_font_ok() {
+    _lvf_file="$1"
+    if type _luoshu_fast_font_ok >/dev/null 2>&1; then
+        _luoshu_fast_font_ok "$_lvf_file"
+        return $?
+    fi
+    [ -f "$_lvf_file" ] || return 1
+    if command -v stat >/dev/null 2>&1; then
+        _lvf_size=$(stat -c '%s' "$_lvf_file" 2>/dev/null)
+    elif command -v toybox >/dev/null 2>&1; then
+        _lvf_size=$(toybox stat -c '%s' "$_lvf_file" 2>/dev/null)
+    else
+        _lvf_size=$(wc -c < "$_lvf_file" 2>/dev/null | tr -d '[:space:]')
+    fi
+    case "$_lvf_size" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$_lvf_size" -ge 1024 ]
+}
+
+_luoshu_v4_validate_xml_refs() {
+    _lvx_xml="$1"
+    _lvx_font_dir="$2"
+    [ -s "$_lvx_xml" ] || return 1
+    _lvx_refs=$(grep -oE 'LuoShu(Mono)?-[1-9][0-9][0-9]\.ttf' "$_lvx_xml" 2>/dev/null | sort -u)
+    [ -n "$_lvx_refs" ] || return 0
+    for _lvx_ref in $_lvx_refs; do
+        _luoshu_v4_font_ok "$_lvx_font_dir/$_lvx_ref" || return 1
+    done
+    return 0
+}
+
+luoshu_payload_validate_current() {
+    _lpv_active="${1:-unknown}"
+    _lpv_module="$(_luoshu_safety_module)"
+    _lpv_config="$(_luoshu_safety_config)"
+    [ "$_lpv_active" != default ] || return 0
+
+    # One verified anchor is enough to prove that the generated text payload exists.
+    # The dynamic target manifest below verifies every mapped alias without reading
+    # the same multi-megabyte inode repeatedly.
+    _lpv_anchor=''
+    for _lpv_candidate in \
+        "$_lpv_module/system/fonts/.luoshu-font-store/mix-composite.font" \
+        "$_lpv_module/system/fonts/LuoShu-400.ttf" \
+        "$_lpv_module/system/fonts/Roboto-Regular.ttf" \
+        "$_lpv_module/system/fonts/MiSansVF.ttf" \
+        "$_lpv_module/system/fonts/SysSans-Hans-Regular.ttf" \
+        "$_lpv_module/system/fonts/NotoSans-Regular.ttf"; do
+        if _luoshu_v4_font_ok "$_lpv_candidate"; then
+            _lpv_anchor="$_lpv_candidate"
+            break
+        fi
+    done
+    [ -n "$_lpv_anchor" ] || return 1
+
+    _lpv_coverage="$_lpv_config/font-target-coverage.conf"
+    _lpv_manifest="$_lpv_config/font-target-aliases.conf"
+    if [ -f "$_lpv_coverage" ]; then
+        _lpv_targets=$(sed -n 's/^targets=//p' "$_lpv_coverage" 2>/dev/null | head -n1)
+        _lpv_mapped=$(sed -n 's/^mapped=//p' "$_lpv_coverage" 2>/dev/null | head -n1)
+        _lpv_status=$(sed -n 's/^status=//p' "$_lpv_coverage" 2>/dev/null | head -n1)
+        case "$_lpv_targets" in ''|*[!0-9]*) return 1 ;; esac
+        case "$_lpv_mapped" in ''|*[!0-9]*) return 1 ;; esac
+        [ "$_lpv_mapped" -le "$_lpv_targets" ] || return 1
+        case "$_lpv_status" in
+            full) [ "$_lpv_mapped" -eq "$_lpv_targets" ] || return 1 ;;
+            partial) [ "$_lpv_mapped" -gt 0 ] && [ "$_lpv_mapped" -lt "$_lpv_targets" ] || return 1 ;;
+            '') [ "$_lpv_targets" -eq 0 ] || [ "$_lpv_mapped" -gt 0 ] || return 1 ;;
+            *) return 1 ;;
+        esac
+
+        if [ "$_lpv_mapped" -gt 0 ]; then
+            [ -s "$_lpv_manifest" ] || return 1
+            _lpv_count=$(awk 'NF { n++ } END { print n+0 }' "$_lpv_manifest" 2>/dev/null)
+            case "$_lpv_count" in ''|*[!0-9]*) return 1 ;; esac
+            [ "$_lpv_count" -eq "$_lpv_mapped" ] || return 1
+            while IFS='|' read -r _lpv_rel _lpv_key _lpv_weight _lpv_family; do
+                [ -n "$_lpv_rel" ] || continue
+                case "$_lpv_rel" in */fonts/*.ttf|*/fonts/*.otf|*/fonts/*.ttc) ;; *) return 1 ;; esac
+                _luoshu_v4_font_ok "$_lpv_module/$_lpv_rel" || return 1
+            done < "$_lpv_manifest"
+        fi
+    fi
+
+    # Stage 91 already generated and validated these XML files. At 94% only
+    # verify that each generated document still exists and every LuoShu font
+    # reference resolves to a real payload file. This is shell-only and bounded.
+    while IFS='|' read -r _lpv_key _lpv_real _lpv_overlay _lpv_font_dir; do
+        [ -f "$_lpv_overlay" ] || continue
+        grep -Eq 'LuoShu(Mono)?-[1-9][0-9][0-9]\.ttf' "$_lpv_overlay" 2>/dev/null || continue
+        _luoshu_v4_validate_xml_refs "$_lpv_overlay" "$_lpv_font_dir" || return 1
+    done <<EOF_LUOSHU_V4_VALIDATE
+$(_luoshu_font_config_specs)
+EOF_LUOSHU_V4_VALIDATE
+
+    LUOSHU_PAYLOAD_VALIDATED_ACTIVE="$_lpv_active"
+    return 0
+}
+
+# A boot quarantine must remove the unsafe generated payload, but it must not
+# destroy the user's selected font. Selection and effective boot state are
+# separate concepts; the App can keep showing what the user selected.
+luoshu_payload_quarantine() {
+    _lpq_module="$(_luoshu_safety_module)"
+    _lpq_config="$(_luoshu_safety_config)"
+    _lpq_selected=$(head -n1 "$_lpq_config/active_font.conf" 2>/dev/null | tr -d '\r\n')
+    [ -n "$_lpq_selected" ] || _lpq_selected=default
+    _lpq_fail=$(cat "$_lpq_config/font-boot-failures" 2>/dev/null)
+    case "$_lpq_fail" in ''|*[!0-9]*) _lpq_fail=0 ;; esac
+    _lpq_fail=$((_lpq_fail + 1))
+    printf '%s\n' "$_lpq_fail" > "$_lpq_config/font-boot-failures" 2>/dev/null || true
+
+    for _lpq_part in $(_luoshu_payload_parts); do
+        rm -rf "$_lpq_module/$_lpq_part/fonts" 2>/dev/null || true
+        _lpq_etc="$_lpq_module/$_lpq_part/etc"
+        [ -d "$_lpq_etc" ] || continue
+        for _lpq_xml in "$_lpq_etc"/*.xml; do
+            [ -f "$_lpq_xml" ] || continue
+            grep -Eq 'LuoShu(Mono)?-' "$_lpq_xml" 2>/dev/null && rm -f "$_lpq_xml" 2>/dev/null || true
+        done
+    done
+    if type luoshu_meta_content_roots >/dev/null 2>&1; then
+        for _lpq_root in $(luoshu_meta_content_roots); do
+            [ -d "$_lpq_root" ] || continue
+            for _lpq_part in $(_luoshu_payload_parts); do
+                rm -rf "$_lpq_root/$_lpq_part/fonts" 2>/dev/null || true
+                _lpq_etc="$_lpq_root/$_lpq_part/etc"
+                [ -d "$_lpq_etc" ] || continue
+                for _lpq_xml in "$_lpq_etc"/*.xml; do
+                    [ -f "$_lpq_xml" ] || continue
+                    grep -Eq 'LuoShu(Mono)?-' "$_lpq_xml" 2>/dev/null && rm -f "$_lpq_xml" 2>/dev/null || true
+                done
+            done
+        done
+    fi
+
+    # Preserve active_font.conf; only clear generated/effective payload state.
+    rm -f "$_lpq_config/font-payload-boot.conf" "$_lpq_config/font-payload-manifest.conf" \
+          "$_lpq_config/font-payload-schema.conf" "$_lpq_config/font-payload-rebuild-pending.conf" \
+          "$_lpq_config/font-payload-reapply-notified.conf" \
+          "$_lpq_config/font-target-aliases.conf" "$_lpq_config/font-target-coverage.conf" \
+          "$_lpq_config/font-config-overlay.conf" "$_lpq_config/text_reboot_required.conf" \
+          "$_lpq_config/font-boot-inconclusive.conf" "$_lpq_config/font-mount-verify-failures" 2>/dev/null || true
+    {
+        printf 'state=quarantined\n'
+        printf 'selectedFont=%s\n' "$_lpq_selected"
+        printf 'effectiveFont=stock\n'
+        printf 'failures=%s\n' "$_lpq_fail"
+        printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
+    } > "$_lpq_config/font-payload-quarantine.conf" 2>/dev/null || true
+    _luoshu_safety_log ERROR "检测到字体负载启动校验失败，已撤销生成负载但保留用户字体选择（failure=$_lpq_fail）"
+}

--- a/common/module_update_hotfix_v4.sh
+++ b/common/module_update_hotfix_v4.sh
@@ -1,0 +1,132 @@
+#!/system/bin/sh
+# v4.0.0 update migration hotfix.
+# Never turn an update into "restore default". Preserve the selected font and
+# rebuild incompatible payloads inside the staged module before the update commits.
+set +e
+
+luoshu_v4_clear_incompatible_payload() {
+    _lvc_module="$1"
+    rm -rf "$_lvc_module/system/fonts" 2>/dev/null || true
+    mkdir -p "$_lvc_module/system/fonts" 2>/dev/null || return 1
+    rm -f "$_lvc_module/system/etc/fonts.xml" \
+          "$_lvc_module/system/etc/font_fallback.xml" 2>/dev/null || true
+    for _lvc_part in $(luoshu_update_payload_partitions); do
+        [ "$_lvc_part" != system ] || continue
+        rm -rf "$_lvc_module/$_lvc_part" 2>/dev/null || true
+    done
+    rm -rf "$_lvc_module/config/device-font-cache" \
+           "$_lvc_module/.font-payload-stage."* \
+           "$_lvc_module/.font-payload-backup."* 2>/dev/null || true
+    rm -f "$_lvc_module/.font-payload-commit.ok" \
+          "$_lvc_module/config/font-payload-schema.conf" \
+          "$_lvc_module/config/font-payload-manifest.conf" \
+          "$_lvc_module/config/font-payload-boot.conf" \
+          "$_lvc_module/config/font-target-aliases.conf" \
+          "$_lvc_module/config/font-target-coverage.conf" \
+          "$_lvc_module/config/font-config-overlay.conf" 2>/dev/null || true
+    return 0
+}
+
+# Override the legacy migrator after module_update_state.sh is loaded.
+luoshu_migrate_active_install() {
+    _lvm_old="$1"
+    _lvm_new="$2"
+    [ -f "$_lvm_old/module.prop" ] || return 2
+    [ "$_lvm_old" != "$_lvm_new" ] || return 2
+
+    _lvm_active=$(head -n1 "$_lvm_old/config/active_font.conf" 2>/dev/null | tr -d '\r\n')
+    [ -n "$_lvm_active" ] || _lvm_active=default
+    _lvm_old_schema=$(luoshu_update_payload_schema "$_lvm_old")
+    _lvm_compatible=false
+    [ -n "$_lvm_old_schema" ] && [ "$_lvm_old_schema" = "$LUOSHU_PAYLOAD_SCHEMA_CURRENT" ] && _lvm_compatible=true
+    if [ "$_lvm_active" != default ] && ! luoshu_update_has_font_payload "$_lvm_old"; then
+        _lvm_compatible=false
+    fi
+
+    LUOSHU_UPDATE_ACTIVE="$_lvm_active"
+    LUOSHU_UPDATE_OLD_SCHEMA="$_lvm_old_schema"
+    LUOSHU_UPDATE_REBUILD_REQUIRED=false
+    LUOSHU_UPDATE_PAYLOAD_PRESERVED=false
+    [ "$_lvm_active" = default ] || [ "$_lvm_compatible" = true ] || LUOSHU_UPDATE_REBUILD_REQUIRED=true
+
+    mkdir -p "$_lvm_new/config" "$_lvm_new/system/fonts" 2>/dev/null || return 1
+    luoshu_migrate_update_config "$_lvm_old" "$_lvm_new" || return 1
+
+    if [ "$_lvm_active" != default ] && [ "$_lvm_compatible" = true ]; then
+        for _lvm_rel in system/fonts system/etc; do
+            [ -d "$_lvm_old/$_lvm_rel" ] || continue
+            rm -rf "$_lvm_new/$_lvm_rel" 2>/dev/null || return 1
+            mkdir -p "${_lvm_new}/${_lvm_rel%/*}" 2>/dev/null || return 1
+            luoshu_copy_update_tree "$_lvm_old/$_lvm_rel" "$_lvm_new/$_lvm_rel" || return 1
+        done
+        for _lvm_part in $(luoshu_update_payload_partitions); do
+            [ "$_lvm_part" != system ] || continue
+            [ -d "$_lvm_old/$_lvm_part" ] || continue
+            rm -rf "$_lvm_new/$_lvm_part" 2>/dev/null || return 1
+            luoshu_copy_update_tree "$_lvm_old/$_lvm_part" "$_lvm_new/$_lvm_part" || return 1
+        done
+        LUOSHU_UPDATE_PAYLOAD_PRESERVED=true
+    else
+        luoshu_v4_clear_incompatible_payload "$_lvm_new" || return 1
+    fi
+
+    luoshu_migrate_update_cache "$_lvm_old" "$_lvm_new" "$_lvm_compatible"
+    luoshu_clear_update_volatile "$_lvm_new"
+
+    # active_font.conf is selection state, never an "effective stock" flag.
+    printf '%s\n' "$_lvm_active" > "$_lvm_new/config/active_font.conf" || return 1
+    chmod 0644 "$_lvm_new/config/active_font.conf" 2>/dev/null || true
+
+    if [ "$LUOSHU_UPDATE_REBUILD_REQUIRED" = true ]; then
+        {
+            printf 'state=install-rebuild-required\n'
+            printf 'mode=preserve-selection\n'
+            printf 'reason=schema-mismatch\n'
+            printf 'font=%s\n' "$_lvm_active"
+            printf 'oldSchema=%s\n' "${_lvm_old_schema:-missing}"
+            printf 'newSchema=%s\n' "$LUOSHU_PAYLOAD_SCHEMA_CURRENT"
+            printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
+        } > "$_lvm_new/config/font-payload-rebuild-pending.conf" 2>/dev/null || return 1
+    fi
+
+    find "$_lvm_new/config" -type d -exec chmod 0755 {} \; 2>/dev/null || true
+    find "$_lvm_new/config" -type f -exec chmod 0644 {} \; 2>/dev/null || true
+    return 0
+}
+
+luoshu_v4_update_rebuild_selected() {
+    _lvr_module="$1"
+    _lvr_active=$(head -n1 "$_lvr_module/config/active_font.conf" 2>/dev/null | tr -d '\r\n')
+    [ -n "$_lvr_active" ] || _lvr_active=default
+    [ "$_lvr_active" != default ] || return 0
+
+    rm -f "$_lvr_module/config/text_reboot_required.conf" \
+          "$_lvr_module/config/switch_task.conf" \
+          "$_lvr_module/config/mix_task.conf" \
+          "$_lvr_module/.font_switch.lock" 2>/dev/null || true
+    rm -rf "$_lvr_module/.font_switch.lock" 2>/dev/null || true
+
+    _lvr_started=$(date +%s 2>/dev/null || echo 0)
+    if [ "$_lvr_active" = mix ]; then
+        _lvr_conf="$_lvr_module/config/font_mix.conf"
+        _lvr_cjk=$(sed -n 's/^cjk=//p' "$_lvr_conf" 2>/dev/null | head -n1 | tr -d '\r\n')
+        _lvr_latin=$(sed -n 's/^latin=//p' "$_lvr_conf" 2>/dev/null | head -n1 | tr -d '\r\n')
+        _lvr_digit=$(sed -n 's/^digit=//p' "$_lvr_conf" 2>/dev/null | head -n1 | tr -d '\r\n')
+        [ -n "$_lvr_cjk" ] && [ -n "$_lvr_latin" ] && [ -n "$_lvr_digit" ] || return 1
+        MODDIR="$_lvr_module" sh "$_lvr_module/common/font_mix.sh" worker \
+            "update-rebuild-${_lvr_started}-$$" "$_lvr_cjk" "$_lvr_latin" "$_lvr_digit" "$_lvr_started" \
+            >> "$_lvr_module/logs/fontswitch.log" 2>&1
+        _lvr_state=$(sed -n 's/^state=//p' "$_lvr_module/config/mix_task.conf" 2>/dev/null | head -n1)
+        [ "$_lvr_state" = success ] || return 1
+    else
+        _lvr_output=$(MODDIR="$_lvr_module" sh "$_lvr_module/common/font_manager.sh" action switch "$_lvr_active" 2>&1)
+        printf '%s\n' "$_lvr_output" >> "$_lvr_module/logs/fontswitch.log" 2>/dev/null || true
+        printf '%s\n' "$_lvr_output" | grep -q '"status":"ok"' || return 1
+    fi
+
+    _lvr_after=$(head -n1 "$_lvr_module/config/active_font.conf" 2>/dev/null | tr -d '\r\n')
+    [ "$_lvr_after" = "$_lvr_active" ] || return 1
+    rm -f "$_lvr_module/config/font-payload-rebuild-pending.conf" \
+          "$_lvr_module/config/font-payload-reapply-notified.conf" 2>/dev/null || true
+    return 0
+}

--- a/customize.sh
+++ b/customize.sh
@@ -2,7 +2,8 @@
 # LuoShu v2.3.0 installer wrapper: run the verified installer, then hide every
 # standard partition payload before the first boot.
 # Delegated core contract: module_update_state.sh records upgrade migration.
-# User contract retained by the delegated core: 后台不改写字体，只在明确应用时提交。
+# User contract: updates preserve the selected font; incompatible payloads are
+# rebuilt before commit and never converted into a default-font update.
 # Delegated inventory output: 原厂字体文件
 # Delegated slot summary: XML 与 OEM 探测
 set +e
@@ -11,9 +12,11 @@ LUOSHU_OLD_MOD="${LUOSHU_OLD_MOD:-/data/adb/modules/LuoShu}"
 _lc_source_dir=$(CDPATH= cd -- "${0%/*}" 2>/dev/null && pwd)
 _lc_base="$MODPATH/.luoshu-runtime/customize-v227.sh"
 _lc_helper="$MODPATH/common/private_payload.sh"
+_lc_update_hotfix="$MODPATH/common/module_update_hotfix_v4.sh"
 [ -f "$_lc_base" ] || _lc_base="$_lc_source_dir/.luoshu-runtime/customize-v227.sh"
 [ -f "$_lc_helper" ] || _lc_helper="$_lc_source_dir/common/private_payload.sh"
 _lc_temp="$MODPATH/.customize-v227.$$.sh"
+_lc_patched="$MODPATH/.customize-v227.patched.$$.sh"
 [ -f "$_lc_helper" ] && . "$_lc_helper"
 
 # Existing private-payload installations are exposed only for the duration of
@@ -28,16 +31,46 @@ fi
 # rm -f "$_enable_dir/disable"
 # luoshu_cli.sh is deployed to system/bin/洛书 by the verified installer.
 [ -f "$_lc_base" ] || abort '缺少洛书安装核心'
+[ -f "$_lc_update_hotfix" ] || abort '缺少洛书 v4 更新迁移修复'
 sed '$d' "$_lc_base" > "$_lc_temp" 2>/dev/null || abort '安装入口准备失败'
+
+# The delegated installer sources module_update_state.sh itself. Inject the v4
+# override immediately after that source line so the old migrator can never
+# relabel an update as default or inherit an incompatible generated payload.
+awk -v hotfix="$_lc_update_hotfix" '
+{
+    print
+    if (index($0, "common/module_update_state.sh") && index($0, "&& .")) {
+        print "[ -f \"" hotfix "\" ] && . \"" hotfix "\""
+    }
+}
+' "$_lc_temp" > "$_lc_patched" 2>/dev/null || abort '更新迁移入口准备失败'
+mv -f "$_lc_patched" "$_lc_temp" 2>/dev/null || abort '更新迁移入口提交失败'
+grep -q 'module_update_hotfix_v4.sh' "$_lc_temp" 2>/dev/null || abort '更新迁移修复未载入'
+
 . "$_lc_temp"
 _lc_rc=$?
-rm -f "$_lc_temp" 2>/dev/null || true
+rm -f "$_lc_temp" "$_lc_patched" 2>/dev/null || true
 luoshu_private_unmount_module_view "$LUOSHU_OLD_MOD" >/dev/null 2>&1 || true
 if [ "$_lc_rc" -ne 0 ]; then
     # APatch sources customize.sh into its installer process. Returning here keeps
     # the manager's commit phase alive; direct execution still exits with the
     # delegated installer's status.
     return "$_lc_rc" 2>/dev/null || exit "$_lc_rc"
+fi
+
+# A schema boundary is rebuilt in the staged new module before root manager commit.
+# If the new engine cannot reproduce the selected font, abort the update so the
+# currently installed module/font remains untouched after reboot.
+if [ "${LUOSHU_UPDATE_REBUILD_REQUIRED:-false}" = true ]; then
+    ui_print '• 字体负载架构已变化，正在按当前选择自动重建...'
+    if ! type luoshu_v4_update_rebuild_selected >/dev/null 2>&1; then
+        abort '更新重建器未载入；已拒绝提交本次更新'
+    fi
+    if ! luoshu_v4_update_rebuild_selected "$MODPATH"; then
+        abort '当前字体无法用新版引擎安全重建；已拒绝提交本次更新，旧版字体保持不变'
+    fi
+    ui_print '✓ 当前字体已按新版引擎重建，未切换为系统默认字体'
 fi
 
 if ! luoshu_private_install_migrate "$MODPATH"; then

--- a/scripts/module_payload_manifest.txt
+++ b/scripts/module_payload_manifest.txt
@@ -59,6 +59,7 @@ common/font_mix.sh
 common/font_mix_controller.sh
 common/font_name_normalize.py
 common/font_provider_cache.sh
+common/font_validate_fast_v4.sh
 common/google_font_provider_bridge.sh
 common/google_font_provider_patch.py
 common/google_font_provider_service.sh
@@ -76,6 +77,7 @@ common/luoshu_composite.sh
 common/mix_task_handoff.sh
 common/mix_weight_mode.sh
 common/module_status.sh
+common/module_update_hotfix_v4.sh
 common/module_update_state.sh
 common/private_payload.sh
 common/private_mount_policy.sh

--- a/scripts/v4_fast_validate_test.sh
+++ b/scripts/v4_fast_validate_test.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t luoshu-v4-validate)
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+MOD="$TMP/module"
+mkdir -p "$MOD/system/fonts/.luoshu-font-store" "$MOD/system/etc" "$MOD/config"
+dd if=/dev/zero of="$MOD/system/fonts/.luoshu-font-store/mix-composite.font" bs=2048 count=1 2>/dev/null
+ln "$MOD/system/fonts/.luoshu-font-store/mix-composite.font" "$MOD/system/fonts/LuoShu-400.ttf"
+
+# 120 aliases share one inode. The foreground validator must use metadata only.
+: > "$MOD/config/font-target-aliases.conf"
+i=1
+while [ "$i" -le 120 ]; do
+    name=$(printf 'Alias%03d.ttf' "$i")
+    ln "$MOD/system/fonts/.luoshu-font-store/mix-composite.font" "$MOD/system/fonts/$name"
+    printf 'system/fonts/%s|system/fonts.xml|400|Test\n' "$name" >> "$MOD/config/font-target-aliases.conf"
+    i=$((i + 1))
+done
+cat > "$MOD/config/font-target-coverage.conf" <<'EOF'
+targets=120
+mapped=120
+status=full
+EOF
+cat > "$MOD/system/etc/fonts.xml" <<'EOF'
+<familyset><family name="sans"><font weight="400">LuoShu-400.ttf</font></family></familyset>
+EOF
+printf 'mix\n' > "$MOD/config/active_font.conf"
+
+MODULE_DIR="$MOD"
+MODDIR="$MOD"
+export MODULE_DIR MODDIR
+_luoshu_safety_module() { printf '%s\n' "$MOD"; }
+_luoshu_safety_config() { printf '%s/config\n' "$MOD"; }
+_luoshu_payload_parts() { printf '%s\n' system; }
+_luoshu_font_config_specs() {
+    printf 'system/fonts.xml|/system/etc/fonts.xml|%s/system/etc/fonts.xml|%s/system/fonts\n' "$MOD" "$MOD"
+}
+_luoshu_fast_font_ok() {
+    [ -f "$1" ] || return 1
+    size=$(stat -c '%s' "$1" 2>/dev/null || wc -c < "$1")
+    [ "$size" -ge 1024 ]
+}
+_luoshu_safety_log() { :; }
+luoshu_meta_content_roots() { return 0; }
+# Old 94% code invoked this embedded-Python path for every XML. Any call is a failure here.
+_luoshu_font_config_validate() { echo 'heavy XML validator was called' >&2; return 99; }
+
+. "$ROOT/common/font_validate_fast_v4.sh"
+luoshu_payload_validate_current mix
+[ "$LUOSHU_PAYLOAD_VALIDATED_ACTIVE" = mix ]
+
+# Quarantine removes generated payload but keeps selection instead of relabeling it default.
+printf 'mix\n' > "$MOD/config/active_font.conf"
+luoshu_payload_quarantine
+[ "$(cat "$MOD/config/active_font.conf")" = mix ]
+grep -q '^selectedFont=mix$' "$MOD/config/font-payload-quarantine.conf"
+grep -q '^effectiveFont=stock$' "$MOD/config/font-payload-quarantine.conf"
+
+echo 'v4 fast validate test: ok'

--- a/scripts/v4_update_preserve_test.sh
+++ b/scripts/v4_update_preserve_test.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t luoshu-v4-update)
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+OLD="$TMP/old"
+NEW="$TMP/new"
+mkdir -p "$OLD/config" "$OLD/system/fonts" "$OLD/vendor/fonts" "$NEW/config" "$NEW/system/fonts"
+printf 'id=LuoShu\nversion=v4.0.0\nversionCode=40000\n' > "$OLD/module.prop"
+printf 'id=LuoShu\nversion=v4.0.0\nversionCode=40000\n' > "$NEW/module.prop"
+printf 'mix\n' > "$OLD/config/active_font.conf"
+printf 'cjk=CJK\nlatin=Latin\ndigit=Digit\n' > "$OLD/config/font_mix.conf"
+printf 'schema=old-incompatible-schema\n' > "$OLD/config/font-payload-schema.conf"
+dd if=/dev/zero of="$OLD/system/fonts/Roboto-Regular.ttf" bs=2048 count=1 2>/dev/null
+dd if=/dev/zero of="$OLD/vendor/fonts/BadBoot.ttf" bs=2048 count=1 2>/dev/null
+
+LUOSHU_PAYLOAD_SCHEMA_CURRENT='new-safe-schema'
+export LUOSHU_PAYLOAD_SCHEMA_CURRENT
+. "$ROOT/common/module_update_state.sh"
+. "$ROOT/common/module_update_hotfix_v4.sh"
+
+luoshu_migrate_active_install "$OLD" "$NEW"
+[ "$(cat "$NEW/config/active_font.conf")" = mix ]
+[ "$LUOSHU_UPDATE_REBUILD_REQUIRED" = true ]
+[ ! -f "$NEW/system/fonts/Roboto-Regular.ttf" ]
+[ ! -f "$NEW/vendor/fonts/BadBoot.ttf" ]
+grep -q '^mode=preserve-selection$' "$NEW/config/font-payload-rebuild-pending.conf"
+grep -q '^font=mix$' "$NEW/config/font-payload-rebuild-pending.conf"
+
+# Same-schema migration still preserves an already validated payload.
+rm -rf "$NEW"
+mkdir -p "$NEW/config" "$NEW/system/fonts"
+printf 'id=LuoShu\nversion=v4.0.0\nversionCode=40000\n' > "$NEW/module.prop"
+printf 'schema=%s\n' "$LUOSHU_PAYLOAD_SCHEMA_CURRENT" > "$OLD/config/font-payload-schema.conf"
+luoshu_migrate_active_install "$OLD" "$NEW"
+[ "$(cat "$NEW/config/active_font.conf")" = mix ]
+[ "$LUOSHU_UPDATE_REBUILD_REQUIRED" = false ]
+[ -s "$NEW/system/fonts/Roboto-Regular.ttf" ]
+[ -s "$NEW/vendor/fonts/BadBoot.ttf" ]
+
+grep -q 'luoshu_v4_update_rebuild_selected' "$ROOT/customize.sh"
+grep -q '未切换为系统默认字体' "$ROOT/customize.sh"
+! grep -q "printf 'default\\n'.*active_font.conf" "$ROOT/customize.sh"
+
+echo 'v4 update preserve test: ok'


### PR DESCRIPTION
## 修复目标

保持版本号 v4.0.0，不发布 v4.0.1。

- 修复复合字体卡在 94%：前台最终校验不再对大量硬链接字体别名和每份 XML 重复启动重型验证，只校验真实锚点、动态别名存在/大小和 XML 引用；98% 事务 manifest 与开机轻量校验仍保留。
- 更新时绝不把 `active_font.conf` 改成 `default`。
- payload schema 不兼容时不继承旧生成负载，但保留当前字体选择和复合字体配置。
- 在 Root 管理器提交更新前自动按新版引擎重建当前选择；重建失败则拒绝这次更新，旧模块/旧字体继续保留。
- 启动隔离只撤销不安全 payload，不再抹掉用户字体选择。

## 回归

- `scripts/v4_update_preserve_test.sh`：模拟跨 schema 更新，确认选择保持、危险旧负载不继承。
- `scripts/v4_fast_validate_test.sh`：120 个硬链接别名 + XML，确认 94% 路径不调用重型 XML validator。
- Runtime update safety workflow 同时跑完整 `scripts/check.sh`。
