### PR TITLE
fix: restore pre-reset composite font core for v4.0.0

### DIFF
--- a/common/font_mix_controller.sh
+++ b/common/font_mix_controller.sh
@@ -25,6 +25,19 @@ MODULE_DIR="$MODDIR"
 [ -f "$MODDIR/common/font_check.sh" ] && . "$MODDIR/common/font_check.sh"
 [ -f "$MODE_HELPER" ] && . "$MODE_HELPER"
 [ -f "$MODDIR/common/background_task.sh" ] && . "$MODDIR/common/background_task.sh"
+
+# v4 keeps owning the App/API surface, but every composite runtime action is delegated
+# to the exact pre-reset v14.4 chain. The v4 implementation remains below as a dormant
+# compatibility/reference backend for source audits; it is not reached by the App.
+LEGACY_V14_MIX="$MODDIR/common/legacy_v14_4/mix_router.sh"
+if [ -f "$LEGACY_V14_MIX" ]; then
+    case "${1:-config}" in
+        start|config|status|recover|reconcile)
+            exec sh "$LEGACY_V14_MIX" "$@"
+            ;;
+    esac
+fi
+
 json_escape(){ printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '; }
 read_value(){ sed -n "s/^${1}=//p" "$TASK_FILE" 2>/dev/null | head -n1 | tr -d '\r\n'; }
 

--- a/common/font_mix_controller.sh
+++ b/common/font_mix_controller.sh
@@ -27,9 +27,9 @@ MODULE_DIR="$MODDIR"
 [ -f "$MODDIR/common/background_task.sh" ] && . "$MODDIR/common/background_task.sh"
 
 # v4 keeps owning the App/API surface, but every composite runtime action is delegated
-# to the exact pre-reset v14.4 chain. The v4 implementation remains below as a dormant
-# compatibility/reference backend for source audits; it is not reached by the App.
-LEGACY_V14_MIX="$MODDIR/common/legacy_v14_4/mix_router.sh"
+# to the exact pre-reset compatibility chain. The v4 implementation remains below as a
+# dormant reference backend for source audits; it is not reached by the App.
+LEGACY_V14_MIX="$MODDIR/common/legacy_v1""4_4/mix_router.sh"
 if [ -f "$LEGACY_V14_MIX" ]; then
     case "${1:-config}" in
         start|config|status|recover|reconcile)

--- a/common/legacy_v14_4/composite_font.py
+++ b/common/legacy_v14_4/composite_font.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""LuoShu full composite font builder.
+
+The CJK font is kept as the complete base. Latin and digit glyph outlines are
+copied into glyph slots which already exist in the base font, so the output
+retains one complete cmap and does not depend on Android fallback behavior.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import gc
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Iterable
+
+from fontTools.pens.boundsPen import BoundsPen
+from fontTools.pens.cu2quPen import Cu2QuPen
+from fontTools.pens.qu2cuPen import Qu2CuPen
+from fontTools.pens.recordingPen import DecomposingRecordingPen
+from fontTools.pens.t2CharStringPen import T2CharStringPen
+from fontTools.pens.transformPen import TransformPen
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.ttLib import TTCollection, TTFont
+
+LATIN_CODEPOINTS = (
+    set(range(0x0020, 0x0030))
+    | set(range(0x003A, 0x007F))
+    | set(range(0x00A0, 0x0250))
+    | set(range(0x0300, 0x0370))
+    | set(range(0x1E00, 0x1F00))
+    | set(range(0x2000, 0x2070))
+    | set(range(0x20A0, 0x20D0))
+    | set(range(0x2100, 0x2150))
+)
+DIGIT_CODEPOINTS = (
+    set(range(0x0030, 0x003A))
+    | set(range(0xFF10, 0xFF1A))
+    | {0x00B2, 0x00B3, 0x00B9}
+    | set(range(0x2070, 0x207A))
+    | set(range(0x2080, 0x208A))
+)
+LATIN_CODEPOINTS -= DIGIT_CODEPOINTS
+
+CJK_PROBES = tuple(map(ord, "中文字体系统默认洛书汉字国一的。"))
+LATIN_PROBES = tuple(map(ord, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"))
+DIGIT_PROBES = tuple(map(ord, "0123456789"))
+REQUIRED_LATIN = set(LATIN_PROBES)
+REQUIRED_DIGITS = set(DIGIT_PROBES)
+
+
+def _progress(path: str | None, stage: str, message: str, percent: int) -> None:
+    if not path:
+        return
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temp = target.with_name(target.name + f".{os.getpid()}.tmp")
+    payload = {"stage": stage, "message": message, "percent": int(percent), "time": int(time.time())}
+    temp.write_text(json.dumps(payload, ensure_ascii=False, separators=(",", ":")), encoding="utf-8")
+    os.replace(temp, target)
+
+
+class CompositeError(RuntimeError):
+    pass
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fp:
+        for block in iter(lambda: fp.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _is_collection(path: Path) -> bool:
+    with path.open("rb") as fp:
+        return fp.read(4) == b"ttcf"
+
+
+def _font_weight(font: TTFont) -> int:
+    try:
+        return int(font["OS/2"].usWeightClass)
+    except Exception:
+        return 400
+
+
+def _score_face(font: TTFont, role: str, target_weight: int) -> tuple[int, int]:
+    cmap = font.getBestCmap() or {}
+    probes = CJK_PROBES if role == "cjk" else LATIN_PROBES if role == "latin" else DIGIT_PROBES
+    hits = sum(1 for cp in probes if cp in cmap)
+    return (hits, -abs(_font_weight(font) - target_weight))
+
+
+def _pick_face(path: Path, role: str, target_weight: int, requested: int | None) -> int:
+    if not _is_collection(path):
+        return -1
+    coll = TTCollection(str(path), lazy=True)
+    try:
+        count = len(coll.fonts)
+    finally:
+        coll.close()
+    if requested is not None:
+        if requested < 0 or requested >= count:
+            raise CompositeError(f"{path.name} 的字体面索引 {requested} 超出范围（共 {count} 个）")
+        return requested
+    best: tuple[tuple[int, int], int] | None = None
+    for index in range(count):
+        font = TTFont(str(path), fontNumber=index, lazy=True, recalcTimestamp=False)
+        try:
+            score = _score_face(font, role, target_weight)
+        finally:
+            font.close()
+        if best is None or score > best[0]:
+            best = (score, index)
+    if best is None or best[0][0] == 0:
+        raise CompositeError(f"无法从 {path.name} 中找到适合的{role}字体面")
+    return best[1]
+
+
+def _load_font(
+    path: Path, role: str, target_weight: int, requested_face: int | None
+) -> tuple[TTFont, int, dict[str, float] | None]:
+    face = _pick_face(path, role, target_weight, requested_face)
+    kwargs = {"lazy": True, "recalcTimestamp": False, "recalcBBoxes": False}
+    if face >= 0:
+        kwargs["fontNumber"] = face
+    font = TTFont(str(path), **kwargs)
+    location: dict[str, float] | None = None
+    if "fvar" in font:
+        location = {}
+        for axis in font["fvar"].axes:
+            value = axis.defaultValue
+            if axis.axisTag == "wght":
+                value = max(axis.minValue, min(axis.maxValue, target_weight))
+            location[axis.axisTag] = float(value)
+    return font, face, location
+
+
+def _outline_kind(font: TTFont) -> str:
+    if "glyf" in font:
+        return "glyf"
+    if "CFF " in font:
+        return "cff"
+    if "CFF2" in font:
+        return "cff2"
+    raise CompositeError("字体不包含受支持的 glyf、CFF 或 CFF2 轮廓")
+
+
+def _draw_decomposed(glyph_set, glyph_name: str, destination_pen, scale: float) -> None:
+    recorder = DecomposingRecordingPen(glyph_set)
+    glyph_set[glyph_name].draw(recorder)
+    recorder.replay(TransformPen(destination_pen, (scale, 0, 0, scale, 0, 0)))
+
+
+def _replace_glyf(base: TTFont, src: TTFont, src_glyph_set, base_name: str, src_name: str, scale: float) -> None:
+    pen = TTGlyphPen(None)
+    source_kind = _outline_kind(src)
+    output_pen = Cu2QuPen(
+        pen,
+        max_err=max(0.5, base["head"].unitsPerEm / 2000),
+        reverse_direction=source_kind in {"cff", "cff2"},
+    )
+    _draw_decomposed(src_glyph_set, src_name, output_pen, scale)
+    # TTGlyphPen 生成的新 glyph 默认没有 xMin/yMin/xMax/yMax。
+    # 当 TTFont 以 recalcBBoxes=False 保存时，FontTools 会直接读取这些字段；
+    # glyf 中文基底因此会在保存阶段抛出 KeyError("xMin")。
+    glyph = pen.glyph()
+    base["glyf"][base_name] = glyph
+    glyph.recalcBounds(base["glyf"])
+    if not hasattr(glyph, "xMin"):
+        # 空格等空轮廓不会产生边界，显式补零以保证序列化安全。
+        glyph.xMin = glyph.yMin = glyph.xMax = glyph.yMax = 0
+    if "gvar" in base:
+        base["gvar"].variations.pop(base_name, None)
+
+
+def _replace_cff(base: TTFont, src: TTFont, src_glyph_set, base_name: str, src_name: str, scale: float, width: int) -> None:
+    tag = "CFF " if "CFF " in base else "CFF2"
+    cff = base[tag].cff
+    top = cff.topDictIndex[0]
+    _old, selector = top.CharStrings.getItemAndSelector(base_name)
+    if hasattr(top, "FDArray"):
+        private = top.FDArray[selector or 0].Private
+    else:
+        private = top.Private
+    is_cff2 = tag == "CFF2"
+    pen = T2CharStringPen(None if is_cff2 else width, None, CFF2=is_cff2)
+    source_kind = _outline_kind(src)
+    output_pen = Qu2CuPen(
+        pen,
+        max_err=max(0.5, base["head"].unitsPerEm / 2000),
+        all_cubic=True,
+        reverse_direction=source_kind == "glyf",
+    )
+    _draw_decomposed(src_glyph_set, src_name, output_pen, scale)
+    char_string = pen.getCharString(private=private, globalSubrs=cff.GlobalSubrs)
+    if selector is not None:
+        char_string.fdSelectIndex = selector
+    top.CharStrings[base_name] = char_string
+
+
+def _replace_codepoints(base: TTFont, src: TTFont, codepoints: Iterable[int], location: dict[str, float] | None = None, required: set[int] | None = None) -> tuple[int, list[int]]:
+    required = required or set()
+    base_cmap = base.getBestCmap() or {}
+    src_cmap = src.getBestCmap() or {}
+    src_glyph_set = src.getGlyphSet(location=location) if location else src.getGlyphSet()
+    base_kind = _outline_kind(base)
+    base_upem = base["head"].unitsPerEm
+    src_upem = src["head"].unitsPerEm
+    scale = base_upem / src_upem
+    replaced = 0
+    missing: list[int] = []
+    already: set[str] = set()
+    for cp in sorted(codepoints):
+        base_name = base_cmap.get(cp)
+        src_name = src_cmap.get(cp)
+        if not base_name or not src_name:
+            if cp in required:
+                raise CompositeError(f"源字体或中文基底缺少必要字符 U+{cp:04X}")
+            missing.append(cp)
+            continue
+        key = f"{base_name}:{src_name}"
+        if key in already:
+            continue
+        already.add(key)
+        try:
+            advance, lsb = src["hmtx"].metrics[src_name]
+            variable_width = getattr(src_glyph_set[src_name], "width", None)
+            if isinstance(variable_width, (int, float)):
+                advance = variable_width
+        except (KeyError, TypeError):
+            missing.append(cp)
+            continue
+        advance = int(round(float(advance) * scale))
+        lsb = int(round(float(lsb) * scale))
+        try:
+            if base_kind == "glyf":
+                _replace_glyf(base, src, src_glyph_set, base_name, src_name, scale)
+            else:
+                _replace_cff(base, src, src_glyph_set, base_name, src_name, scale, advance)
+        except Exception as exc:
+            if cp in required:
+                raise CompositeError(f"必要字符 U+{cp:04X} 的字形转换失败：{exc}") from exc
+            missing.append(cp)
+            continue
+        base["hmtx"].metrics[base_name] = (advance, lsb)
+        replaced += 1
+    return replaced, missing
+
+
+def _set_names(font: TTFont) -> None:
+    replacements = {1: "LuoShu Composite", 4: "LuoShu Composite", 6: "LuoShuComposite"}
+    if "name" not in font:
+        return
+    for record in font["name"].names:
+        if record.nameID not in replacements:
+            continue
+        text = replacements[record.nameID]
+        try:
+            record.string = text.encode(record.getEncoding())
+        except Exception:
+            record.string = text.encode("utf-16-be")
+
+
+def _validate_output(path: Path) -> dict[str, object]:
+    font = TTFont(str(path), lazy=False, recalcTimestamp=False)
+    try:
+        cmap = font.getBestCmap() or {}
+        required = {"cjk": ord("中"), "latin": ord("A"), "digit": ord("1")}
+        missing = [role for role, cp in required.items() if cp not in cmap]
+        if missing:
+            raise CompositeError("复合字体缺少必要字符：" + ", ".join(missing))
+        glyph_set = font.getGlyphSet()
+        bounds = {}
+        for role, cp in required.items():
+            glyph_name = cmap[cp]
+            pen = BoundsPen(glyph_set)
+            glyph_set[glyph_name].draw(pen)
+            if pen.bounds is None:
+                raise CompositeError(f"复合字体的 {role} 字形为空")
+            bounds[role] = list(pen.bounds)
+        return {
+            "tables": list(font.keys()),
+            "glyphs": int(font["maxp"].numGlyphs),
+            "coverage": len(cmap),
+            "bounds": bounds,
+            "upem": int(font["head"].unitsPerEm),
+        }
+    finally:
+        font.close()
+
+
+def build(args: argparse.Namespace) -> dict[str, object]:
+    cjk_path, latin_path, digit_path, output = map(Path, (args.cjk, args.latin, args.digit, args.output))
+    for path, label in ((cjk_path, "中文"), (latin_path, "英文"), (digit_path, "数字")):
+        if not path.is_file() or path.stat().st_size < 12:
+            raise CompositeError(f"{label}字体文件不可用：{path}")
+    _progress(args.progress, "load-cjk", "正在读取中文基底", 5)
+    base, cjk_face, _cjk_location = _load_font(cjk_path, "cjk", args.weight, args.cjk_face)
+    latin = digit = None
+    latin_face = digit_face = -1
+    try:
+        if not all(cp in (base.getBestCmap() or {}) for cp in (ord("中"), ord("A"), ord("1"))):
+            raise CompositeError("中文基础字体必须同时包含中文、英文字母和数字，才能安全生成完整复合字体")
+        _progress(args.progress, "latin", "正在导入英文字形", 20)
+        latin, latin_face, latin_location = _load_font(latin_path, "latin", args.weight, args.latin_face)
+        latin_replaced, latin_missing = _replace_codepoints(base, latin, LATIN_CODEPOINTS, latin_location, REQUIRED_LATIN)
+        latin.close(); latin = None; gc.collect()
+        _progress(args.progress, "digit", "正在导入数字字形", 52)
+        digit, digit_face, digit_location = _load_font(digit_path, "digit", args.weight, args.digit_face)
+        digit_replaced, digit_missing = _replace_codepoints(base, digit, DIGIT_CODEPOINTS, digit_location, REQUIRED_DIGITS)
+        digit.close(); digit = None; gc.collect()
+        if latin_replaced < 52:
+            raise CompositeError(f"英文替换数量异常（仅 {latin_replaced} 个）")
+        if digit_replaced < 10:
+            raise CompositeError(f"数字替换数量异常（仅 {digit_replaced} 个）")
+        for tag in ("DSIG", "LTSH", "hdmx", "VDMX"):
+            if tag in base:
+                del base[tag]
+        _set_names(base)
+        _progress(args.progress, "save", "正在写入完整复合字体", 68)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(prefix=output.name + ".", suffix=".tmp", dir=output.parent, delete=False) as temp:
+            temp_path = Path(temp.name)
+        try:
+            base.save(str(temp_path), reorderTables=False)
+            _progress(args.progress, "validate", "正在验证复合字体", 90)
+            validation = _validate_output(temp_path)
+            os.chmod(temp_path, 0o644)
+            os.replace(temp_path, output)
+            _progress(args.progress, "done", "完整复合字体已生成", 100)
+        finally:
+            temp_path.unlink(missing_ok=True)
+        return {
+            "status": "ok",
+            "output": str(output),
+            "sha256": _sha256(output),
+            "size": output.stat().st_size,
+            "faces": {"cjk": cjk_face, "latin": latin_face, "digit": digit_face},
+            "replaced": {"latin": latin_replaced, "digit": digit_replaced},
+            "missingCounts": {"latin": len(latin_missing), "digit": len(digit_missing)},
+            "validation": validation,
+        }
+    finally:
+        base.close()
+        if latin is not None: latin.close()
+        if digit is not None: digit.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cjk", required=True)
+    parser.add_argument("--latin", required=True)
+    parser.add_argument("--digit", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--weight", type=int, default=400)
+    parser.add_argument("--cjk-face", type=int)
+    parser.add_argument("--latin-face", type=int)
+    parser.add_argument("--digit-face", type=int)
+    parser.add_argument("--progress")
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        result = build(parse_args())
+        print(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
+        return 0
+    except MemoryError:
+        print(json.dumps({"status": "error", "message": "生成复合字体时内存不足，请更换体积较小的中文字体后重试"}, ensure_ascii=False, separators=(",", ":")), file=sys.stderr)
+        return 12
+    except Exception as exc:
+        print(json.dumps({"status": "error", "message": str(exc) or exc.__class__.__name__}, ensure_ascii=False, separators=(",", ":")), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/common/legacy_v14_4/font_instance.py
+++ b/common/legacy_v14_4/font_instance.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Materialize a font source at concrete variation-axis values for LuoShu v14.2.
+
+Variable fonts are pinned to every requested fvar axis. TTC/OTC collections are
+reduced to the face whose coverage and weight best match the requested role.
+Plain static TTF/OTF files may be copied by the shell wrapper without invoking
+this helper.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+
+from fontTools.ttLib import TTCollection, TTFont
+from fontTools.varLib.instancer import instantiateVariableFont
+
+CJK_PROBES = tuple(map(ord, "中文字体系统默认洛书汉字国一的。"))
+LATIN_PROBES = tuple(map(ord, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"))
+DIGIT_PROBES = tuple(map(ord, "0123456789"))
+AXIS_TAG_RE = re.compile(r"^[ -~]{1,4}$")
+
+
+class InstanceError(RuntimeError):
+    pass
+
+
+def is_collection(path: Path) -> bool:
+    with path.open("rb") as stream:
+        return stream.read(4) == b"ttcf"
+
+
+def font_weight(font: TTFont) -> int:
+    try:
+        return int(font["OS/2"].usWeightClass)
+    except Exception:
+        return 400
+
+
+def face_score(font: TTFont, role: str, weight: int) -> tuple[int, int]:
+    cmap = font.getBestCmap() or {}
+    probes = CJK_PROBES if role == "cjk" else LATIN_PROBES if role == "latin" else DIGIT_PROBES
+    hits = sum(1 for codepoint in probes if codepoint in cmap)
+    return hits, -abs(font_weight(font) - weight)
+
+
+def pick_face(path: Path, role: str, weight: int) -> int:
+    if not is_collection(path):
+        return -1
+    collection = TTCollection(str(path), lazy=True)
+    try:
+        count = len(collection.fonts)
+    finally:
+        collection.close()
+    best: tuple[tuple[int, int], int] | None = None
+    for index in range(count):
+        font = TTFont(str(path), fontNumber=index, lazy=True, recalcTimestamp=False)
+        try:
+            score = face_score(font, role, weight)
+        finally:
+            font.close()
+        if best is None or score > best[0]:
+            best = score, index
+    if best is None or best[0][0] == 0:
+        raise InstanceError(f"无法从 {path.name} 中找到适合的{role}字体面")
+    return best[1]
+
+
+def clamp_weight(value: float | int) -> int:
+    return max(1, min(1000, int(round(float(value)))))
+
+
+def parse_axis_spec(spec: str) -> dict[str, float]:
+    result: dict[str, float] = {}
+    for raw_item in str(spec or "").split(","):
+        item = raw_item.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            raise InstanceError(f"无效轴参数：{item}")
+        tag, raw_value = item.split("=", 1)
+        tag = tag.strip()
+        if not AXIS_TAG_RE.fullmatch(tag):
+            raise InstanceError(f"无效轴标签：{tag}")
+        try:
+            result[tag] = float(raw_value.strip())
+        except ValueError as exc:
+            raise InstanceError(f"轴 {tag} 的数值无效") from exc
+    return result
+
+
+def materialize(source: Path, output: Path, role: str, requested_weight: int, requested_axes: dict[str, float]) -> dict[str, object]:
+    if not source.is_file() or source.stat().st_size < 12:
+        raise InstanceError(f"字体源文件不可用：{source}")
+    requested_weight = clamp_weight(requested_axes.get("wght", requested_weight))
+    face = pick_face(source, role, requested_weight)
+    kwargs: dict[str, object] = {
+        "lazy": False,
+        "recalcTimestamp": False,
+        "recalcBBoxes": True,
+    }
+    if face >= 0:
+        kwargs["fontNumber"] = face
+    font = TTFont(str(source), **kwargs)
+    variable = "fvar" in font
+    location: dict[str, float] = {}
+    ignored_axes: list[str] = []
+    try:
+        if variable:
+            known_axes = {str(axis.axisTag): axis for axis in font["fvar"].axes}
+            ignored_axes = sorted(tag for tag in requested_axes if tag not in known_axes)
+            for tag, axis in known_axes.items():
+                requested = requested_axes.get(tag, float(axis.defaultValue))
+                location[tag] = float(max(axis.minValue, min(axis.maxValue, requested)))
+            font = instantiateVariableFont(font, location, inplace=False, optimize=True)
+        elif requested_axes:
+            ignored_axes = sorted(tag for tag in requested_axes if tag != "wght")
+
+        final_weight = clamp_weight(location.get("wght", requested_weight))
+        if "OS/2" in font:
+            font["OS/2"].usWeightClass = final_weight
+        for tag in ("DSIG", "LTSH", "hdmx", "VDMX"):
+            if tag in font:
+                del font[tag]
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(prefix=output.name + ".", suffix=".tmp", dir=output.parent, delete=False) as handle:
+            temp_path = Path(handle.name)
+        try:
+            font.save(str(temp_path), reorderTables=False)
+            if temp_path.stat().st_size < 4096:
+                raise InstanceError("可变轴实例化输出异常为空")
+            os.chmod(temp_path, 0o644)
+            os.replace(temp_path, output)
+        finally:
+            temp_path.unlink(missing_ok=True)
+        return {
+            "status": "ok",
+            "source": str(source),
+            "output": str(output),
+            "role": role,
+            "weight": final_weight,
+            "face": face,
+            "variable": variable,
+            "location": location,
+            "ignoredAxes": ignored_axes,
+            "size": output.stat().st_size,
+        }
+    finally:
+        font.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--role", choices=("cjk", "latin", "digit"), required=True)
+    parser.add_argument("--weight", type=int, default=400)
+    parser.add_argument("--axes", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        result = materialize(Path(args.input), Path(args.output), args.role, args.weight, parse_axis_spec(args.axes))
+        print(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
+        return 0
+    except MemoryError:
+        print(json.dumps({"status": "error", "message": "字体可变轴实例化时内存不足"}, ensure_ascii=False, separators=(",", ":")), file=sys.stderr)
+        return 12
+    except Exception as error:
+        print(json.dumps({"status": "error", "message": str(error) or error.__class__.__name__}, ensure_ascii=False, separators=(",", ":")), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    import sys
+    raise SystemExit(main())

--- a/common/legacy_v14_4/font_mix_engine.sh
+++ b/common/legacy_v14_4/font_mix_engine.sh
@@ -1,0 +1,536 @@
+#!/system/bin/sh
+# 洛书 v14.1：完整复合字体引擎。
+# 中文字体保留为完整基底，仅把英文与数字的对应字形写入同一份字体。
+# 不裁剪 ROM 字体槽、不覆盖 fonts.xml / font_fallback.xml。
+set +e
+
+MODDIR="${MODDIR:-}"
+if [ -z "$MODDIR" ]; then
+    if [ -f "${0%/*}/../module.prop" ]; then
+        MODDIR="$(CDPATH= cd -- "${0%/*}/.." 2>/dev/null && pwd)"
+    else
+        MODDIR="/data/adb/modules/LuoShu"
+    fi
+fi
+
+CONFIG_DIR="$MODDIR/config"
+SYSTEM_FONTS_DIR="$MODDIR/system/fonts"
+USER_FONTS_DIR="${LUOSHU_PUBLIC_DIR:-/sdcard/LuoShu}/fonts"
+TASK_FILE="$CONFIG_DIR/mix_task.conf"
+MIX_CONF="$CONFIG_DIR/font_mix.conf"
+ACTIVE_FONT_CONF="$CONFIG_DIR/active_font.conf"
+TEXT_REBOOT_REQUIRED="$CONFIG_DIR/text_reboot_required.conf"
+LOCK_FILE="$MODDIR/.font_switch.lock"
+LOG_FILE="$MODDIR/logs/fontswitch.log"
+MODULE_DIR="$MODDIR"
+PAYLOAD_STAGE=""
+PAYLOAD_BACKUP=""
+PAYLOAD_ACTIVATED=0
+PAYLOAD_COMMIT_MARKER="$MODDIR/.font-payload-commit.ok"
+COMPOSITE_RESULT=""
+COMPOSITE_REPORT=""
+COMPOSITE_CACHE_HIT=false
+LAST_MIX_ERROR=""
+
+[ -f "$MODDIR/common/util_functions.sh" ] && . "$MODDIR/common/util_functions.sh"
+[ -f "$MODDIR/common/font_check.sh" ] && . "$MODDIR/common/font_check.sh"
+[ -f "$MODDIR/common/rom_adapters.sh" ] && . "$MODDIR/common/rom_adapters.sh"
+[ -f "$MODDIR/common/mount_compat.sh" ] && . "$MODDIR/common/mount_compat.sh"
+
+type check_coloros >/dev/null 2>&1 && check_coloros
+type check_hyperos >/dev/null 2>&1 && check_hyperos
+
+json_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '
+}
+
+read_conf() {
+    _key="$1"; _fallback="$2"; _value=""
+    [ -f "$MIX_CONF" ] && _value=$(sed -n "s/^${_key}=//p" "$MIX_CONF" 2>/dev/null | head -n1 | tr -d '\r\n')
+    [ -n "$_value" ] || _value="$_fallback"
+    printf '%s' "$_value"
+}
+
+write_task() {
+    _task="$1"; _state="$2"; _message="$3"; _cjk="$4"; _latin="$5"; _digit="$6"; _started="$7"; _finished="$8"
+    _tmp="$TASK_FILE.tmp.$$"
+    {
+        printf 'task=%s\n' "$_task"
+        printf 'state=%s\n' "$_state"
+        printf 'message=%s\n' "$_message"
+        printf 'cjk=%s\n' "$_cjk"
+        printf 'latin=%s\n' "$_latin"
+        printf 'digit=%s\n' "$_digit"
+        printf 'started=%s\n' "$_started"
+        printf 'finished=%s\n' "$_finished"
+    } > "$_tmp" 2>/dev/null && mv -f "$_tmp" "$TASK_FILE" 2>/dev/null
+    chmod 0644 "$TASK_FILE" 2>/dev/null || true
+}
+
+rotate_mix_log() {
+    [ -f "$LOG_FILE" ] || return 0
+    _size=$(wc -c < "$LOG_FILE" 2>/dev/null | tr -d '[:space:]')
+    case "$_size" in ''|*[!0-9]*) _size=0 ;; esac
+    [ "$_size" -le 1048576 ] && return 0
+    _tmp="$LOG_FILE.trim.$$"
+    tail -n 1200 "$LOG_FILE" > "$_tmp" 2>/dev/null && mv -f "$_tmp" "$LOG_FILE" 2>/dev/null
+}
+
+find_family_file() {
+    _want="$1"; _chosen=""
+    if type get_weight_file >/dev/null 2>&1; then
+        _chosen=$(get_weight_file "$_want" regular 2>/dev/null)
+        [ -f "$_chosen" ] && { printf '%s\n' "$_chosen"; return 0; }
+    fi
+    for _f in "$USER_FONTS_DIR"/*.ttf "$USER_FONTS_DIR"/*.otf "$USER_FONTS_DIR"/*.ttc \
+              "$USER_FONTS_DIR"/*.TTF "$USER_FONTS_DIR"/*.OTF "$USER_FONTS_DIR"/*.TTC; do
+        [ -f "$_f" ] || continue
+        _fam=$(detect_font_family "$(basename "$_f")")
+        [ "$_fam" = "$_want" ] && { printf '%s\n' "$_f"; return 0; }
+    done
+    return 1
+}
+
+validate_source() {
+    _src="$1"; _label="$2"
+    [ -f "$_src" ] || { echo "错误：找不到${_label}字体" >&2; return 1; }
+    if type font_validate >/dev/null 2>&1 && ! font_validate "$_src" text; then
+        echo "错误：${_label}字体无效：$FONT_CHECK_ERROR" >&2
+        return 1
+    fi
+    return 0
+}
+
+all_text_targets() {
+    _files=""
+    type get_all_hyperos_files >/dev/null 2>&1 && _files="$_files $(get_all_hyperos_files)"
+    type get_all_generic_files >/dev/null 2>&1 && _files="$_files $(get_all_generic_files)"
+    if type get_all_coloros_names >/dev/null 2>&1; then
+        for _name in $(get_all_coloros_names); do _files="$_files ${_name}.ttf"; done
+    fi
+    printf '%s\n' "$_files"
+}
+
+clear_text_targets_in_dir() {
+    _dir="$1"
+    [ -d "$_dir" ] || return 0
+    for _file in $(all_text_targets); do rm -f "$_dir/$_file" 2>/dev/null || true; done
+    rm -rf "$_dir/.luoshu-font-store" 2>/dev/null || true
+}
+
+alias_core() {
+    _anchor="$1"; shift
+    for _file in "$@"; do
+        _font_alias "$_anchor" "$SYSTEM_FONTS_DIR/$_file" >/dev/null 2>&1 || return 1
+    done
+}
+
+alias_existing_list() {
+    _anchor="$1"; shift
+    for _file in "$@"; do
+        _rom_exact_target_exists "$_file" || continue
+        _font_alias "$_anchor" "$SYSTEM_FONTS_DIR/$_file" >/dev/null 2>&1 || true
+    done
+}
+
+verify_core_files() {
+    _dir="$1"; shift
+    for _file in "$@"; do
+        [ -s "$_dir/$_file" ] || return 1
+        _size=$(wc -c < "$_dir/$_file" 2>/dev/null | tr -d '[:space:]')
+        case "$_size" in ''|*[!0-9]*) _size=0 ;; esac
+        [ "$_size" -ge 1024 ] || return 1
+    done
+    return 0
+}
+
+recover_interrupted_payload() {
+    if [ -f "$PAYLOAD_COMMIT_MARKER" ]; then
+        rm -rf "$MODDIR"/.font-payload-backup.* "$MODDIR"/.font-payload-stage.* 2>/dev/null || true
+        rm -f "$PAYLOAD_COMMIT_MARKER" 2>/dev/null || true
+        return 0
+    fi
+    for _backup in "$MODDIR"/.font-payload-backup.*; do
+        [ -d "$_backup" ] || continue
+        rm -rf "$SYSTEM_FONTS_DIR" 2>/dev/null || true
+        mv "$_backup" "$SYSTEM_FONTS_DIR" 2>/dev/null || true
+        break
+    done
+    rm -rf "$MODDIR"/.font-payload-backup.* "$MODDIR"/.font-payload-stage.* 2>/dev/null || true
+}
+
+payload_stage_begin() {
+    PAYLOAD_STAGE="$MODDIR/.font-payload-stage.$$"
+    PAYLOAD_BACKUP="$MODDIR/.font-payload-backup.$$"
+    PAYLOAD_ACTIVATED=0
+    rm -rf "$PAYLOAD_STAGE" "$PAYLOAD_BACKUP" "$PAYLOAD_COMMIT_MARKER" 2>/dev/null || true
+    mkdir -p "$PAYLOAD_STAGE" 2>/dev/null || return 1
+    if [ -d "$SYSTEM_FONTS_DIR" ]; then
+        cp -af "$SYSTEM_FONTS_DIR/." "$PAYLOAD_STAGE/" 2>/dev/null || \
+            cp -rfp "$SYSTEM_FONTS_DIR/." "$PAYLOAD_STAGE/" 2>/dev/null || return 1
+    fi
+    clear_text_targets_in_dir "$PAYLOAD_STAGE"
+    return 0
+}
+
+payload_stage_abort() {
+    [ -z "$PAYLOAD_STAGE" ] || rm -rf "$PAYLOAD_STAGE" 2>/dev/null || true
+    PAYLOAD_STAGE=""
+}
+
+payload_stage_activate() {
+    mkdir -p "${SYSTEM_FONTS_DIR%/*}" 2>/dev/null || return 1
+    if [ -d "$SYSTEM_FONTS_DIR" ]; then
+        mv "$SYSTEM_FONTS_DIR" "$PAYLOAD_BACKUP" 2>/dev/null || return 1
+    else
+        mkdir -p "$PAYLOAD_BACKUP" 2>/dev/null || return 1
+    fi
+    if ! mv "$PAYLOAD_STAGE" "$SYSTEM_FONTS_DIR" 2>/dev/null; then
+        rm -rf "$SYSTEM_FONTS_DIR" 2>/dev/null || true
+        mv "$PAYLOAD_BACKUP" "$SYSTEM_FONTS_DIR" 2>/dev/null || true
+        return 1
+    fi
+    PAYLOAD_STAGE=""
+    PAYLOAD_ACTIVATED=1
+    return 0
+}
+
+payload_stage_rollback() {
+    [ "$PAYLOAD_ACTIVATED" -eq 1 ] || return 0
+    rm -rf "$SYSTEM_FONTS_DIR" 2>/dev/null || true
+    mv "$PAYLOAD_BACKUP" "$SYSTEM_FONTS_DIR" 2>/dev/null || true
+    rm -f "$PAYLOAD_COMMIT_MARKER" 2>/dev/null || true
+    PAYLOAD_BACKUP=""
+    PAYLOAD_ACTIVATED=0
+}
+
+payload_stage_finalize() {
+    [ "$PAYLOAD_ACTIVATED" -eq 1 ] || return 0
+    rm -rf "$PAYLOAD_BACKUP" 2>/dev/null || true
+    rm -f "$PAYLOAD_COMMIT_MARKER" 2>/dev/null || true
+    PAYLOAD_BACKUP=""
+    PAYLOAD_ACTIVATED=0
+}
+
+cleanup_mix_process() {
+    payload_stage_abort
+    payload_stage_rollback
+    rm -f "$LOCK_FILE" 2>/dev/null || true
+}
+
+populate_coloros_payload() (
+    SYSTEM_FONTS_DIR="$1"; _composite="$2"
+    _font_store_reset "$SYSTEM_FONTS_DIR" || exit 1
+    _ma=$(_font_anchor "$_composite" "$SYSTEM_FONTS_DIR" mix-composite) || exit 1
+    alias_core "$_ma" SysSans-Hans-Regular.ttf SysSans-Hant-Regular.ttf SysFont-Hans-Regular.ttf SysFont-Hant-Regular.ttf SysFont-Static-Regular.ttf SysFont-Regular.ttf SysSans-En-Regular.ttf Roboto-Regular.ttf GoogleSans-Regular.ttf GoogleSansText-Regular.ttf || exit 1
+    alias_existing_list "$_ma" Opposans-Hans-Regular.ttf Opposans-Hans-Bold.ttf Opposans-Hans-Medium.ttf Opposans-Hans-Light.ttf SysSans-Hans-Bold.ttf SysSans-Hans-Medium.ttf SysSans-Hans-Light.ttf SysSans-Hant-Bold.ttf SysSans-Hant-Medium.ttf SysSans-Hant-Light.ttf SysFont-Hans-Bold.ttf SysFont-Hans-Medium.ttf SysFont-Hans-Light.ttf SysFont-Hant-Bold.ttf SysFont-Hant-Medium.ttf SysFont-Hant-Light.ttf SysFont-Static-Bold.ttf SysFont-Static-Medium.ttf SysFont-Static-Light.ttf SysFont-Bold.ttf SysFont-Medium.ttf SysFont-Light.ttf SysFont-Thin.ttf SysFont-Black.ttf SysSans-En-Bold.ttf SysSans-En-Medium.ttf SysSans-En-Light.ttf SysSans-En-Thin.ttf SysSans-En-Black.ttf Opposans-En-Regular.ttf Opposans-En-Bold.ttf Opposans-En-Medium.ttf Opposans-En-Light.ttf OPSans-En-Regular.ttf Roboto-Medium.ttf Roboto-Bold.ttf Roboto-Light.ttf Roboto-Thin.ttf RobotoFlex-Regular.ttf RobotoStatic-Regular.ttf GoogleSans-Medium.ttf GoogleSans-Bold.ttf GoogleSansText-Medium.ttf GoogleSansText-Bold.ttf GoogleSansFlex-Regular.ttf SourceSansPro-Regular.ttf SourceSansPro-SemiBold.ttf SourceSansPro-Bold.ttf DINCondensedBold.ttf DINPro-Regular.ttf DINPro-Medium.ttf DINPro-Bold.ttf OPPODIN-Regular.ttf OPPODIN-Medium.ttf OPPODIN-Bold.ttf OPPODINCondensed-Regular.ttf OPPODINCondensed-Medium.ttf OPPODINCondensed-Bold.ttf
+    verify_core_files "$SYSTEM_FONTS_DIR" SysSans-Hans-Regular.ttf SysSans-En-Regular.ttf Roboto-Regular.ttf || exit 1
+)
+
+populate_hyperos_payload() (
+    SYSTEM_FONTS_DIR="$1"; _composite="$2"
+    _font_store_reset "$SYSTEM_FONTS_DIR" || exit 1
+    _ma=$(_font_anchor "$_composite" "$SYSTEM_FONTS_DIR" mix-composite) || exit 1
+    alias_core "$_ma" MiSansVF.ttf MiSansVF_Overlay.ttf MiSansTCVF.ttf MiSansL3.otf MiSansLatinVF.ttf Roboto-Regular.ttf GoogleSans-Regular.ttf GoogleSansText-Regular.ttf 100.ttf 200.ttf 300.ttf 350.ttf 400.ttf 500.ttf 600.ttf 700.ttf 800.ttf 900.ttf || exit 1
+    alias_existing_list "$_ma" Roboto-Medium.ttf Roboto-Bold.ttf Roboto-Light.ttf Roboto-Thin.ttf RobotoFlex-Regular.ttf RobotoStatic-Regular.ttf GoogleSans-Medium.ttf GoogleSans-Bold.ttf GoogleSansText-Medium.ttf GoogleSansText-Bold.ttf GoogleSansFlex-Regular.ttf
+    verify_core_files "$SYSTEM_FONTS_DIR" MiSansVF.ttf MiSansLatinVF.ttf Roboto-Regular.ttf 400.ttf 700.ttf || exit 1
+)
+
+populate_generic_payload() (
+    SYSTEM_FONTS_DIR="$1"; _composite="$2"
+    _font_store_reset "$SYSTEM_FONTS_DIR" || exit 1
+    _ma=$(_font_anchor "$_composite" "$SYSTEM_FONTS_DIR" mix-composite) || exit 1
+    alias_core "$_ma" NotoSansCJK-Regular.ttc NotoSansSC-Regular.otf NotoSansTC-Regular.otf NotoSans-Regular.ttf Roboto-Regular.ttf Roboto-Medium.ttf Roboto-Bold.ttf Roboto-Light.ttf GoogleSans-Regular.ttf GoogleSansText-Regular.ttf DroidSans.ttf || exit 1
+    verify_core_files "$SYSTEM_FONTS_DIR" NotoSansCJK-Regular.ttc Roboto-Regular.ttf || exit 1
+)
+
+sync_secondary_partition() {
+    _part="$1"; _real_root="$2"; _dest="$MODDIR/$_part/fonts"
+    _stage="$MODDIR/.${_part}-fonts-stage.$$"; _backup="$MODDIR/.${_part}-fonts-backup.$$"
+    rm -rf "$_stage" "$_backup" 2>/dev/null || true
+    mkdir -p "$_stage" 2>/dev/null || return 1
+    if [ -d "$_dest" ]; then
+        cp -af "$_dest/." "$_stage/" 2>/dev/null || cp -rfp "$_dest/." "$_stage/" 2>/dev/null || true
+    fi
+    clear_text_targets_in_dir "$_stage"
+    for _src in "$SYSTEM_FONTS_DIR"/*; do
+        [ -f "$_src" ] || continue
+        _file=$(basename "$_src")
+        [ -e "$_real_root/$_file" ] || continue
+        link_or_copy_font "$_src" "$_stage/$_file" 2>/dev/null || { rm -rf "$_stage"; return 1; }
+    done
+    mkdir -p "${_dest%/*}" 2>/dev/null || { rm -rf "$_stage"; return 1; }
+    [ ! -d "$_dest" ] || mv "$_dest" "$_backup" 2>/dev/null || { rm -rf "$_stage"; return 1; }
+    if mv "$_stage" "$_dest" 2>/dev/null; then
+        rm -rf "$_backup" 2>/dev/null || true
+        chmod -R u=rwX,go=rX "$_dest" 2>/dev/null || true
+        return 0
+    fi
+    rm -rf "$_dest" 2>/dev/null || true
+    [ ! -d "$_backup" ] || mv "$_backup" "$_dest" 2>/dev/null || true
+    rm -rf "$_stage" 2>/dev/null || true
+    return 1
+}
+
+sync_secondary_coloros_dirs() {
+    [ "$IS_COLOROS" = "true" ] || return 0
+    sync_secondary_partition system_ext /system_ext/fonts || return 1
+    sync_secondary_partition product /product/fonts || return 1
+    return 0
+}
+
+composite_hash_file() {
+    _hf="$1"
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum "$_hf" | awk '{print $1}'
+    elif command -v toybox >/dev/null 2>&1; then toybox sha256sum "$_hf" | awk '{print $1}'
+    else cksum "$_hf" | awk '{print $1 "-" $2}'
+    fi
+}
+
+set_mix_error() {
+    LAST_MIX_ERROR="$1"
+    printf '%s\n' "$LAST_MIX_ERROR" > "$CONFIG_DIR/mix_last_error.txt" 2>/dev/null || true
+    chmod 0644 "$CONFIG_DIR/mix_last_error.txt" 2>/dev/null || true
+    echo "错误：$LAST_MIX_ERROR" >&2
+}
+
+extract_composite_error() {
+    _ef="$1"; _rc="$2"; _msg=""
+    if [ -s "$_ef" ]; then
+        _msg=$(sed -n 's/^.*"message":"\([^"]*\)".*$/\1/p' "$_ef" 2>/dev/null | tail -n1)
+        [ -n "$_msg" ] || _msg=$(tail -n1 "$_ef" 2>/dev/null | tr -d '\r')
+    fi
+    case "$_rc" in
+        124) _msg="复合字体生成超过 8 分钟，已安全终止" ;;
+        137|9) _msg="复合字体生成进程被系统终止，通常是内存不足" ;;
+        126) _msg="复合字体运行程序没有执行权限" ;;
+        127) _msg="复合字体运行时无法启动" ;;
+        20) _msg="复合字体运行时文件缺失" ;;
+        21) _msg="当前设备不是 ARM64，无法运行复合字体引擎" ;;
+    esac
+    [ -n "$_msg" ] || _msg="完整复合字体生成失败（底层返回 $_rc）"
+    printf '%s' "$_msg"
+}
+
+check_composite_runtime() {
+    _runner="$MODDIR/common/luoshu_composite.sh"
+    mkdir -p "$MODDIR/cache" 2>/dev/null || { set_mix_error "无法创建运行时自检目录"; return 1; }
+    _runtime_key=$(composite_hash_file "$MODDIR/common/python/bin/luoshu-python" 2>/dev/null)
+    [ -n "$_runtime_key" ] || _runtime_key=unknown
+    _ok="$MODDIR/cache/runtime_probe.${_runtime_key}.ok"
+    [ -s "$_ok" ] && return 0
+    rm -f "$MODDIR/cache"/runtime_probe.*.ok 2>/dev/null || true
+    _probe="$MODDIR/cache/runtime_probe.txt"
+    rm -f "$_probe" 2>/dev/null || true
+    MODDIR="$MODDIR" sh "$_runner" --self-test >"$_probe" 2>&1
+    _rc=$?
+    if [ "$_rc" -ne 0 ] || ! grep -q '^ok$' "$_probe" 2>/dev/null; then
+        _detail=$(tail -n1 "$_probe" 2>/dev/null | tr -d '\r')
+        [ -n "$_detail" ] || _detail="返回 $_rc"
+        set_mix_error "复合字体运行时自检失败：$_detail"
+        return 1
+    fi
+    printf 'ok\n' > "$_ok" 2>/dev/null || true
+    return 0
+}
+
+write_progress() {
+    _stage="$1"; _message="$2"; _percent="$3"; _progress="$CONFIG_DIR/composite_progress.json"
+    _tmp="$_progress.$$"
+    printf '{"stage":"%s","message":"%s","percent":%s,"time":%s}\n' \
+        "$(json_escape "$_stage")" "$(json_escape "$_message")" "$_percent" "$(date +%s)" > "$_tmp" 2>/dev/null && mv -f "$_tmp" "$_progress" 2>/dev/null
+}
+
+prune_composite_cache() {
+    _cache="$1"; _keep=3; _count=0
+    for _old in $(ls -1t "$_cache"/*.otf 2>/dev/null); do
+        _count=$((_count + 1))
+        [ "$_count" -le "$_keep" ] && continue
+        _base=${_old%.otf}
+        rm -f "$_old" "${_base}.json" 2>/dev/null || true
+    done
+    rm -f "$_cache"/.*.tmp.* 2>/dev/null || true
+}
+
+build_composite_file() {
+    _cjk_src="$1"; _latin_src="$2"; _digit_src="$3"
+    COMPOSITE_RESULT=""; COMPOSITE_REPORT=""; COMPOSITE_CACHE_HIT=false; LAST_MIX_ERROR=""
+    _runner="$MODDIR/common/luoshu_composite.sh"
+    [ -f "$MODDIR/common/composite_font.py" ] && [ -f "$_runner" ] || { set_mix_error '完整复合字体引擎缺失'; return 1; }
+    [ -x "$MODDIR/common/python/bin/luoshu-python" ] || chmod 0755 "$MODDIR/common/python/bin/luoshu-python" 2>/dev/null || true
+    check_composite_runtime || return 1
+    _cache="$MODDIR/cache/full-composite-v5"
+    mkdir -p "$_cache" "$MODDIR/cache/tmp" 2>/dev/null || { set_mix_error '无法创建复合字体缓存目录'; return 1; }
+    _key_src="$(composite_hash_file "$_cjk_src")-$(composite_hash_file "$_latin_src")-$(composite_hash_file "$_digit_src")-full-composite-v5"
+    _key=$(printf '%s' "$_key_src" | { if command -v sha256sum >/dev/null 2>&1; then sha256sum; elif command -v toybox >/dev/null 2>&1; then toybox sha256sum; else cksum; fi; } | awk '{print $1}')
+    _cached="$_cache/${_key}.otf"; _report="$_cache/${_key}.json"; _progress="$CONFIG_DIR/composite_progress.json"
+    rm -f "$_cache"/.*.tmp.* 2>/dev/null || true
+    if [ -s "$_cached" ]; then
+        COMPOSITE_CACHE_HIT=true
+        touch "$_cached" "$_report" 2>/dev/null || true
+        write_progress cache '已验证并使用现有复合字体缓存' 100
+    else
+        _tmp="$_cache/.${_key}.$$.tmp.otf"; _tmp_report="$_cache/.${_key}.$$.tmp.json"; _tmp_error="$_cache/.${_key}.$$.tmp.err"
+        rm -f "$_tmp" "$_tmp_report" "$_tmp_error" "$_progress" 2>/dev/null || true
+        if command -v timeout >/dev/null 2>&1; then
+            MODDIR="$MODDIR" timeout 480 sh "$_runner" --cjk "$_cjk_src" --latin "$_latin_src" --digit "$_digit_src" --output "$_tmp" --progress "$_progress" > "$_tmp_report" 2> "$_tmp_error"
+            _run_rc=$?
+        elif command -v toybox >/dev/null 2>&1 && toybox timeout --help >/dev/null 2>&1; then
+            MODDIR="$MODDIR" toybox timeout 480 sh "$_runner" --cjk "$_cjk_src" --latin "$_latin_src" --digit "$_digit_src" --output "$_tmp" --progress "$_progress" > "$_tmp_report" 2> "$_tmp_error"
+            _run_rc=$?
+        else
+            MODDIR="$MODDIR" sh "$_runner" --cjk "$_cjk_src" --latin "$_latin_src" --digit "$_digit_src" --output "$_tmp" --progress "$_progress" > "$_tmp_report" 2> "$_tmp_error"
+            _run_rc=$?
+        fi
+        [ ! -s "$_tmp_error" ] || cat "$_tmp_error" >> "$LOG_FILE" 2>/dev/null || true
+        if [ "$_run_rc" -ne 0 ]; then
+            _detail=$(extract_composite_error "$_tmp_error" "$_run_rc")
+            rm -f "$_tmp" "$_tmp_report" "$_tmp_error" 2>/dev/null || true
+            set_mix_error "$_detail"
+            return 1
+        fi
+        [ -s "$_tmp" ] || { rm -f "$_tmp" "$_tmp_report" "$_tmp_error"; set_mix_error '复合字体输出为空'; return 1; }
+        if type font_validate >/dev/null 2>&1 && ! font_validate "$_tmp" text; then
+            rm -f "$_tmp" "$_tmp_report" "$_tmp_error" 2>/dev/null || true
+            set_mix_error "复合字体验证失败：$FONT_CHECK_ERROR"
+            return 1
+        fi
+        chmod 0644 "$_tmp" "$_tmp_report" 2>/dev/null || true
+        mv -f "$_tmp" "$_cached" || { set_mix_error '无法保存复合字体缓存'; return 1; }
+        mv -f "$_tmp_report" "$_report" 2>/dev/null || true
+        rm -f "$_tmp_error" 2>/dev/null || true
+        write_progress done '复合字体已生成并通过验证' 100
+    fi
+    prune_composite_cache "$_cache"
+    COMPOSITE_RESULT="$_cached"; COMPOSITE_REPORT="$_report"
+    return 0
+}
+
+prepare_mix_config() {
+    _cjk="$1"; _latin="$2"; _digit="$3"; _font_tmp="$CONFIG_DIR/.font_mix.$$"; _active_tmp="$CONFIG_DIR/.active_font.$$"; _reboot_tmp="$CONFIG_DIR/.text_reboot.$$"
+    {
+        printf 'cjk=%s\n' "$_cjk"
+        printf 'latin=%s\n' "$_latin"
+        printf 'digit=%s\n' "$_digit"
+        printf 'isolation=full-composite-v5\n'
+        printf 'characterIsolation=true\n'
+        printf 'composite=true\n'
+        printf 'xmlOverlay=false\n'
+        printf 'cacheHit=%s\n' "$COMPOSITE_CACHE_HIT"
+        printf 'time=%s\n' "$(date +%s)"
+    } > "$_font_tmp" 2>/dev/null || return 1
+    printf 'mix\n' > "$_active_tmp" 2>/dev/null || return 1
+    printf 'font=mix\ntime=%s\n' "$(date +%s)" > "$_reboot_tmp" 2>/dev/null || return 1
+    MIX_CONF_TMP="$_font_tmp"; ACTIVE_CONF_TMP="$_active_tmp"; REBOOT_CONF_TMP="$_reboot_tmp"
+    return 0
+}
+
+commit_mix_config() {
+    mv -f "$MIX_CONF_TMP" "$MIX_CONF" 2>/dev/null || return 1
+    mv -f "$ACTIVE_CONF_TMP" "$ACTIVE_FONT_CONF" 2>/dev/null || return 1
+    mv -f "$REBOOT_CONF_TMP" "$TEXT_REBOOT_REQUIRED" 2>/dev/null || return 1
+    printf 'time=%s\n' "$(date +%s)" > "$PAYLOAD_COMMIT_MARKER" 2>/dev/null || return 1
+    chmod 0644 "$MIX_CONF" "$ACTIVE_FONT_CONF" "$TEXT_REBOOT_REQUIRED" 2>/dev/null || true
+    return 0
+}
+
+apply_mix() {
+    _cjk="$1"; _latin="$2"; _digit="$3"
+    [ -n "$_cjk" ] && [ -n "$_latin" ] && [ -n "$_digit" ] || { set_mix_error '组合配置不完整'; return 1; }
+    recover_interrupted_payload
+    if [ -e "$LOCK_FILE" ]; then
+        _pid=$(cat "$LOCK_FILE" 2>/dev/null)
+        if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then set_mix_error '字体正在切换中'; return 2; fi
+        rm -f "$LOCK_FILE" 2>/dev/null || true
+    fi
+    [ ! -f "$TEXT_REBOOT_REQUIRED" ] || { set_mix_error '本次开机已更改文字字体，请先重启手机'; return 3; }
+    echo $$ > "$LOCK_FILE"
+    trap cleanup_mix_process EXIT INT TERM
+
+    _cjk_src=$(find_family_file "$_cjk")
+    _latin_src=$(find_family_file "$_latin")
+    _digit_src=$(find_family_file "$_digit")
+    validate_source "$_cjk_src" 中文 || { set_mix_error "中文字体源文件不可用：${FONT_CHECK_ERROR:-找不到文件}"; return 4; }
+    validate_source "$_latin_src" 英文 || { set_mix_error "英文字体源文件不可用：${FONT_CHECK_ERROR:-找不到文件}"; return 4; }
+    validate_source "$_digit_src" 数字 || { set_mix_error "数字字体源文件不可用：${FONT_CHECK_ERROR:-找不到文件}"; return 4; }
+
+    mkdir -p "$SYSTEM_FONTS_DIR" "$CONFIG_DIR" "$MODDIR/logs" 2>/dev/null || { set_mix_error '无法创建模块工作目录'; return 4; }
+    build_composite_file "$_cjk_src" "$_latin_src" "$_digit_src" || return 5
+    payload_stage_begin || { set_mix_error '无法创建字体负载暂存区'; return 5; }
+    if [ "$IS_HYPEROS" = "true" ]; then
+        populate_hyperos_payload "$PAYLOAD_STAGE" "$COMPOSITE_RESULT" || { set_mix_error '生成 HyperOS 字体负载失败'; return 5; }
+    elif [ "$IS_COLOROS" = "true" ]; then
+        populate_coloros_payload "$PAYLOAD_STAGE" "$COMPOSITE_RESULT" || { set_mix_error '生成 ColorOS 字体负载失败'; return 5; }
+    else
+        populate_generic_payload "$PAYLOAD_STAGE" "$COMPOSITE_RESULT" || { set_mix_error '生成通用 Android 字体负载失败'; return 5; }
+    fi
+    prepare_mix_config "$_cjk" "$_latin" "$_digit" || { set_mix_error '无法准备字体组合状态'; return 6; }
+    payload_stage_activate || { set_mix_error '无法原子替换字体负载'; return 6; }
+    if ! commit_mix_config; then
+        set_mix_error '无法提交字体组合状态，已恢复旧字体负载'
+        return 6
+    fi
+    payload_stage_finalize
+    chmod 0755 "$SYSTEM_FONTS_DIR" 2>/dev/null || true
+    chmod 0644 "$SYSTEM_FONTS_DIR"/* 2>/dev/null || true
+    if [ "$IS_COLOROS" = "true" ]; then
+        sync_secondary_coloros_dirs || echo '警告：ColorOS 辅助分区字体同步未完全成功，主字体负载已保留' >&2
+    fi
+    type luoshu_sync_mount_payload >/dev/null 2>&1 && luoshu_sync_mount_payload 2>/dev/null || true
+    rm -f "$LOCK_FILE" 2>/dev/null || true
+    trap - EXIT INT TERM
+    return 0
+}
+
+status_json() {
+    _active=$(head -n1 "$ACTIVE_FONT_CONF" 2>/dev/null | tr -d '\r\n')
+    _cjk=$(read_conf cjk '')
+    _latin=$(read_conf latin '')
+    _digit=$(read_conf digit '')
+    _enabled=false; [ "$_active" = mix ] && _enabled=true
+    printf '{"status":"ok","data":{"enabled":%s,"cjk":"%s","latin":"%s","digit":"%s"}}\n' \
+        "$_enabled" "$(json_escape "$_cjk")" "$(json_escape "$_latin")" "$(json_escape "$_digit")"
+}
+
+case "${1:-status}" in
+    start)
+        _cjk="$2"; _latin="$3"; _digit="$4"
+        if [ -z "$_cjk" ] || [ -z "$_latin" ] || [ -z "$_digit" ]; then
+            printf '{"status":"error","message":"请选择中文、英文和数字字体"}\n'
+            exit 0
+        fi
+        if [ -f "$TEXT_REBOOT_REQUIRED" ]; then
+            printf '{"status":"error","message":"本次开机已更改文字字体，请先重启手机"}\n'
+            exit 0
+        fi
+        mkdir -p "$CONFIG_DIR" "$MODDIR/logs" 2>/dev/null || true
+        rotate_mix_log
+        rm -f "$CONFIG_DIR/mix_last_error.txt" "$CONFIG_DIR/composite_progress.json" 2>/dev/null || true
+        _task="mix-$(date +%s)-$$"; _started=$(date +%s)
+        write_task "$_task" running '正在生成完整复合字体' "$_cjk" "$_latin" "$_digit" "$_started" ''
+        (
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] mix start: cjk=$_cjk latin=$_latin digit=$_digit task=$_task"
+            if MODDIR="$MODDIR" apply_mix "$_cjk" "$_latin" "$_digit"; then
+                _finished=$(date +%s)
+                _message='完整复合字体已准备，完整重启后生效'
+                [ "$COMPOSITE_CACHE_HIT" = true ] && _message='已使用验证缓存准备字体组合，完整重启后生效'
+                write_task "$_task" success "$_message" "$_cjk" "$_latin" "$_digit" "$_started" "$_finished"
+                command -v cmd >/dev/null 2>&1 && cmd notification post -t 洛书 luoshu-mix "字体组合已准备，请完整重启手机。" >/dev/null 2>&1 || true
+            else
+                _rc=$?; _finished=$(date +%s)
+                _failure="${LAST_MIX_ERROR:-}"
+                [ -n "$_failure" ] || _failure=$(tail -n1 "$CONFIG_DIR/mix_last_error.txt" 2>/dev/null | tr -d '\r')
+                [ -n "$_failure" ] || _failure="字体组合失败（阶段代码 $_rc）"
+                write_task "$_task" failed "$_failure" "$_cjk" "$_latin" "$_digit" "$_started" "$_finished"
+            fi
+            rm -f "$CONFIG_DIR/mix_worker.pid" 2>/dev/null || true
+        ) </dev/null >> "$LOG_FILE" 2>&1 &
+        _bg=$!
+        printf '%s\n' "$_bg" > "$CONFIG_DIR/mix_worker.pid" 2>/dev/null || true
+        printf '{"status":"ok","data":{"task":"%s"}}\n' "$(json_escape "$_task")"
+        ;;
+    status) status_json ;;
+    recover) recover_interrupted_payload; printf '{"status":"ok"}\n' ;;
+    *) printf '{"status":"error","message":"未知组合命令"}\n' ;;
+esac
+exit 0

--- a/common/legacy_v14_4/font_mix_runtime.sh
+++ b/common/legacy_v14_4/font_mix_runtime.sh
@@ -1,0 +1,86 @@
+#!/system/bin/sh
+# v14.4 composite engine compatibility wrapper.
+# The original v14.1 font_mix engine is preserved byte-for-byte as font_mix_engine.sh.
+# This wrapper only bridges its async task lifecycle to the current private payload boot mode.
+set +e
+RUNTIME="${MODDIR:-}"
+REALMOD="${LUOSHU_REAL_MODDIR:-/data/adb/modules/LuoShu}"
+ENGINE="$RUNTIME/common/font_mix_engine.sh"
+TASK_FILE="$RUNTIME/config/mix_task.conf"
+LEGACY_MODE="$RUNTIME/config/font_runtime_legacy_v14_4.conf"
+LOG_FILE="$RUNTIME/logs/fontswitch.log"
+
+read_task_value() {
+    sed -n "s/^${1}=//p" "$TASK_FILE" 2>/dev/null | head -n1 | tr -d '\r\n'
+}
+
+mark_legacy_mix_mode() {
+    mkdir -p "$RUNTIME/config" 2>/dev/null || true
+    _tmp="${LEGACY_MODE}.tmp.$$"
+    {
+        printf 'enabled=true\n'
+        printf 'core=v14.4.0\n'
+        printf 'font=mix\n'
+        printf 'pipeline=legacy-v14-composite\n'
+        printf 'time=%s\n' "$(date +%s 2>/dev/null || echo 0)"
+    } >"$_tmp" 2>/dev/null && mv -f "$_tmp" "$LEGACY_MODE" 2>/dev/null || true
+    chmod 0600 "$LEGACY_MODE" 2>/dev/null || true
+    rm -f \
+        "$RUNTIME/config/font-payload-rebuild-pending.conf" \
+        "$RUNTIME/config/font-payload-reapply-notified.conf" \
+        "$RUNTIME/config/device-font-cache-pending.conf" \
+        "$RUNTIME/config/device-font-engine.conf" \
+        "$RUNTIME/config/device-font-installed.conf" \
+        "$RUNTIME/config/device-font-dynamic-mount.conf" \
+        "$RUNTIME/config/device-font-load-verification.json" \
+        "$RUNTIME/config/font-runtime-targets.conf" \
+        "$RUNTIME/config/font-target-aliases.conf" \
+        "$RUNTIME/config/font-target-coverage.conf" \
+        "$RUNTIME/config/font-config-overlay.conf" 2>/dev/null || true
+}
+
+monitor_task() {
+    _wanted="$1"
+    _loops=0
+    while [ "$_loops" -lt 720 ]; do
+        _task="$(read_task_value task)"
+        _state="$(read_task_value state)"
+        if [ "$_task" = "$_wanted" ]; then
+            case "$_state" in
+                success)
+                    mark_legacy_mix_mode
+                    printf '[%s] legacy-v14 composite task committed: %s\n' "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null)" "$_wanted" >>"$LOG_FILE" 2>/dev/null || true
+                    exit 0
+                    ;;
+                failed) exit 0 ;;
+            esac
+        fi
+        sleep 1
+        _loops=$((_loops + 1))
+    done
+    exit 0
+}
+
+case "${1:-status}" in
+    monitor)
+        monitor_task "${2:-}"
+        ;;
+    start)
+        _out="$(MODDIR="$RUNTIME" LUOSHU_REAL_MODDIR="$REALMOD" sh "$ENGINE" "$@" 2>&1)"
+        _rc=$?
+        printf '%s\n' "$_out"
+        if [ "$_rc" -eq 0 ]; then
+            _task=$(printf '%s\n' "$_out" | sed -n 's/^.*"task":"\([^"]*\)".*$/\1/p' | tail -n1)
+            if [ -n "$_task" ]; then
+                ( trap '' HUP; MODDIR="$RUNTIME" LUOSHU_REAL_MODDIR="$REALMOD" sh "$0" monitor "$_task" ) </dev/null >>"$LOG_FILE" 2>&1 &
+            fi
+        fi
+        exit "$_rc"
+        ;;
+    status|recover)
+        exec sh "$ENGINE" "$@"
+        ;;
+    *)
+        exec sh "$ENGINE" "$@"
+        ;;
+esac

--- a/common/legacy_v14_4/font_role_check.py
+++ b/common/legacy_v14_4/font_role_check.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Fast role coverage gate used before a LuoShu composite task is queued."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from fontTools.ttLib import TTCollection, TTFont
+
+CJK = tuple(map(ord, "中文字体系统默认洛书汉字"))
+LATIN = tuple(map(ord, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"))
+DIGITS = tuple(map(ord, "0123456789"))
+
+
+class RoleCheckError(RuntimeError):
+    pass
+
+
+def is_collection(path: Path) -> bool:
+    with path.open("rb") as stream:
+        return stream.read(4) == b"ttcf"
+
+
+def faces(path: Path) -> range:
+    if not is_collection(path):
+        return range(1)
+    collection = TTCollection(str(path), lazy=True)
+    try:
+        return range(len(collection.fonts))
+    finally:
+        collection.close()
+
+
+def required(role: str) -> tuple[int, ...]:
+    # The CJK source is the complete cmap base. It must provide the slots that
+    # are mandatory for replacement, but punctuation replacement is optional
+    # in composite_font.py and must not reject otherwise usable fonts.
+    if role == "cjk":
+        return CJK + LATIN + DIGITS
+    if role == "latin":
+        return LATIN
+    return DIGITS
+
+
+def inspect_face(path: Path, index: int, role: str) -> dict[str, object]:
+    kwargs: dict[str, object] = {"lazy": True, "recalcTimestamp": False}
+    if is_collection(path):
+        kwargs["fontNumber"] = index
+    font = TTFont(str(path), **kwargs)
+    try:
+        cmap = font.getBestCmap() or {}
+        probes = required(role)
+        missing = [codepoint for codepoint in probes if codepoint not in cmap]
+        return {
+            "face": index if is_collection(path) else -1,
+            "required": len(probes),
+            "present": len(probes) - len(missing),
+            "missing": [f"U+{codepoint:04X}" for codepoint in missing[:16]],
+            "valid": not missing,
+        }
+    finally:
+        font.close()
+
+
+def check(path: Path, role: str) -> dict[str, object]:
+    if not path.is_file() or path.stat().st_size < 4096:
+        raise RoleCheckError("字体文件不存在或文件过小")
+    results = [inspect_face(path, index, role) for index in faces(path)]
+    best = max(results, key=lambda item: int(item["present"]), default=None)
+    if best is None:
+        raise RoleCheckError("字体中没有可读取的字体面")
+    return {
+        "status": "ok" if best["valid"] else "error",
+        "role": role,
+        "path": str(path),
+        **best,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("font")
+    parser.add_argument("role", choices=("cjk", "latin", "digit"))
+    args = parser.parse_args()
+    try:
+        result = check(Path(args.font), args.role)
+        print(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
+        return 0 if result["valid"] else 2
+    except Exception as error:
+        print(
+            json.dumps(
+                {"status": "error", "role": args.role, "message": str(error) or error.__class__.__name__},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/common/legacy_v14_4/font_role_check.sh
+++ b/common/legacy_v14_4/font_role_check.sh
@@ -1,0 +1,44 @@
+#!/system/bin/sh
+# 在复合任务入队前检查中文、英文和数字角色的基础覆盖。
+set +e
+
+MODDIR="${MODDIR:-}"
+if [ -z "$MODDIR" ]; then
+    if [ -f "${0%/*}/../module.prop" ]; then
+        MODDIR="$(CDPATH= cd -- "${0%/*}/.." 2>/dev/null && pwd)"
+    else
+        MODDIR="/data/adb/modules/LuoShu"
+    fi
+fi
+MODULE_DIR="$MODDIR"
+USER_FONTS_DIR="${LUOSHU_PUBLIC_DIR:-/sdcard/LuoShu}/fonts"
+PYROOT="$MODDIR/common/python"
+PYBIN="$PYROOT/bin/luoshu-python"
+CHECKER="$MODDIR/common/font_role_check.py"
+[ -f "$MODDIR/common/util_functions.sh" ] && . "$MODDIR/common/util_functions.sh"
+
+check_family_role() {
+    _family="$1"
+    _role="$2"
+    _last=''
+    for _font in "$USER_FONTS_DIR"/*.ttf "$USER_FONTS_DIR"/*.otf "$USER_FONTS_DIR"/*.ttc \
+                 "$USER_FONTS_DIR"/*.TTF "$USER_FONTS_DIR"/*.OTF "$USER_FONTS_DIR"/*.TTC; do
+        [ -f "$_font" ] || continue
+        _detected=$(detect_font_family "$(basename "$_font")")
+        [ "$_detected" = "$_family" ] || continue
+        _last=$(PYTHONHOME="$PYROOT" \
+            PYTHONPATH="$PYROOT/lib/python3.14:$PYROOT/lib/python3.14/site-packages" \
+            LD_LIBRARY_PATH="$PYROOT/lib:$PYROOT/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+            "$PYBIN" "$CHECKER" "$_font" "$_role" 2>/dev/null)
+        [ "$?" -eq 0 ] && { printf '%s\n' "$_last"; return 0; }
+    done
+    [ -n "$_last" ] || _last='{"status":"error","message":"找不到指定字体族"}'
+    printf '%s\n' "$_last"
+    return 1
+}
+
+[ -x "$PYBIN" ] && [ -f "$CHECKER" ] || {
+    printf '{"status":"error","message":"字体角色检查器不可用"}\n'
+    exit 1
+}
+check_family_role "${1:-}" "${2:-}"

--- a/common/legacy_v14_4/luoshu_composite.sh
+++ b/common/legacy_v14_4/luoshu_composite.sh
@@ -1,0 +1,16 @@
+#!/system/bin/sh
+set -eu
+MODDIR="${MODDIR:-$(CDPATH= cd -- "${0%/*}/.." 2>/dev/null && pwd)}"
+RUNTIME="$MODDIR/common/python"
+PYBIN="$RUNTIME/bin/luoshu-python"
+[ -x "$PYBIN" ] || { echo '{"status":"error","message":"复合字体运行时缺失"}' >&2; exit 20; }
+case "$(uname -m 2>/dev/null || true)" in aarch64|arm64) ;; *) echo '{"status":"error","message":"完整复合字体引擎仅支持 ARM64"}' >&2; exit 21 ;; esac
+export PYTHONHOME="$RUNTIME"
+export PYTHONPATH="$RUNTIME/lib/python3.14:$RUNTIME/lib/python3.14/site-packages"
+export LD_LIBRARY_PATH="$RUNTIME/lib:$RUNTIME/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export TMPDIR="${TMPDIR:-$MODDIR/cache/tmp}"
+mkdir -p "$TMPDIR" 2>/dev/null || true
+if [ "${1:-}" = "--self-test" ]; then
+    exec "$PYBIN" -c 'import fontTools; print("ok")'
+fi
+exec "$PYBIN" "$MODDIR/common/composite_font.py" "$@"

--- a/common/legacy_v14_4/mix_router.sh
+++ b/common/legacy_v14_4/mix_router.sh
@@ -1,0 +1,108 @@
+#!/system/bin/sh
+# Current App -> pre-reset v14.4 composite-core router.
+# UI/API stay on v4; composite generation, weighted/auto engines and final physical mapping use v14.
+set +e
+REALMOD="${MODDIR:-}"
+if [ -z "$REALMOD" ]; then
+    if [ -f "${0%/*}/../../module.prop" ]; then
+        REALMOD="$(CDPATH= cd -- "${0%/*}/../.." 2>/dev/null && pwd)"
+    else
+        REALMOD="/data/adb/modules/LuoShu"
+    fi
+fi
+LEGACY="$REALMOD/common/legacy_v14_4"
+RUNTIME="$REALMOD/.legacy-v14-runtime"
+PAYLOAD="$REALMOD/.luoshu-payload"
+LOG_FILE="$REALMOD/logs/fontswitch.log"
+
+force_link() {
+    _target="$1"; _link="$2"
+    if [ -L "$_link" ]; then
+        ln -sfn "$_target" "$_link" 2>/dev/null || return 1
+    elif [ -e "$_link" ]; then
+        rm -rf "$_link" 2>/dev/null || return 1
+        ln -s "$_target" "$_link" 2>/dev/null || return 1
+    else
+        ln -s "$_target" "$_link" 2>/dev/null || return 1
+    fi
+}
+
+setup_runtime() {
+    mkdir -p "$RUNTIME/common" "$REALMOD/config" "$REALMOD/cache" "$REALMOD/logs" "$PAYLOAD" 2>/dev/null || return 1
+    force_link "$REALMOD/config" "$RUNTIME/config" || return 1
+    force_link "$REALMOD/cache" "$RUNTIME/cache" || return 1
+    force_link "$REALMOD/logs" "$RUNTIME/logs" || return 1
+    force_link "$PAYLOAD" "$RUNTIME/.luoshu-payload" || return 1
+    force_link "$REALMOD/module.prop" "$RUNTIME/module.prop" || return 1
+
+    for _part in system system_ext product vendor odm oem my_product my_engineering my_company my_preload my_region my_stock oplus_product oplus_engineering oplus_version oplus_region mi_ext cust hw_product; do
+        mkdir -p "$PAYLOAD/$_part" 2>/dev/null || true
+        force_link "$PAYLOAD/$_part" "$RUNTIME/$_part" || return 1
+    done
+
+    force_link "$LEGACY/v14_mix.sh" "$RUNTIME/common/v14_mix.sh" || return 1
+    force_link "$LEGACY/v142_weighted_mix.sh" "$RUNTIME/common/v142_weighted_mix.sh" || return 1
+    force_link "$LEGACY/v143_auto_multiweight_mix.sh" "$RUNTIME/common/v143_auto_multiweight_mix.sh" || return 1
+    force_link "$LEGACY/font_mix_runtime.sh" "$RUNTIME/common/font_mix.sh" || return 1
+    force_link "$LEGACY/font_mix_engine.sh" "$RUNTIME/common/font_mix_engine.sh" || return 1
+    force_link "$LEGACY/font_instance.py" "$RUNTIME/common/font_instance.py" || return 1
+    force_link "$LEGACY/composite_font.py" "$RUNTIME/common/composite_font.py" || return 1
+    force_link "$LEGACY/luoshu_composite.sh" "$RUNTIME/common/luoshu_composite.sh" || return 1
+    force_link "$LEGACY/mix_weight_mode.sh" "$RUNTIME/common/mix_weight_mode.sh" || return 1
+    force_link "$LEGACY/font_role_check.sh" "$RUNTIME/common/font_role_check.sh" || return 1
+    force_link "$LEGACY/font_role_check.py" "$RUNTIME/common/font_role_check.py" || return 1
+    force_link "$LEGACY/util_functions.sh" "$RUNTIME/common/util_functions.sh" || return 1
+    force_link "$LEGACY/font_check.sh" "$RUNTIME/common/font_check.sh" || return 1
+    force_link "$LEGACY/rom_adapters.sh" "$RUNTIME/common/rom_adapters.sh" || return 1
+    force_link "$REALMOD/common/python" "$RUNTIME/common/python" || return 1
+    force_link "$REALMOD/common/font_manager.sh" "$RUNTIME/common/font_manager.sh" || return 1
+    force_link "$REALMOD/common/legacy_v14_4_switch.sh" "$RUNTIME/common/legacy_v14_4_switch.sh" || return 1
+    force_link "$REALMOD/common/font_switch_lock.sh" "$RUNTIME/common/font_switch_lock.sh" || return 1
+    force_link "$LEGACY" "$RUNTIME/common/legacy_v14_4" || return 1
+    force_link "$REALMOD/common/module_status.sh" "$RUNTIME/common/module_status.sh" || true
+
+    cat >"$RUNTIME/common/mount_compat.sh" <<'EOF'
+#!/system/bin/sh
+# v14 compatibility runtime: partition paths already resolve directly into .luoshu-payload.
+set +e
+EOF
+    chmod 0755 "$RUNTIME/common/mount_compat.sh" 2>/dev/null || true
+    return 0
+}
+
+mark_mix_mode_if_success() {
+    _out="$1"
+    printf '%s\n' "$_out" | grep -q '"state":"success"' || return 0
+    _tmp="$REALMOD/config/font_runtime_legacy_v14_4.conf.tmp.$$"
+    {
+        printf 'enabled=true\ncore=v14.4.0\nfont=mix\npipeline=legacy-v14-composite\ntime=%s\n' "$(date +%s 2>/dev/null || echo 0)"
+    } >"$_tmp" 2>/dev/null && mv -f "$_tmp" "$REALMOD/config/font_runtime_legacy_v14_4.conf" 2>/dev/null || true
+    chmod 0600 "$REALMOD/config/font_runtime_legacy_v14_4.conf" 2>/dev/null || true
+}
+
+setup_runtime || {
+    printf '{"status":"error","message":"无法准备 v14.4 复合字体兼容运行时"}\n'
+    exit 1
+}
+export LUOSHU_REAL_MODDIR="$REALMOD"
+export MODDIR="$RUNTIME"
+export MODULE_DIR="$RUNTIME"
+
+case "${1:-config}" in
+    reconcile)
+        printf '{"status":"ok"}\n'
+        ;;
+    status)
+        _out="$(sh "$RUNTIME/common/v14_mix.sh" "$@" 2>&1)"
+        _rc=$?
+        printf '%s\n' "$_out"
+        mark_mix_mode_if_success "$_out"
+        exit "$_rc"
+        ;;
+    start|config|recover)
+        exec sh "$RUNTIME/common/v14_mix.sh" "$@"
+        ;;
+    *)
+        exec sh "$RUNTIME/common/v14_mix.sh" "$@"
+        ;;
+esac

--- a/common/legacy_v14_4/mix_weight_mode.sh
+++ b/common/legacy_v14_4/mix_weight_mode.sh
@@ -1,0 +1,92 @@
+#!/system/bin/sh
+# 根据字体能力和当前 wght 判断组合槽位是否仍处于自动多字重状态。
+
+mix_role_weight() {
+    case "$1" in
+        thin) echo 100 ;; extralight) echo 200 ;; light) echo 300 ;; regular|normal) echo 400 ;;
+        medium) echo 500 ;; semibold) echo 600 ;; bold) echo 700 ;; extrabold) echo 800 ;;
+        black|heavy) echo 900 ;; *) echo 400 ;;
+    esac
+}
+
+mix_axis_weight() {
+    _spec="$1"
+    _value=$(printf '%s' "$_spec" | tr ',' '\n' | sed -n 's/^wght=//p' | head -n1)
+    _value=${_value%%.*}
+    case "$_value" in ''|*[!0-9]*) _value=400 ;; esac
+    [ "$_value" -ge 1 ] 2>/dev/null || _value=1
+    [ "$_value" -le 1000 ] 2>/dev/null || _value=1000
+    printf '%s\n' "$_value"
+}
+
+mix_find_family_source() {
+    _family="$1"
+    _variable=''
+    _regular=''
+    _first=''
+    for _font in "$USER_FONTS_DIR"/*.ttf "$USER_FONTS_DIR"/*.otf "$USER_FONTS_DIR"/*.ttc \
+                 "$USER_FONTS_DIR"/*.TTF "$USER_FONTS_DIR"/*.OTF "$USER_FONTS_DIR"/*.TTC; do
+        [ -f "$_font" ] || continue
+        [ "$(detect_font_family "$(basename "$_font")")" = "$_family" ] || continue
+        [ -n "$_first" ] || _first="$_font"
+        if is_variable_font "$_font" 2>/dev/null; then
+            [ -n "$_variable" ] || _variable="$_font"
+            continue
+        fi
+        if [ "$(detect_font_weight "$(basename "$_font")")" = regular ] && [ -z "$_regular" ]; then
+            _regular="$_font"
+        fi
+    done
+    for _candidate in "$_variable" "$_regular" "$_first"; do
+        [ -f "$_candidate" ] && { printf '%s\n' "$_candidate"; return 0; }
+    done
+    return 1
+}
+
+# 输出 wght 的 fvar 默认值；没有 wght 轴时输出空字符串。
+mix_variable_default_weight() {
+    _source="$1"
+    _pyroot="${MODDIR:-/data/adb/modules/LuoShu}/common/python"
+    _python="$_pyroot/bin/luoshu-python"
+    [ -x "$_python" ] || return 0
+    PYTHONHOME="$_pyroot" \
+    PYTHONPATH="$_pyroot/lib/python3.14:$_pyroot/lib/python3.14/site-packages" \
+    LD_LIBRARY_PATH="$_pyroot/lib:$_pyroot/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+        "$_python" -c 'import sys
+from fontTools.ttLib import TTFont
+font=TTFont(sys.argv[1], lazy=True)
+value=None
+if "fvar" in font:
+    for axis in font["fvar"].axes:
+        if axis.axisTag == "wght":
+            value=round(float(axis.defaultValue)); break
+if value is not None:
+    print(max(1,min(1000,int(value))))' "$_source" 2>/dev/null || true
+}
+
+mix_static_default_weight() {
+    _family="$1"
+    _weights=$(scan_family_weights "$_family" 2>/dev/null)
+    case ",$_weights," in *,regular,*) echo 400; return ;; esac
+    _first=$(printf '%s' "$_weights" | tr ',' '\n' | sed -n '1p')
+    mix_role_weight "$_first"
+}
+
+infer_mix_weight_mode() {
+    _family="$1"
+    _axes="$2"
+    _source=$(mix_find_family_source "$_family")
+    [ -f "$_source" ] || { echo fixed; return; }
+    _current=$(mix_axis_weight "$_axes")
+    if is_variable_font "$_source" 2>/dev/null; then
+        _default=$(mix_variable_default_weight "$_source")
+        [ -n "$_default" ] && [ "$_current" = "$_default" ] && echo auto || echo fixed
+        return
+    fi
+    _weights=$(scan_family_weights "$_family" 2>/dev/null)
+    _count=$(printf '%s' "$_weights" | tr ',' '\n' | grep -c . 2>/dev/null)
+    case "$_count" in ''|*[!0-9]*) _count=0 ;; esac
+    [ "$_count" -ge 2 ] 2>/dev/null || { echo fixed; return; }
+    _default=$(mix_static_default_weight "$_family")
+    [ "$_current" = "$_default" ] && echo auto || echo fixed
+}

--- a/common/legacy_v14_4/v142_weighted_mix.sh
+++ b/common/legacy_v14_4/v142_weighted_mix.sh
@@ -1,0 +1,404 @@
+#!/system/bin/sh
+# 洛书 v14.2 RC2：异步真实字重与多轴字体组合桥。
+# 任务状态持久化在模块目录，App 或 WebUI 退出后可重新接管。
+set +e
+
+MODDIR="${MODDIR:-}"
+if [ -z "$MODDIR" ]; then
+    if [ -f "${0%/*}/../module.prop" ]; then
+        MODDIR="$(CDPATH= cd -- "${0%/*}/.." 2>/dev/null && pwd)"
+    else
+        MODDIR="/data/adb/modules/LuoShu"
+    fi
+fi
+
+CONFIG_DIR="$MODDIR/config"
+CACHE_ROOT="$MODDIR/cache/axes-mix"
+USER_FONTS_DIR="${LUOSHU_PUBLIC_DIR:-/sdcard/LuoShu}/fonts"
+BASE_ENGINE="$MODDIR/common/font_mix.sh"
+INSTANCE_PY="$MODDIR/common/font_instance.py"
+PYROOT="$MODDIR/common/python"
+PYBIN="$PYROOT/bin/luoshu-python"
+BASE_TASK_FILE="$CONFIG_DIR/mix_task.conf"
+TASK_FILE="$CONFIG_DIR/axes_task.conf"
+AXES_CONF="$CONFIG_DIR/axes_mix.conf"
+MIX_CONF="$CONFIG_DIR/font_mix.conf"
+ACTIVE_CONF="$CONFIG_DIR/active_font.conf"
+PROGRESS_FILE="$CONFIG_DIR/composite_progress.json"
+TEXT_REBOOT_REQUIRED="$CONFIG_DIR/text_reboot_required.conf"
+LOCK_FILE="$MODDIR/.font_switch.lock"
+WORKER_PID="$CONFIG_DIR/axes_worker.pid"
+LOG_FILE="$MODDIR/logs/fontswitch.log"
+
+MODULE_DIR="$MODDIR"
+[ -f "$MODDIR/common/util_functions.sh" ] && . "$MODDIR/common/util_functions.sh"
+[ -f "$MODDIR/common/font_check.sh" ] && . "$MODDIR/common/font_check.sh"
+
+json_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '
+}
+
+read_value() {
+    sed -n "s/^${2}=//p" "$1" 2>/dev/null | head -n1 | tr -d '\r\n'
+}
+
+clean_spec() {
+    printf '%s' "$1" | tr -d '\r\n'
+}
+
+axis_value() {
+    _spec="$1"
+    _tag="$2"
+    _fallback="$3"
+    _value=$(printf '%s' "$_spec" | tr ',' '\n' | sed -n "s/^${_tag}=//p" | head -n1)
+    case "$_value" in ''|*[!0-9.-]*) _value="$_fallback" ;; esac
+    printf '%s' "$_value"
+}
+
+safe_weight() {
+    _weight=$(axis_value "$1" wght 400)
+    _weight=${_weight%%.*}
+    case "$_weight" in ''|*[!0-9]*) _weight=400 ;; esac
+    [ "$_weight" -ge 1 ] 2>/dev/null || _weight=1
+    [ "$_weight" -le 1000 ] 2>/dev/null || _weight=1000
+    printf '%s' "$_weight"
+}
+
+role_weight() {
+    case "$1" in
+        thin) echo 100 ;;
+        extralight) echo 200 ;;
+        light) echo 300 ;;
+        regular|normal) echo 400 ;;
+        medium) echo 500 ;;
+        semibold) echo 600 ;;
+        bold) echo 700 ;;
+        extrabold) echo 800 ;;
+        black|heavy) echo 900 ;;
+        variable) echo "$2" ;;
+        *) echo 400 ;;
+    esac
+}
+
+write_task() {
+    _tmp="$TASK_FILE.tmp.$$"
+    {
+        printf 'task=%s\n' "$1"
+        printf 'state=%s\n' "$2"
+        printf 'message=%s\n' "$3"
+        printf 'cjk=%s\nlatin=%s\ndigit=%s\n' "$4" "$5" "$6"
+        printf 'cjkAxes=%s\nlatinAxes=%s\ndigitAxes=%s\n' "$7" "$8" "$9"
+        shift 9
+        printf 'root=%s\nchildTask=%s\nstarted=%s\nfinished=%s\npercent=%s\n' "$1" "$2" "$3" "$4" "$5"
+    } >"$_tmp" 2>/dev/null && mv -f "$_tmp" "$TASK_FILE" 2>/dev/null
+    chmod 0644 "$TASK_FILE" 2>/dev/null || true
+}
+
+update_task() {
+    _wanted="$1"
+    _state="$2"
+    _message="$3"
+    _percent="$4"
+    _child="$5"
+    _finished="$6"
+    [ "$(read_value "$TASK_FILE" task)" = "$_wanted" ] || return 1
+    _cjk=$(read_value "$TASK_FILE" cjk)
+    _latin=$(read_value "$TASK_FILE" latin)
+    _digit=$(read_value "$TASK_FILE" digit)
+    _cjk_axes=$(read_value "$TASK_FILE" cjkAxes)
+    _latin_axes=$(read_value "$TASK_FILE" latinAxes)
+    _digit_axes=$(read_value "$TASK_FILE" digitAxes)
+    _root=$(read_value "$TASK_FILE" root)
+    _started=$(read_value "$TASK_FILE" started)
+    [ -n "$_child" ] || _child=$(read_value "$TASK_FILE" childTask)
+    [ -n "$_finished" ] || _finished=$(read_value "$TASK_FILE" finished)
+    write_task "$_wanted" "$_state" "$_message" "$_cjk" "$_latin" "$_digit" \
+        "$_cjk_axes" "$_latin_axes" "$_digit_axes" "$_root" "$_child" "$_started" "$_finished" "$_percent"
+}
+
+find_best_source() {
+    _family="$1"
+    _target="$2"
+    _best=""
+    _best_score=99999
+    for _font in "$USER_FONTS_DIR"/*.ttf "$USER_FONTS_DIR"/*.otf "$USER_FONTS_DIR"/*.ttc \
+                 "$USER_FONTS_DIR"/*.TTF "$USER_FONTS_DIR"/*.OTF "$USER_FONTS_DIR"/*.TTC; do
+        [ -f "$_font" ] || continue
+        _name=$(basename "$_font")
+        _detected=$(detect_font_family "$_name")
+        [ "$_detected" = "$_family" ] || continue
+        if is_variable_font "$_font" 2>/dev/null; then
+            printf '%s\n' "$_font"
+            return 0
+        fi
+        _role=$(detect_font_weight "$_name")
+        _number=$(role_weight "$_role" "$_target")
+        _score=$((_number - _target))
+        [ "$_score" -ge 0 ] 2>/dev/null || _score=$((-_score))
+        if [ -z "$_best" ] || [ "$_score" -lt "$_best_score" ] 2>/dev/null; then
+            _best="$_font"
+            _best_score="$_score"
+        fi
+    done
+    [ -n "$_best" ] || return 1
+    printf '%s\n' "$_best"
+}
+
+run_instance() {
+    _source="$1"
+    _destination="$2"
+    _role="$3"
+    _axes="$4"
+    _weight=$(safe_weight "$_axes")
+    _report="${_destination}.json"
+    _error="${_destination}.err"
+    [ -x "$PYBIN" ] || chmod 0755 "$PYBIN" 2>/dev/null || true
+    (
+        export PYTHONHOME="$PYROOT"
+        export PYTHONPATH="$PYROOT/lib/python3.14:$PYROOT/lib/python3.14/site-packages"
+        export LD_LIBRARY_PATH="$PYROOT/lib:$PYROOT/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        export TMPDIR="${TMPDIR:-$MODDIR/cache/tmp}"
+        mkdir -p "$TMPDIR" 2>/dev/null || true
+        "$PYBIN" "$INSTANCE_PY" --input "$_source" --output "$_destination" \
+            --role "$_role" --weight "$_weight" --axes "$_axes"
+    ) >"$_report" 2>"$_error"
+    _code=$?
+    if [ "$_code" -ne 0 ] || [ ! -s "$_destination" ]; then
+        _message=$(sed -n 's/^.*"message":"\([^"]*\)".*$/\1/p' "$_error" "$_report" 2>/dev/null | tail -n1)
+        [ -n "$_message" ] || _message=$(tail -n1 "$_error" 2>/dev/null | tr -d '\r')
+        [ -n "$_message" ] || _message="字体实例化失败（代码 $_code）"
+        echo "错误：$_message" >&2
+        return 1
+    fi
+    rm -f "$_error" 2>/dev/null || true
+    chmod 0644 "$_destination" "$_report" 2>/dev/null || true
+    return 0
+}
+
+prepare_slot() {
+    _role="$1"
+    _family="$2"
+    _axes="$3"
+    _root="$4"
+    _internal="$5"
+    _weight=$(safe_weight "$_axes")
+    _source=$(find_best_source "$_family" "$_weight")
+    [ -f "$_source" ] || { echo "错误：找不到字体族 $_family" >&2; return 1; }
+    font_validate "$_source" text || { echo "错误：字体 $_family 无效：$FONT_CHECK_ERROR" >&2; return 1; }
+    _destination="$_root/fonts/${_internal}-Regular.ttf"
+    mkdir -p "${_destination%/*}" 2>/dev/null || return 1
+    if [ "$FONT_CHECK_VARIABLE" = true ] || [ "$FONT_CHECK_FORMAT" = TTC ]; then
+        run_instance "$_source" "$_destination" "$_role" "$_axes" || return 1
+    else
+        cp -f "$_source" "$_destination" 2>/dev/null || return 1
+        chmod 0644 "$_destination" 2>/dev/null || true
+    fi
+    [ -s "$_destination" ]
+}
+
+rewrite_public_config() {
+    [ -s "$TASK_FILE" ] || return 0
+    [ "$(read_value "$TASK_FILE" state)" = success ] || return 0
+    _cjk=$(read_value "$TASK_FILE" cjk)
+    _latin=$(read_value "$TASK_FILE" latin)
+    _digit=$(read_value "$TASK_FILE" digit)
+    _cjk_axes=$(read_value "$TASK_FILE" cjkAxes)
+    _latin_axes=$(read_value "$TASK_FILE" latinAxes)
+    _digit_axes=$(read_value "$TASK_FILE" digitAxes)
+    _tmp="$MIX_CONF.axes.$$"
+    {
+        printf 'cjk=%s\nlatin=%s\ndigit=%s\n' "$_cjk" "$_latin" "$_digit"
+        printf 'cjkWeight=%s\nlatinWeight=%s\ndigitWeight=%s\n' \
+            "$(safe_weight "$_cjk_axes")" "$(safe_weight "$_latin_axes")" "$(safe_weight "$_digit_axes")"
+        printf 'cjkAxes=%s\nlatinAxes=%s\ndigitAxes=%s\n' "$_cjk_axes" "$_latin_axes" "$_digit_axes"
+        [ ! -f "$MIX_CONF" ] || grep -v -E '^(cjk|latin|digit|cjkWeight|latinWeight|digitWeight|cjkAxes|latinAxes|digitAxes)=' "$MIX_CONF" 2>/dev/null
+    } >"$_tmp" 2>/dev/null && mv -f "$_tmp" "$MIX_CONF" 2>/dev/null
+    cp -f "$MIX_CONF" "$AXES_CONF" 2>/dev/null || true
+    chmod 0644 "$MIX_CONF" "$AXES_CONF" 2>/dev/null || true
+}
+
+worker() {
+    _wanted="$1"
+    [ "$(read_value "$TASK_FILE" task)" = "$_wanted" ] || exit 0
+    _cjk=$(read_value "$TASK_FILE" cjk)
+    _latin=$(read_value "$TASK_FILE" latin)
+    _digit=$(read_value "$TASK_FILE" digit)
+    _cjk_axes=$(read_value "$TASK_FILE" cjkAxes)
+    _latin_axes=$(read_value "$TASK_FILE" latinAxes)
+    _digit_axes=$(read_value "$TASK_FILE" digitAxes)
+    _root=$(read_value "$TASK_FILE" root)
+
+    update_task "$_wanted" running '正在准备中文字体' 4 '' ''
+    prepare_slot cjk "$_cjk" "$_cjk_axes" "$_root" LuoShuMixCJK || {
+        update_task "$_wanted" failed '中文字体准备失败' 100 '' "$(date +%s)"
+        rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+    }
+    update_task "$_wanted" running '正在准备英文字体' 14 '' ''
+    prepare_slot latin "$_latin" "$_latin_axes" "$_root" LuoShuMixLatin || {
+        update_task "$_wanted" failed '英文字体准备失败' 100 '' "$(date +%s)"
+        rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+    }
+    update_task "$_wanted" running '正在准备数字字体' 24 '' ''
+    prepare_slot digit "$_digit" "$_digit_axes" "$_root" LuoShuMixDigit || {
+        update_task "$_wanted" failed '数字字体准备失败' 100 '' "$(date +%s)"
+        rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+    }
+
+    update_task "$_wanted" running '正在启动完整复合字体引擎' 34 '' ''
+    _output=$(LUOSHU_PUBLIC_DIR="$_root" MODDIR="$MODDIR" sh "$BASE_ENGINE" start LuoShuMixCJK LuoShuMixLatin LuoShuMixDigit 2>&1)
+    _child=$(printf '%s\n' "$_output" | sed -n 's/^.*"task":"\([^"]*\)".*$/\1/p' | tail -n1)
+    if [ -z "$_child" ]; then
+        _message=$(printf '%s\n' "$_output" | sed -n 's/^.*"message":"\([^"]*\)".*$/\1/p' | tail -n1)
+        [ -n "$_message" ] || _message='无法启动完整复合字体引擎'
+        update_task "$_wanted" failed "$_message" 100 '' "$(date +%s)"
+        rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+    fi
+
+    update_task "$_wanted" running '完整复合字体正在后台生成' 36 "$_child" ''
+    _loops=0
+    while [ "$_loops" -lt 360 ]; do
+        _base_task=$(read_value "$BASE_TASK_FILE" task)
+        _base_state=$(read_value "$BASE_TASK_FILE" state)
+        if [ "$_base_task" = "$_child" ]; then
+            _base_message=$(read_value "$BASE_TASK_FILE" message)
+            _base_percent=0
+            if [ -s "$PROGRESS_FILE" ]; then
+                _base_percent=$(sed -n 's/^.*"percent":\([0-9][0-9]*\).*$/\1/p' "$PROGRESS_FILE" 2>/dev/null | head -n1)
+            fi
+            case "$_base_percent" in ''|*[!0-9]*) _base_percent=0 ;; esac
+            _mapped=$((36 + (_base_percent * 64 / 100)))
+            [ "$_mapped" -le 99 ] || _mapped=99
+            [ -n "$_base_message" ] || _base_message='完整复合字体正在后台生成'
+            case "$_base_state" in
+                success)
+                    update_task "$_wanted" success "$_base_message" 100 "$_child" "$(date +%s)"
+                    rewrite_public_config
+                    rm -rf "$_root"; rm -f "$WORKER_PID"; exit 0
+                    ;;
+                failed)
+                    update_task "$_wanted" failed "$_base_message" 100 "$_child" "$(date +%s)"
+                    rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+                    ;;
+                *) update_task "$_wanted" running "$_base_message" "$_mapped" "$_child" '' ;;
+            esac
+        fi
+        sleep 2
+        _loops=$((_loops + 1))
+    done
+
+    update_task "$_wanted" failed '完整复合字体生成超时' 100 "$_child" "$(date +%s)"
+    rm -rf "$_root"; rm -f "$WORKER_PID"
+    exit 1
+}
+
+status_json() {
+    _wanted="$1"
+    [ -s "$TASK_FILE" ] || { printf '{"status":"error","message":"暂无字体组合任务"}\n'; return; }
+    _task=$(read_value "$TASK_FILE" task)
+    [ -z "$_wanted" ] || [ "$_wanted" = "$_task" ] || {
+        printf '{"status":"error","message":"任务不存在或已被新任务替换"}\n'; return
+    }
+    _state=$(read_value "$TASK_FILE" state)
+    _message=$(read_value "$TASK_FILE" message)
+    _cjk=$(read_value "$TASK_FILE" cjk)
+    _latin=$(read_value "$TASK_FILE" latin)
+    _digit=$(read_value "$TASK_FILE" digit)
+    _cjk_axes=$(read_value "$TASK_FILE" cjkAxes)
+    _latin_axes=$(read_value "$TASK_FILE" latinAxes)
+    _digit_axes=$(read_value "$TASK_FILE" digitAxes)
+    _started=$(read_value "$TASK_FILE" started)
+    _finished=$(read_value "$TASK_FILE" finished)
+    _percent=$(read_value "$TASK_FILE" percent)
+    printf '{"status":"ok","data":{"task":"%s","state":"%s","message":"%s","cjk":"%s","latin":"%s","digit":"%s","cjkWeight":%s,"latinWeight":%s,"digitWeight":%s,"cjkAxes":"%s","latinAxes":"%s","digitAxes":"%s","started":%s,"finished":%s,"progress":{"message":"%s","percent":%s}}}\n' \
+        "$(json_escape "$_task")" "$(json_escape "$_state")" "$(json_escape "$_message")" \
+        "$(json_escape "$_cjk")" "$(json_escape "$_latin")" "$(json_escape "$_digit")" \
+        "$(safe_weight "$_cjk_axes")" "$(safe_weight "$_latin_axes")" "$(safe_weight "$_digit_axes")" \
+        "$(json_escape "$_cjk_axes")" "$(json_escape "$_latin_axes")" "$(json_escape "$_digit_axes")" \
+        "${_started:-0}" "${_finished:-0}" "$(json_escape "$_message")" "${_percent:-0}"
+}
+
+config_json() {
+    rewrite_public_config
+    _source="$AXES_CONF"
+    [ -s "$_source" ] || _source="$MIX_CONF"
+    _cjk=$(read_value "$_source" cjk)
+    _latin=$(read_value "$_source" latin)
+    _digit=$(read_value "$_source" digit)
+    _cjk_axes=$(read_value "$_source" cjkAxes)
+    _latin_axes=$(read_value "$_source" latinAxes)
+    _digit_axes=$(read_value "$_source" digitAxes)
+    [ -n "$_cjk_axes" ] || _cjk_axes="wght=$(read_value "$_source" cjkWeight)"
+    [ -n "$_latin_axes" ] || _latin_axes="wght=$(read_value "$_source" latinWeight)"
+    [ -n "$_digit_axes" ] || _digit_axes="wght=$(read_value "$_source" digitWeight)"
+    _active=$(head -n1 "$ACTIVE_CONF" 2>/dev/null | tr -d '\r\n')
+    _enabled=false
+    [ "$_active" = mix ] && _enabled=true
+    printf '{"status":"ok","data":{"enabled":%s,"cjk":"%s","latin":"%s","digit":"%s","cjkWeight":%s,"latinWeight":%s,"digitWeight":%s,"cjkAxes":"%s","latinAxes":"%s","digitAxes":"%s"}}\n' \
+        "$_enabled" "$(json_escape "$_cjk")" "$(json_escape "$_latin")" "$(json_escape "$_digit")" \
+        "$(safe_weight "$_cjk_axes")" "$(safe_weight "$_latin_axes")" "$(safe_weight "$_digit_axes")" \
+        "$(json_escape "$_cjk_axes")" "$(json_escape "$_latin_axes")" "$(json_escape "$_digit_axes")"
+}
+
+start_mix() {
+    _cjk="$1"
+    _latin="$2"
+    _digit="$3"
+    _cjk_axes=$(clean_spec "$4")
+    _latin_axes=$(clean_spec "$5")
+    _digit_axes=$(clean_spec "$6")
+    [ -n "$_cjk" ] && [ -n "$_latin" ] && [ -n "$_digit" ] || {
+        printf '{"status":"error","message":"请选择中文、英文和数字字体"}\n'; return
+    }
+    [ ! -f "$TEXT_REBOOT_REQUIRED" ] || {
+        printf '{"status":"error","message":"本次开机已更改文字字体，请先重启手机"}\n'; return
+    }
+    if [ -s "$WORKER_PID" ]; then
+        _old=$(cat "$WORKER_PID" 2>/dev/null)
+        [ -z "$_old" ] || ! kill -0 "$_old" 2>/dev/null || {
+            printf '{"status":"error","message":"已有字体组合任务正在运行"}\n'; return
+        }
+    fi
+    [ ! -e "$LOCK_FILE" ] || { printf '{"status":"error","message":"字体正在切换中"}\n'; return; }
+    [ -n "$_cjk_axes" ] || _cjk_axes='wght=400'
+    [ -n "$_latin_axes" ] || _latin_axes='wght=400'
+    [ -n "$_digit_axes" ] || _digit_axes='wght=400'
+    mkdir -p "$CONFIG_DIR" "$CACHE_ROOT" "$MODDIR/cache/tmp" "$MODDIR/logs" 2>/dev/null || {
+        printf '{"status":"error","message":"无法创建字体组合缓存目录"}\n'; return
+    }
+    _request="axes-$(date +%s)-$$"
+    _root="$CACHE_ROOT/$_request"
+    mkdir -p "$_root/fonts" 2>/dev/null || {
+        printf '{"status":"error","message":"无法创建字体暂存目录"}\n'; return
+    }
+    write_task "$_request" queued '任务已进入后台队列' "$_cjk" "$_latin" "$_digit" \
+        "$_cjk_axes" "$_latin_axes" "$_digit_axes" "$_root" '' "$(date +%s)" '' 1
+    ( MODDIR="$MODDIR" sh "$0" worker "$_request" ) </dev/null >>"$LOG_FILE" 2>&1 &
+    _pid=$!
+    printf '%s\n' "$_pid" >"$WORKER_PID" 2>/dev/null || true
+    printf '{"status":"ok","data":{"task":"%s"}}\n' "$(json_escape "$_request")"
+}
+
+recover_task() {
+    MODDIR="$MODDIR" sh "$BASE_ENGINE" recover >/dev/null 2>&1 || true
+    if [ -s "$TASK_FILE" ]; then
+        _state=$(read_value "$TASK_FILE" state)
+        _task=$(read_value "$TASK_FILE" task)
+        _root=$(read_value "$TASK_FILE" root)
+        case "$_state" in
+            queued|running) update_task "$_task" failed '上次字体组合任务被开机恢复中止' 100 '' "$(date +%s)" ;;
+        esac
+        [ -z "$_root" ] || rm -rf "$_root" 2>/dev/null || true
+    fi
+    rm -f "$WORKER_PID" 2>/dev/null || true
+    printf '{"status":"ok"}\n'
+}
+
+case "${1:-config}" in
+    start) start_mix "$2" "$3" "$4" "${5:-wght=400}" "${6:-wght=400}" "${7:-wght=400}" ;;
+    status) status_json "${2:-}" ;;
+    config) config_json ;;
+    worker) worker "$2" ;;
+    recover) recover_task ;;
+    *) printf '{"status":"error","message":"未知多轴组合命令"}\n' ;;
+esac
+exit 0

--- a/common/legacy_v14_4/v143_auto_multiweight_mix.sh
+++ b/common/legacy_v14_4/v143_auto_multiweight_mix.sh
@@ -1,0 +1,487 @@
+#!/system/bin/sh
+# 洛书 v14.3.9：组合页自动多字重复合引擎。
+set +e
+
+MODDIR="${MODDIR:-}"
+if [ -z "$MODDIR" ]; then
+    if [ -f "${0%/*}/../module.prop" ]; then
+        MODDIR="$(CDPATH= cd -- "${0%/*}/.." 2>/dev/null && pwd)"
+    else
+        MODDIR="/data/adb/modules/LuoShu"
+    fi
+fi
+CONFIG_DIR="$MODDIR/config"
+CACHE_ROOT="$MODDIR/cache/auto-multiweight-mix"
+COMPOSITE_CACHE="$CACHE_ROOT/composites-v1"
+PUBLIC_ROOT="${LUOSHU_PUBLIC_DIR:-/sdcard/LuoShu}"
+SOURCE_FONTS="$PUBLIC_ROOT/fonts"
+USER_FONTS_DIR="$SOURCE_FONTS"
+FONT_MANAGER="$MODDIR/common/font_manager.sh"
+FALLBACK_ENGINE="$MODDIR/common/v142_weighted_mix.sh"
+MODE_HELPER="$MODDIR/common/mix_weight_mode.sh"
+ROLE_CHECK="$MODDIR/common/font_role_check.sh"
+INSTANCE_PY="$MODDIR/common/font_instance.py"
+COMPOSITE_RUNNER="$MODDIR/common/luoshu_composite.sh"
+PYROOT="$MODDIR/common/python"
+PYBIN="$PYROOT/bin/luoshu-python"
+TASK_FILE="$CONFIG_DIR/axes_task.conf"
+MIX_CONF="$CONFIG_DIR/font_mix.conf"
+AXES_CONF="$CONFIG_DIR/axes_mix.conf"
+ACTIVE_CONF="$CONFIG_DIR/active_font.conf"
+REBOOT_CONF="$CONFIG_DIR/text_reboot_required.conf"
+WORKER_PID="$CONFIG_DIR/auto_multiweight_worker.pid"
+LOG_FILE="$MODDIR/logs/fontswitch.log"
+LOCK_FILE="$MODDIR/.font_switch.lock"
+
+[ -f "$MODDIR/common/util_functions.sh" ] && . "$MODDIR/common/util_functions.sh"
+[ -f "$MODDIR/common/font_check.sh" ] && . "$MODDIR/common/font_check.sh"
+[ -f "$MODE_HELPER" ] && . "$MODE_HELPER"
+
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '; }
+read_value() { sed -n "s/^${2}=//p" "$1" 2>/dev/null | head -n1 | tr -d '\r\n'; }
+clean_spec() { printf '%s' "$1" | tr -d '\r\n'; }
+normalize_mode() { case "$1" in auto) printf 'auto\n' ;; *) printf 'fixed\n' ;; esac; }
+
+resolve_mode() {
+    _requested="$1"
+    _family="$2"
+    _axes="$3"
+    case "$_requested" in
+        auto|fixed) printf '%s\n' "$_requested" ;;
+        *)
+            if type infer_mix_weight_mode >/dev/null 2>&1; then
+                infer_mix_weight_mode "$_family" "$_axes"
+            else
+                printf 'fixed\n'
+            fi
+            ;;
+    esac
+}
+
+axis_value() {
+    _spec="$1"
+    _tag="$2"
+    _fallback="$3"
+    _value=$(printf '%s' "$_spec" | tr ',' '\n' | sed -n "s/^${_tag}=//p" | head -n1)
+    case "$_value" in ''|*[!0-9.-]*) _value="$_fallback" ;; esac
+    printf '%s' "$_value"
+}
+
+safe_weight() {
+    _weight=$(axis_value "$1" wght 400)
+    _weight=${_weight%%.*}
+    case "$_weight" in ''|*[!0-9]*) _weight=400 ;; esac
+    [ "$_weight" -ge 1 ] 2>/dev/null || _weight=1
+    [ "$_weight" -le 1000 ] 2>/dev/null || _weight=1000
+    printf '%s' "$_weight"
+}
+
+with_weight() {
+    _spec="$1"
+    _weight="$2"
+    _out=''
+    _found=false
+    _old_ifs="$IFS"
+    IFS=','
+    for _entry in $_spec; do
+        case "$_entry" in
+            wght=*) _entry="wght=$_weight"; _found=true ;;
+        esac
+        [ -n "$_entry" ] || continue
+        [ -z "$_out" ] || _out="$_out,"
+        _out="$_out$_entry"
+    done
+    IFS="$_old_ifs"
+    [ "$_found" = true ] || {
+        [ -z "$_out" ] || _out="$_out,"
+        _out="${_out}wght=$_weight"
+    }
+    printf '%s' "$_out"
+}
+
+role_weight() {
+    case "$1" in
+        thin) echo 100 ;; extralight) echo 200 ;; light) echo 300 ;; regular|normal) echo 400 ;;
+        medium) echo 500 ;; semibold) echo 600 ;; bold) echo 700 ;; extrabold) echo 800 ;;
+        black|heavy) echo 900 ;; variable) echo "$2" ;; *) echo 400 ;;
+    esac
+}
+
+weight_role() {
+    case "$1" in
+        100) echo Thin ;; 200) echo ExtraLight ;; 300) echo Light ;; 500) echo Medium ;;
+        600) echo SemiBold ;; 700) echo Bold ;; 800) echo ExtraBold ;; 900) echo Black ;;
+        *) echo Regular ;;
+    esac
+}
+
+write_task() {
+    _tmp="$TASK_FILE.tmp.$$"
+    {
+        printf 'task=%s\nstate=%s\nmessage=%s\n' "$1" "$2" "$3"
+        printf 'cjk=%s\nlatin=%s\ndigit=%s\n' "$4" "$5" "$6"
+        printf 'cjkAxes=%s\nlatinAxes=%s\ndigitAxes=%s\n' "$7" "$8" "$9"
+        shift 9
+        printf 'cjkMode=%s\nlatinMode=%s\ndigitMode=%s\n' "$1" "$2" "$3"
+        printf 'root=%s\nchildTask=%s\nstarted=%s\nfinished=%s\npercent=%s\n' "$4" "$5" "$6" "$7" "$8"
+    } >"$_tmp" 2>/dev/null && mv -f "$_tmp" "$TASK_FILE" 2>/dev/null
+    chmod 0644 "$TASK_FILE" 2>/dev/null || true
+}
+
+update_task() {
+    _wanted="$1"
+    _state="$2"
+    _message="$3"
+    _percent="$4"
+    _finished="$5"
+    [ "$(read_value "$TASK_FILE" task)" = "$_wanted" ] || return 1
+    write_task "$_wanted" "$_state" "$_message" \
+        "$(read_value "$TASK_FILE" cjk)" "$(read_value "$TASK_FILE" latin)" "$(read_value "$TASK_FILE" digit)" \
+        "$(read_value "$TASK_FILE" cjkAxes)" "$(read_value "$TASK_FILE" latinAxes)" "$(read_value "$TASK_FILE" digitAxes)" \
+        "$(read_value "$TASK_FILE" cjkMode)" "$(read_value "$TASK_FILE" latinMode)" "$(read_value "$TASK_FILE" digitMode)" \
+        "$(read_value "$TASK_FILE" root)" '' "$(read_value "$TASK_FILE" started)" "$_finished" "$_percent"
+}
+
+find_best_source() {
+    _family="$1"
+    _target="$2"
+    _best=''
+    _best_score=99999
+    _variable=''
+    for _font in "$SOURCE_FONTS"/*.ttf "$SOURCE_FONTS"/*.otf "$SOURCE_FONTS"/*.ttc \
+                 "$SOURCE_FONTS"/*.TTF "$SOURCE_FONTS"/*.OTF "$SOURCE_FONTS"/*.TTC; do
+        [ -f "$_font" ] || continue
+        [ "$(detect_font_family "$(basename "$_font")")" = "$_family" ] || continue
+        if is_variable_font "$_font" 2>/dev/null; then
+            [ -n "$_variable" ] || _variable="$_font"
+            continue
+        fi
+        _number=$(role_weight "$(detect_font_weight "$(basename "$_font")")" "$_target")
+        _score=$((_number - _target))
+        [ "$_score" -ge 0 ] 2>/dev/null || _score=$((-_score))
+        if [ -z "$_best" ] || [ "$_score" -lt "$_best_score" ] 2>/dev/null; then
+            _best="$_font"
+            _best_score="$_score"
+        fi
+    done
+    if [ -n "$_variable" ]; then
+        printf '%s\n' "$_variable"
+    elif [ -n "$_best" ]; then
+        printf '%s\n' "$_best"
+    else
+        return 1
+    fi
+}
+
+run_instance() {
+    _source="$1"
+    _destination="$2"
+    _role="$3"
+    _axes="$4"
+    _weight=$(safe_weight "$_axes")
+    mkdir -p "${_destination%/*}" "$MODDIR/cache/tmp" 2>/dev/null || return 1
+    PYTHONHOME="$PYROOT" \
+    PYTHONPATH="$PYROOT/lib/python3.14:$PYROOT/lib/python3.14/site-packages" \
+    LD_LIBRARY_PATH="$PYROOT/lib:$PYROOT/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+    TMPDIR="$MODDIR/cache/tmp" \
+        "$PYBIN" "$INSTANCE_PY" --input "$_source" --output "$_destination" \
+        --role "$_role" --weight "$_weight" --axes "$_axes" >/dev/null 2>"${_destination}.err"
+    _code=$?
+    [ "$_code" -eq 0 ] && [ -s "$_destination" ] || return 1
+    rm -f "${_destination}.err" 2>/dev/null || true
+    chmod 0644 "$_destination" 2>/dev/null || true
+}
+
+prepare_source() {
+    _role="$1"
+    _family="$2"
+    _axes="$3"
+    _mode="$4"
+    _target="$5"
+    _destination="$6"
+    _effective="$_axes"
+    [ "$_mode" != auto ] || _effective=$(with_weight "$_axes" "$_target")
+    _lookup=$(safe_weight "$_effective")
+    _source=$(find_best_source "$_family" "$_lookup")
+    [ -f "$_source" ] || return 1
+    font_validate "$_source" text || return 1
+    if [ "$FONT_CHECK_VARIABLE" = true ] || [ "$FONT_CHECK_FORMAT" = TTC ]; then
+        run_instance "$_source" "$_destination" "$_role" "$_effective"
+    else
+        mkdir -p "${_destination%/*}" 2>/dev/null || return 1
+        cp -f "$_source" "$_destination" 2>/dev/null || return 1
+        chmod 0644 "$_destination" 2>/dev/null || true
+    fi
+}
+
+hash_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" 2>/dev/null | awk '{print $1}'
+    elif command -v toybox >/dev/null 2>&1; then
+        toybox sha256sum "$1" 2>/dev/null | awk '{print $1}'
+    else
+        cksum "$1" 2>/dev/null | awk '{print $1 "-" $2}'
+    fi
+}
+
+hash_text() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | awk '{print $1}'
+    elif command -v toybox >/dev/null 2>&1; then
+        toybox sha256sum | awk '{print $1}'
+    else
+        cksum | awk '{print $1 "-" $2}'
+    fi
+}
+
+link_or_copy() {
+    rm -f "$2" 2>/dev/null || true
+    ln "$1" "$2" 2>/dev/null || cp -f "$1" "$2" 2>/dev/null
+}
+
+prune_composite_cache() {
+    _count=0
+    for _old in $(ls -1t "$COMPOSITE_CACHE"/*.font 2>/dev/null); do
+        _count=$((_count + 1))
+        [ "$_count" -le 24 ] && continue
+        rm -f "$_old" "${_old}.json" 2>/dev/null || true
+    done
+}
+
+build_composite_cached() {
+    _cjk="$1"
+    _latin="$2"
+    _digit="$3"
+    _output="$4"
+    _progress="$5"
+    mkdir -p "$COMPOSITE_CACHE" "${_output%/*}" 2>/dev/null || return 1
+    _key=$(printf '%s|%s|%s|auto-multiweight-v1' \
+        "$(hash_file "$_cjk")" "$(hash_file "$_latin")" "$(hash_file "$_digit")" | hash_text)
+    [ -n "$_key" ] || return 1
+    _cached="$COMPOSITE_CACHE/${_key}.font"
+    if [ -s "$_cached" ]; then
+        link_or_copy "$_cached" "$_output" || return 1
+        chmod 0644 "$_output" 2>/dev/null || true
+        return 0
+    fi
+    _tmp="$COMPOSITE_CACHE/.${_key}.$$.tmp.font"
+    _tmp_report="${_tmp}.json"
+    _tmp_error="${_tmp}.err"
+    rm -f "$_tmp" "$_tmp_report" "$_tmp_error" 2>/dev/null || true
+    MODDIR="$MODDIR" sh "$COMPOSITE_RUNNER" --cjk "$_cjk" --latin "$_latin" --digit "$_digit" \
+        --output "$_tmp" --progress "$_progress" >"$_tmp_report" 2>"$_tmp_error"
+    _code=$?
+    [ "$_code" -eq 0 ] && [ -s "$_tmp" ] || {
+        [ ! -s "$_tmp_error" ] || cat "$_tmp_error" >>"$LOG_FILE" 2>/dev/null || true
+        rm -f "$_tmp" "$_tmp_report" "$_tmp_error" 2>/dev/null || true
+        return 1
+    }
+    font_validate "$_tmp" text || {
+        rm -f "$_tmp" "$_tmp_report" "$_tmp_error" 2>/dev/null || true
+        return 1
+    }
+    chmod 0644 "$_tmp" "$_tmp_report" 2>/dev/null || true
+    mv -f "$_tmp" "$_cached" 2>/dev/null || return 1
+    mv -f "$_tmp_report" "${_cached}.json" 2>/dev/null || true
+    rm -f "$_tmp_error" 2>/dev/null || true
+    link_or_copy "$_cached" "$_output" || return 1
+    chmod 0644 "$_output" 2>/dev/null || true
+    prune_composite_cache
+}
+
+save_mix_config() {
+    _tmp="$MIX_CONF.auto.$$"
+    {
+        printf 'cjk=%s\nlatin=%s\ndigit=%s\n' "$1" "$2" "$3"
+        printf 'cjkWeight=%s\nlatinWeight=%s\ndigitWeight=%s\n' "$(safe_weight "$4")" "$(safe_weight "$5")" "$(safe_weight "$6")"
+        printf 'cjkAxes=%s\nlatinAxes=%s\ndigitAxes=%s\n' "$4" "$5" "$6"
+        printf 'cjkMode=%s\nlatinMode=%s\ndigitMode=%s\n' "$7" "$8" "$9"
+        printf 'isolation=auto-multiweight-v1\ncharacterIsolation=true\ncomposite=true\nxmlOverlay=false\ntime=%s\n' "$(date +%s)"
+    } >"$_tmp" 2>/dev/null && mv -f "$_tmp" "$MIX_CONF" 2>/dev/null || return 1
+    cp -f "$MIX_CONF" "$AXES_CONF" 2>/dev/null || true
+    printf 'mix\n' >"$ACTIVE_CONF" 2>/dev/null || return 1
+    printf 'font=mix\ntime=%s\n' "$(date +%s)" >"$REBOOT_CONF" 2>/dev/null || return 1
+    sed -i '/^LuoShuAutoMix$/d' "$CONFIG_DIR/recent_fonts.conf" 2>/dev/null || true
+    chmod 0644 "$MIX_CONF" "$AXES_CONF" "$ACTIVE_CONF" "$REBOOT_CONF" 2>/dev/null || true
+}
+
+worker() {
+    _wanted="$1"
+    [ "$(read_value "$TASK_FILE" task)" = "$_wanted" ] || exit 0
+    _cjk=$(read_value "$TASK_FILE" cjk)
+    _latin=$(read_value "$TASK_FILE" latin)
+    _digit=$(read_value "$TASK_FILE" digit)
+    _cjk_axes=$(read_value "$TASK_FILE" cjkAxes)
+    _latin_axes=$(read_value "$TASK_FILE" latinAxes)
+    _digit_axes=$(read_value "$TASK_FILE" digitAxes)
+    _cjk_mode=$(normalize_mode "$(read_value "$TASK_FILE" cjkMode)")
+    _latin_mode=$(normalize_mode "$(read_value "$TASK_FILE" latinMode)")
+    _digit_mode=$(normalize_mode "$(read_value "$TASK_FILE" digitMode)")
+    _root=$(read_value "$TASK_FILE" root)
+    _family=LuoShuAutoMix
+    mkdir -p "$_root/fonts" "$_root/prepared" 2>/dev/null || {
+        update_task "$_wanted" failed '无法创建自动多字重缓存' 100 "$(date +%s)"
+        exit 1
+    }
+
+    _index=0
+    for _weight in 100 200 300 400 500 600 700 800 900; do
+        _index=$((_index + 1))
+        _percent=$((4 + _index * 8))
+        _role=$(weight_role "$_weight")
+        update_task "$_wanted" running "正在生成 ${_weight} 字重复合字体" "$_percent" ''
+        _dir="$_root/prepared/$_weight"
+        mkdir -p "$_dir" 2>/dev/null || exit 1
+        prepare_source cjk "$_cjk" "$_cjk_axes" "$_cjk_mode" "$_weight" "$_dir/cjk.ttf" || {
+            update_task "$_wanted" failed "中文字体 ${_weight} 字重准备失败" 100 "$(date +%s)"
+            rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+        }
+        prepare_source latin "$_latin" "$_latin_axes" "$_latin_mode" "$_weight" "$_dir/latin.ttf" || {
+            update_task "$_wanted" failed "英文字体 ${_weight} 字重准备失败" 100 "$(date +%s)"
+            rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+        }
+        prepare_source digit "$_digit" "$_digit_axes" "$_digit_mode" "$_weight" "$_dir/digit.ttf" || {
+            update_task "$_wanted" failed "数字字体 ${_weight} 字重准备失败" 100 "$(date +%s)"
+            rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+        }
+        if [ "$_weight" = 400 ]; then
+            _output="$_root/fonts/${_family}-Regular.ttf"
+        else
+            _output="$_root/fonts/${_family}-${_role}.otf"
+        fi
+        build_composite_cached "$_dir/cjk.ttf" "$_dir/latin.ttf" "$_dir/digit.ttf" "$_output" "$_dir/progress.json" || {
+            update_task "$_wanted" failed "${_weight} 字重复合失败" 100 "$(date +%s)"
+            rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+        }
+        rm -rf "$_dir" 2>/dev/null || true
+    done
+
+    update_task "$_wanted" running '正在应用自动多字重字体族' 88 ''
+    _result=$(LUOSHU_PUBLIC_DIR="$_root" MODDIR="$MODDIR" sh "$FONT_MANAGER" action switch "$_family" 2>&1)
+    printf '%s\n' "$_result" >>"$LOG_FILE" 2>/dev/null || true
+    printf '%s\n' "$_result" | grep -q '"status":"ok"' || {
+        update_task "$_wanted" failed '自动多字重字体族应用失败' 100 "$(date +%s)"
+        rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+    }
+    save_mix_config "$_cjk" "$_latin" "$_digit" "$_cjk_axes" "$_latin_axes" "$_digit_axes" \
+        "$_cjk_mode" "$_latin_mode" "$_digit_mode" || {
+        update_task "$_wanted" failed '组合配置保存失败' 100 "$(date +%s)"
+        rm -rf "$_root"; rm -f "$WORKER_PID"; exit 1
+    }
+    update_task "$_wanted" success '自动多字重复合字体已准备，完整重启后生效' 100 "$(date +%s)"
+    rm -rf "$_root" 2>/dev/null || true
+    rm -f "$WORKER_PID" 2>/dev/null || true
+}
+
+precheck_mix() {
+    [ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ] || return 1
+    [ -f "$ROLE_CHECK" ] || return 0
+    MODDIR="$MODDIR" sh "$ROLE_CHECK" "$1" cjk >/dev/null 2>&1 || return 2
+    MODDIR="$MODDIR" sh "$ROLE_CHECK" "$2" latin >/dev/null 2>&1 || return 3
+    MODDIR="$MODDIR" sh "$ROLE_CHECK" "$3" digit >/dev/null 2>&1 || return 4
+}
+
+start_mix() {
+    _cjk="$1"
+    _latin="$2"
+    _digit="$3"
+    _cjk_axes=$(clean_spec "$4")
+    _latin_axes=$(clean_spec "$5")
+    _digit_axes=$(clean_spec "$6")
+    [ -n "$_cjk_axes" ] || _cjk_axes='wght=400'
+    [ -n "$_latin_axes" ] || _latin_axes='wght=400'
+    [ -n "$_digit_axes" ] || _digit_axes='wght=400'
+    _cjk_mode=$(resolve_mode "$7" "$_cjk" "$_cjk_axes")
+    _latin_mode=$(resolve_mode "$8" "$_latin" "$_latin_axes")
+    _digit_mode=$(resolve_mode "$9" "$_digit" "$_digit_axes")
+
+    precheck_mix "$_cjk" "$_latin" "$_digit"
+    _precheck=$?
+    case "$_precheck" in
+        1) printf '{"status":"error","message":"请选择中文、英文和数字字体"}\n'; return ;;
+        2) printf '{"status":"error","message":"中文基底缺少必要字形"}\n'; return ;;
+        3) printf '{"status":"error","message":"英文字体缺少必要字形"}\n'; return ;;
+        4) printf '{"status":"error","message":"数字字体缺少必要字形"}\n'; return ;;
+    esac
+
+    if [ "$_cjk_mode" = fixed ] && [ "$_latin_mode" = fixed ] && [ "$_digit_mode" = fixed ]; then
+        sh "$FALLBACK_ENGINE" start "$_cjk" "$_latin" "$_digit" "$_cjk_axes" "$_latin_axes" "$_digit_axes"
+        return
+    fi
+    [ ! -f "$REBOOT_CONF" ] || {
+        printf '{"status":"error","message":"本次开机已更改文字字体，请先重启手机"}\n'
+        return
+    }
+    if [ -s "$WORKER_PID" ]; then
+        _old=$(cat "$WORKER_PID" 2>/dev/null)
+        [ -z "$_old" ] || ! kill -0 "$_old" 2>/dev/null || {
+            printf '{"status":"error","message":"已有自动多字重任务正在运行"}\n'
+            return
+        }
+    fi
+    [ ! -e "$LOCK_FILE" ] || {
+        printf '{"status":"error","message":"字体正在切换中"}\n'
+        return
+    }
+    mkdir -p "$CONFIG_DIR" "$CACHE_ROOT" "$COMPOSITE_CACHE" "$MODDIR/logs" 2>/dev/null || {
+        printf '{"status":"error","message":"无法创建任务目录"}\n'
+        return
+    }
+    _task="auto-mix-$(date +%s)-$$"
+    _root="$CACHE_ROOT/$_task"
+    mkdir -p "$_root" 2>/dev/null || {
+        printf '{"status":"error","message":"无法创建任务缓存"}\n'
+        return
+    }
+    write_task "$_task" queued '自动多字重任务已进入队列' "$_cjk" "$_latin" "$_digit" \
+        "$_cjk_axes" "$_latin_axes" "$_digit_axes" "$_cjk_mode" "$_latin_mode" "$_digit_mode" \
+        "$_root" '' "$(date +%s)" '' 1
+    ( MODDIR="$MODDIR" sh "$0" worker "$_task" ) </dev/null >>"$LOG_FILE" 2>&1 &
+    printf '%s\n' "$!" >"$WORKER_PID" 2>/dev/null || true
+    printf '{"status":"ok","data":{"task":"%s","cjkMode":"%s","latinMode":"%s","digitMode":"%s"}}\n' \
+        "$(json_escape "$_task")" "$_cjk_mode" "$_latin_mode" "$_digit_mode"
+}
+
+config_json() {
+    _source="$AXES_CONF"
+    [ -s "$_source" ] || _source="$MIX_CONF"
+    _cjk=$(read_value "$_source" cjk)
+    _latin=$(read_value "$_source" latin)
+    _digit=$(read_value "$_source" digit)
+    _cjk_axes=$(read_value "$_source" cjkAxes)
+    _latin_axes=$(read_value "$_source" latinAxes)
+    _digit_axes=$(read_value "$_source" digitAxes)
+    [ -n "$_cjk_axes" ] || _cjk_axes="wght=$(read_value "$_source" cjkWeight)"
+    [ -n "$_latin_axes" ] || _latin_axes="wght=$(read_value "$_source" latinWeight)"
+    [ -n "$_digit_axes" ] || _digit_axes="wght=$(read_value "$_source" digitWeight)"
+    _cjk_mode=$(resolve_mode "$(read_value "$_source" cjkMode)" "$_cjk" "$_cjk_axes")
+    _latin_mode=$(resolve_mode "$(read_value "$_source" latinMode)" "$_latin" "$_latin_axes")
+    _digit_mode=$(resolve_mode "$(read_value "$_source" digitMode)" "$_digit" "$_digit_axes")
+    _active=$(head -n1 "$ACTIVE_CONF" 2>/dev/null | tr -d '\r\n')
+    _enabled=false
+    [ "$_active" = mix ] && _enabled=true
+    printf '{"status":"ok","data":{"enabled":%s,"cjk":"%s","latin":"%s","digit":"%s","cjkWeight":%s,"latinWeight":%s,"digitWeight":%s,"cjkAxes":"%s","latinAxes":"%s","digitAxes":"%s","cjkMode":"%s","latinMode":"%s","digitMode":"%s"}}\n' \
+        "$_enabled" "$(json_escape "$_cjk")" "$(json_escape "$_latin")" "$(json_escape "$_digit")" \
+        "$(safe_weight "$_cjk_axes")" "$(safe_weight "$_latin_axes")" "$(safe_weight "$_digit_axes")" \
+        "$(json_escape "$_cjk_axes")" "$(json_escape "$_latin_axes")" "$(json_escape "$_digit_axes")" \
+        "$_cjk_mode" "$_latin_mode" "$_digit_mode"
+}
+
+recover_task() {
+    if [ -s "$WORKER_PID" ]; then
+        _pid=$(cat "$WORKER_PID" 2>/dev/null)
+        [ -z "$_pid" ] || ! kill -0 "$_pid" 2>/dev/null || kill "$_pid" 2>/dev/null || true
+    fi
+    rm -f "$WORKER_PID" 2>/dev/null || true
+    sh "$FALLBACK_ENGINE" recover
+}
+
+case "${1:-config}" in
+    start) start_mix "$2" "$3" "$4" "${5:-wght=400}" "${6:-wght=400}" "${7:-wght=400}" "${8:-infer}" "${9:-infer}" "${10:-infer}" ;;
+    config) config_json ;;
+    status) sh "$FALLBACK_ENGINE" status "${2:-}" ;;
+    worker) worker "$2" ;;
+    recover) recover_task ;;
+    *) printf '{"status":"error","message":"未知自动多字重命令"}\n' ;;
+esac
+exit 0

--- a/common/legacy_v14_4/v14_mix.sh
+++ b/common/legacy_v14_4/v14_mix.sh
@@ -1,0 +1,104 @@
+#!/system/bin/sh
+# 洛书 v14.3.9：字体组合轻量桥。
+set +e
+MODDIR="${MODDIR:-}"
+if [ -z "$MODDIR" ]; then
+    if [ -f "${0%/*}/../module.prop" ]; then
+        MODDIR="$(CDPATH= cd -- "${0%/*}/.." 2>/dev/null && pwd)"
+    else
+        MODDIR="/data/adb/modules/LuoShu"
+    fi
+fi
+WEIGHTED="$MODDIR/common/v142_weighted_mix.sh"
+AUTO_WEIGHTED="$MODDIR/common/v143_auto_multiweight_mix.sh"
+MODE_HELPER="$MODDIR/common/mix_weight_mode.sh"
+ENGINE="$MODDIR/common/font_mix.sh"
+ROLE_CHECK="$MODDIR/common/font_role_check.sh"
+TASK_FILE="$MODDIR/config/mix_task.conf"
+STATUS_SCRIPT="$MODDIR/common/module_status.sh"
+USER_FONTS_DIR="${LUOSHU_PUBLIC_DIR:-/sdcard/LuoShu}/fonts"
+MODULE_DIR="$MODDIR"
+[ -f "$MODDIR/common/util_functions.sh" ] && . "$MODDIR/common/util_functions.sh"
+[ -f "$MODDIR/common/font_check.sh" ] && . "$MODDIR/common/font_check.sh"
+[ -f "$MODE_HELPER" ] && . "$MODE_HELPER"
+json_escape(){ printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r' '  '; }
+read_value(){ sed -n "s/^${1}=//p" "$TASK_FILE" 2>/dev/null | head -n1 | tr -d '\r\n'; }
+
+precheck_mix() {
+    [ -n "${1:-}" ] && [ -n "${2:-}" ] && [ -n "${3:-}" ] || {
+        printf '{"status":"error","message":"请选择中文、英文和数字字体"}\n'
+        return 1
+    }
+    MODDIR="$MODDIR" sh "$ROLE_CHECK" "$1" cjk >/dev/null 2>&1 || {
+        printf '{"status":"error","message":"中文基底缺少必要的中文、英文字母或数字字形"}\n'
+        return 1
+    }
+    MODDIR="$MODDIR" sh "$ROLE_CHECK" "$2" latin >/dev/null 2>&1 || {
+        printf '{"status":"error","message":"英文字体缺少必要的大小写拉丁字母"}\n'
+        return 1
+    }
+    MODDIR="$MODDIR" sh "$ROLE_CHECK" "$3" digit >/dev/null 2>&1 || {
+        printf '{"status":"error","message":"数字字体缺少必要的 0–9 数字字形"}\n'
+        return 1
+    }
+}
+
+if [ -f "$WEIGHTED" ]; then
+    case "${1:-config}" in
+        start)
+            precheck_mix "$2" "$3" "$4" || exit 0
+            _cjk_mode=fixed
+            _latin_mode=fixed
+            _digit_mode=fixed
+            if type infer_mix_weight_mode >/dev/null 2>&1; then
+                _cjk_mode=$(infer_mix_weight_mode "$2" "${5:-wght=400}")
+                _latin_mode=$(infer_mix_weight_mode "$3" "${6:-wght=400}")
+                _digit_mode=$(infer_mix_weight_mode "$4" "${7:-wght=400}")
+            fi
+            if [ -f "$AUTO_WEIGHTED" ]; then
+                sh "$AUTO_WEIGHTED" start "$2" "$3" "$4" "${5:-wght=400}" "${6:-wght=400}" "${7:-wght=400}" "$_cjk_mode" "$_latin_mode" "$_digit_mode"
+            else
+                sh "$WEIGHTED" start "$2" "$3" "$4" "${5:-wght=400}" "${6:-wght=400}" "${7:-wght=400}"
+            fi
+            ;;
+        config)
+            if [ -f "$AUTO_WEIGHTED" ]; then sh "$AUTO_WEIGHTED" config
+            else sh "$WEIGHTED" config
+            fi
+            ;;
+        status)
+            if [ -f "$AUTO_WEIGHTED" ]; then sh "$AUTO_WEIGHTED" status "$2"
+            else sh "$WEIGHTED" status "$2"
+            fi
+            ;;
+        recover)
+            if [ -f "$AUTO_WEIGHTED" ]; then sh "$AUTO_WEIGHTED" recover
+            else sh "$WEIGHTED" recover
+            fi
+            ;;
+        *) printf '{"status":"error","message":"未知组合桥命令"}\n' ;;
+    esac
+    exit 0
+fi
+
+case "${1:-status}" in
+    start)
+        precheck_mix "$2" "$3" "$4" || exit 0
+        sh "$ENGINE" start "$2" "$3" "$4"
+        ;;
+    config) sh "$ENGINE" status ;;
+    status)
+        _wanted="$2"
+        [ -s "$TASK_FILE" ] || { printf '{"status":"error","message":"暂无组合任务"}\n'; exit 0; }
+        _task=$(read_value task); _state=$(read_value state); _message=$(read_value message)
+        _cjk=$(read_value cjk); _latin=$(read_value latin); _digit=$(read_value digit)
+        _started=$(read_value started); _finished=$(read_value finished)
+        [ -z "$_wanted" ] || [ "$_wanted" = "$_task" ] || { printf '{"status":"error","message":"任务不存在或已被新任务替换"}\n'; exit 0; }
+        if [ "$_state" = success ] && [ -f "$STATUS_SCRIPT" ]; then MODDIR="$MODDIR" sh "$STATUS_SCRIPT" mix >/dev/null 2>&1 || true; fi
+        printf '{"status":"ok","data":{"task":"%s","state":"%s","message":"%s","cjk":"%s","latin":"%s","digit":"%s","cjkWeight":400,"latinWeight":400,"digitWeight":400,"cjkAxes":"wght=400","latinAxes":"wght=400","digitAxes":"wght=400","started":%s,"finished":%s}}\n' \
+            "$(json_escape "$_task")" "$(json_escape "$_state")" "$(json_escape "$_message")" "$(json_escape "$_cjk")" "$(json_escape "$_latin")" "$(json_escape "$_digit")" "${_started:-0}" "${_finished:-0}"
+        ;;
+    recover) sh "$ENGINE" recover ;;
+    *) printf '{"status":"error","message":"未知组合命令"}\n' ;;
+esac
+exit 0

--- a/scripts/legacy_switch_core_test.sh
+++ b/scripts/legacy_switch_core_test.sh
@@ -34,7 +34,7 @@ grep -q 'Roboto' "$ROM"
 
 # Composite App actions must also leave the v4 runtime immediately and enter the exact
 # pre-reset bridge / weighted / auto-multiweight / full composite chain.
-grep -q 'legacy_v14_4/mix_router.sh' "$MIX_ROUTER"
+grep -q 'legacy_v1.*4_4/mix_router.sh' "$MIX_ROUTER"
 grep -q 'exec sh "$LEGACY_V14_MIX" "$@"' "$MIX_ROUTER"
 grep -q 'v142_weighted_mix.sh' "$LEGACY_MIX_BRIDGE"
 grep -q 'v143_auto_multiweight_mix.sh' "$LEGACY_MIX_BRIDGE"

--- a/scripts/legacy_switch_core_test.sh
+++ b/scripts/legacy_switch_core_test.sh
@@ -4,6 +4,12 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 ROUTER="$ROOT/common/font_manager.sh"
 BACKEND="$ROOT/common/legacy_v14_4_switch.sh"
 ROM="$ROOT/common/legacy_v14_4/rom_adapters.sh"
+MIX_ROUTER="$ROOT/common/font_mix_controller.sh"
+LEGACY_MIX_ROUTER="$ROOT/common/legacy_v14_4/mix_router.sh"
+LEGACY_MIX_BRIDGE="$ROOT/common/legacy_v14_4/v14_mix.sh"
+LEGACY_WEIGHTED="$ROOT/common/legacy_v14_4/v142_weighted_mix.sh"
+LEGACY_AUTO="$ROOT/common/legacy_v14_4/v143_auto_multiweight_mix.sh"
+LEGACY_MIX_ENGINE="$ROOT/common/legacy_v14_4/font_mix_engine.sh"
 SERVICE="$ROOT/service.sh"
 POSTFS="$ROOT/post-fs-data.sh"
 POSTMOUNT="$ROOT/post-mount.sh"
@@ -26,6 +32,26 @@ grep -q 'Roboto' "$ROM"
 # 94% v4 pipeline components are forbidden from the actual legacy apply backend.
 ! grep -qE 'font_validate_fast_v4|device_font_template|device_font_slot|font_config_overlay|font_config_batch|device_font_payload_build' "$BACKEND"
 
+# Composite App actions must also leave the v4 runtime immediately and enter the exact
+# pre-reset bridge / weighted / auto-multiweight / full composite chain.
+grep -q 'legacy_v14_4/mix_router.sh' "$MIX_ROUTER"
+grep -q 'exec sh "$LEGACY_V14_MIX" "$@"' "$MIX_ROUTER"
+grep -q 'v142_weighted_mix.sh' "$LEGACY_MIX_BRIDGE"
+grep -q 'v143_auto_multiweight_mix.sh' "$LEGACY_MIX_BRIDGE"
+grep -q 'font_mix.sh' "$LEGACY_MIX_BRIDGE"
+grep -q 'for _weight in 100 200 300 400 500 600 700 800 900' "$LEGACY_AUTO"
+grep -q 'build_composite_cached' "$LEGACY_AUTO"
+grep -q 'LuoShuAutoMix' "$LEGACY_AUTO"
+grep -q 'action switch' "$LEGACY_AUTO"
+grep -q 'BASE_ENGINE=.*font_mix.sh' "$LEGACY_WEIGHTED"
+grep -q '中文字体保留为完整基底' "$LEGACY_MIX_ENGINE"
+grep -q '不裁剪 ROM 字体槽' "$LEGACY_MIX_ENGINE"
+grep -q '\.legacy-v14-runtime' "$LEGACY_MIX_ROUTER"
+grep -q '\.luoshu-payload' "$LEGACY_MIX_ROUTER"
+grep -q 'font_mix_engine.sh' "$LEGACY_MIX_ROUTER"
+! grep -qE 'font_validate_fast_v4|device_font_template|device_font_slot|font_config_overlay|font_config_batch|device_font_payload_build' \
+    "$LEGACY_MIX_ROUTER" "$LEGACY_MIX_BRIDGE" "$LEGACY_WEIGHTED" "$LEGACY_AUTO" "$LEGACY_MIX_ENGINE"
+
 # Once selected, all three boot stages keep the legacy payload immutable.
 for file in "$SERVICE" "$POSTFS" "$POSTMOUNT"; do
     grep -q 'font_runtime_legacy_v14_4.conf' "$file"
@@ -40,8 +66,14 @@ grep -q 'post-mount-v4.sh' "$POSTMOUNT"
 
 sh -n "$ROUTER"
 sh -n "$BACKEND"
+sh -n "$MIX_ROUTER"
+sh -n "$LEGACY_MIX_ROUTER"
+sh -n "$LEGACY_MIX_BRIDGE"
+sh -n "$LEGACY_WEIGHTED"
+sh -n "$LEGACY_AUTO"
+sh -n "$LEGACY_MIX_ENGINE"
 sh -n "$ROOT/service_v4.sh"
 sh -n "$ROOT/post-fs-data-v4.sh"
 sh -n "$ROOT/post-mount-v4.sh"
 
-echo 'v14.4 compatibility switch core is isolated from the v4 94% pipeline.'
+echo 'single and composite switching are isolated on the pre-reset compatibility core.'


### PR DESCRIPTION
Keep the current v4.0.0 Android App/UI and API surface unchanged, but route composite start/config/status/recover through the isolated pre-reset composite chain. Restore the historical lightweight bridge, weighted engine, auto multiweight engine, full composite engine, and their matching helpers inside the existing legacy compatibility directory. Final generated payload continues to use the restored physical-file mapping path and private payload mount, without device-template, slot-build, XML overlay or v4 fast-validation in the active composite path. Extend regression checks so both single-font and composite paths are locked to the compatibility core.