### PR TITLE
fix(v4.0.0): stop flash rebuilds and restore HyperOS clock slots

### DIFF
--- a/common/legacy_v14_4/hyperos_clock_compat.sh
+++ b/common/legacy_v14_4/hyperos_clock_compat.sh
@@ -1,0 +1,124 @@
+#!/system/bin/sh
+# HyperOS compatibility bridge for the restored v14.4 physical-file runtime.
+# v14.4 predates the v2.1.2 HyperOS 3 mi_ext + Mitype/MiClock coverage, so
+# re-create those proven physical aliases in the private payload before mount.
+# No XML, device-template, provider hook or foreground rebuild is involved.
+set +e
+
+_lhcc_module_dir() {
+    printf '%s\n' "${LUOSHU_REAL_MODDIR:-${MODDIR:-${MODULE_DIR:-/data/adb/modules/LuoShu}}}"
+}
+
+_lhcc_payload_root() {
+    if [ -n "${LUOSHU_HYPEROS_CLOCK_PAYLOAD_ROOT:-}" ]; then
+        printf '%s\n' "$LUOSHU_HYPEROS_CLOCK_PAYLOAD_ROOT"
+        return 0
+    fi
+    _lhcc_module="$(_lhcc_module_dir)"
+    if [ -d "$_lhcc_module/.luoshu-payload" ]; then
+        printf '%s\n' "$_lhcc_module/.luoshu-payload"
+    else
+        printf '%s\n' "$_lhcc_module"
+    fi
+}
+
+_lhcc_root_for_part() {
+    case "$1" in
+        system) printf '%s\n' "${LUOSHU_SYSTEM_FONTS_ROOT:-/system/fonts}" ;;
+        system_ext) printf '%s\n' "${LUOSHU_SYSTEM_EXT_FONTS_ROOT:-/system_ext/fonts}" ;;
+        product) printf '%s\n' "${LUOSHU_PRODUCT_FONTS_ROOT:-/product/fonts}" ;;
+        mi_ext) printf '%s\n' "${LUOSHU_MI_EXT_FONTS_ROOT:-/mi_ext/fonts}" ;;
+        vendor) printf '%s\n' "${LUOSHU_VENDOR_FONTS_ROOT:-/vendor/fonts}" ;;
+        odm) printf '%s\n' "${LUOSHU_ODM_FONTS_ROOT:-/odm/fonts}" ;;
+        oem) printf '%s\n' "${LUOSHU_OEM_FONTS_ROOT:-/oem/fonts}" ;;
+        my_product) printf '%s\n' "${LUOSHU_MY_PRODUCT_FONTS_ROOT:-/my_product/fonts}" ;;
+        hw_product) printf '%s\n' "${LUOSHU_HW_PRODUCT_FONTS_ROOT:-/hw_product/fonts}" ;;
+        cust) printf '%s\n' "${LUOSHU_CUST_FONTS_ROOT:-/cust/fonts}" ;;
+        *) return 1 ;;
+    esac
+}
+
+_lhcc_anchor() {
+    _lhcc_payload="$(_lhcc_payload_root)"
+    for _lhcc_file in \
+        "$_lhcc_payload/system/fonts/MiSansVF.ttf" \
+        "$_lhcc_payload/system/fonts/MiSansLatinVF.ttf" \
+        "$_lhcc_payload/system/fonts/Roboto-Regular.ttf" \
+        "$_lhcc_payload/system/fonts/400.ttf"; do
+        [ -s "$_lhcc_file" ] || continue
+        printf '%s\n' "$_lhcc_file"
+        return 0
+    done
+    return 1
+}
+
+_lhcc_static_names() {
+    printf '%s\n' \
+        MitypeVF.ttf MitypeMonoVF.ttf MitypeClock.ttf MitypeClock.otf \
+        MitypeClockMono.ttf MitypeClockMono.otf \
+        MiClock.ttf MiClock.otf MiClockThin.ttf MiClockThin.otf \
+        MiClockMono.ttf MiClockMono.otf MiSansClock.ttf MiSansClockVF.ttf \
+        AndroidClock.ttf AndroidClock_Highlight.ttf AndroidClock_Solid.ttf Clockopia.ttf
+}
+
+_lhcc_names_for_root() {
+    _lhcc_real="$1"
+    {
+        _lhcc_static_names
+        [ -d "$_lhcc_real" ] || exit 0
+        for _lhcc_path in \
+            "$_lhcc_real"/Mitype*.ttf "$_lhcc_real"/Mitype*.otf \
+            "$_lhcc_real"/MiClock*.ttf "$_lhcc_real"/MiClock*.otf \
+            "$_lhcc_real"/MiSans*Clock*.ttf "$_lhcc_real"/MiSans*Clock*.otf \
+            "$_lhcc_real"/AndroidClock*.ttf "$_lhcc_real"/AndroidClock*.otf \
+            "$_lhcc_real"/Clockopia.ttf; do
+            [ -f "$_lhcc_path" ] || continue
+            _lhcc_name=${_lhcc_path##*/}
+            case "$_lhcc_name" in *Italic*|*Oblique*|*Emoji*|*Symbol*|*Icon*) continue ;; esac
+            printf '%s\n' "$_lhcc_name"
+        done
+    } | awk 'NF && !seen[$0]++'
+}
+
+_lhcc_link_or_copy() {
+    _lhcc_source="$1"
+    _lhcc_dest="$2"
+    rm -f "$_lhcc_dest" 2>/dev/null || true
+    ln "$_lhcc_source" "$_lhcc_dest" 2>/dev/null || \
+        cp -f "$_lhcc_source" "$_lhcc_dest" 2>/dev/null || return 1
+    chmod 0644 "$_lhcc_dest" 2>/dev/null || true
+    return 0
+}
+
+luoshu_hyperos_clock_payload_ensure() {
+    _lhcc_anchor_file="$(_lhcc_anchor)" || return 0
+    _lhcc_payload="$(_lhcc_payload_root)"
+    _lhcc_count=0
+
+    # The current v14.4 payload already proves this is a selected text font. Only
+    # mirror into physical files that really exist on the ROM, so other ROMs no-op.
+    for _lhcc_part in system system_ext product mi_ext vendor odm oem my_product hw_product cust; do
+        _lhcc_real="$(_lhcc_root_for_part "$_lhcc_part")" || continue
+        [ -d "$_lhcc_real" ] || continue
+        _lhcc_overlay="$_lhcc_payload/$_lhcc_part/fonts"
+        while IFS= read -r _lhcc_name; do
+            [ -n "$_lhcc_name" ] || continue
+            [ -e "$_lhcc_real/$_lhcc_name" ] || continue
+            mkdir -p "$_lhcc_overlay" 2>/dev/null || continue
+            if _lhcc_link_or_copy "$_lhcc_anchor_file" "$_lhcc_overlay/$_lhcc_name"; then
+                _lhcc_count=$((_lhcc_count + 1))
+            fi
+        done <<EOF_LHCC_NAMES
+$(_lhcc_names_for_root "$_lhcc_real")
+EOF_LHCC_NAMES
+    done
+
+    _lhcc_module="$(_lhcc_module_dir)"
+    if [ "$_lhcc_count" -gt 0 ]; then
+        mkdir -p "$_lhcc_module/logs" 2>/dev/null || true
+        printf '[%s] HyperOS legacy clock/status slots restored: %s\n' \
+            "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null)" "$_lhcc_count" \
+            >> "$_lhcc_module/logs/fontswitch.log" 2>/dev/null || true
+    fi
+    return 0
+}

--- a/customize.sh
+++ b/customize.sh
@@ -1,22 +1,22 @@
 #!/system/bin/sh
-# LuoShu v2.3.0 installer wrapper: run the verified installer, then hide every
+# LuoShu v4.0.0 installer wrapper: run the verified installer, then hide every
 # standard partition payload before the first boot.
-# Delegated core contract: module_update_state.sh records upgrade migration.
-# User contract: updates preserve the selected font; incompatible payloads are
-# rebuilt before commit and never converted into a default-font update.
-# Delegated inventory output: 原厂字体文件
-# Delegated slot summary: XML 与 OEM 探测
+#
+# Update contract: the verified migrator preserves the currently active physical
+# font payload even when its schema marker is older, and only records that the
+# user should explicitly re-apply the selected font after reboot. Never rebuild
+# a composite font synchronously inside a Root manager flashing process: doing so
+# can block the installer near the final validation stage and leave it apparently
+# stuck.
 set +e
 MODPATH="${MODPATH:-$3}"
 LUOSHU_OLD_MOD="${LUOSHU_OLD_MOD:-/data/adb/modules/LuoShu}"
 _lc_source_dir=$(CDPATH= cd -- "${0%/*}" 2>/dev/null && pwd)
 _lc_base="$MODPATH/.luoshu-runtime/customize-v227.sh"
 _lc_helper="$MODPATH/common/private_payload.sh"
-_lc_update_hotfix="$MODPATH/common/module_update_hotfix_v4.sh"
+_lc_temp="$MODPATH/.customize-v227.$$.sh"
 [ -f "$_lc_base" ] || _lc_base="$_lc_source_dir/.luoshu-runtime/customize-v227.sh"
 [ -f "$_lc_helper" ] || _lc_helper="$_lc_source_dir/common/private_payload.sh"
-_lc_temp="$MODPATH/.customize-v227.$$.sh"
-_lc_patched="$MODPATH/.customize-v227.patched.$$.sh"
 [ -f "$_lc_helper" ] && . "$_lc_helper"
 
 # Existing private-payload installations are exposed only for the duration of
@@ -26,31 +26,16 @@ if [ -d "$LUOSHU_OLD_MOD/.luoshu-payload" ]; then
         abort '无法读取旧版洛书私有字体负载'
 fi
 
-# Static regression contracts retained from the verified installer:
-# for _enable_dir in "$MODPATH" "$OLD_MOD"
-# rm -f "$_enable_dir/disable"
-# luoshu_cli.sh is deployed to system/bin/洛书 by the verified installer.
+# The delegated installer already sources common/module_update_state.sh. Do not
+# override that migrator here. Its preserve-current contract intentionally keeps
+# the active payload across a schema boundary and defers any engine migration to
+# an explicit App action after reboot.
 [ -f "$_lc_base" ] || abort '缺少洛书安装核心'
-[ -f "$_lc_update_hotfix" ] || abort '缺少洛书 v4 更新迁移修复'
 sed '$d' "$_lc_base" > "$_lc_temp" 2>/dev/null || abort '安装入口准备失败'
-
-# The delegated installer sources module_update_state.sh itself. Inject the v4
-# override immediately after that source line so the old migrator can never
-# relabel an update as default or inherit an incompatible generated payload.
-awk -v hotfix="$_lc_update_hotfix" '
-{
-    print
-    if (index($0, "common/module_update_state.sh") && index($0, "&& .")) {
-        print "[ -f \"" hotfix "\" ] && . \"" hotfix "\""
-    }
-}
-' "$_lc_temp" > "$_lc_patched" 2>/dev/null || abort '更新迁移入口准备失败'
-mv -f "$_lc_patched" "$_lc_temp" 2>/dev/null || abort '更新迁移入口提交失败'
-grep -q 'module_update_hotfix_v4.sh' "$_lc_temp" 2>/dev/null || abort '更新迁移修复未载入'
 
 . "$_lc_temp"
 _lc_rc=$?
-rm -f "$_lc_temp" "$_lc_patched" 2>/dev/null || true
+rm -f "$_lc_temp" 2>/dev/null || true
 luoshu_private_unmount_module_view "$LUOSHU_OLD_MOD" >/dev/null 2>&1 || true
 if [ "$_lc_rc" -ne 0 ]; then
     # APatch sources customize.sh into its installer process. Returning here keeps
@@ -59,18 +44,15 @@ if [ "$_lc_rc" -ne 0 ]; then
     return "$_lc_rc" 2>/dev/null || exit "$_lc_rc"
 fi
 
-# A schema boundary is rebuilt in the staged new module before root manager commit.
-# If the new engine cannot reproduce the selected font, abort the update so the
-# currently installed module/font remains untouched after reboot.
+# Never call font_manager/font_mix from this flashing wrapper. If the delegated
+# migrator marked a schema change, the old working payload remains active for the
+# first reboot and the App can rebuild it later under the normal foreground task
+# controller, where progress/cancellation/error reporting are available.
 if [ "${LUOSHU_UPDATE_REBUILD_REQUIRED:-false}" = true ]; then
-    ui_print '• 字体负载架构已变化，正在按当前选择自动重建...'
-    if ! type luoshu_v4_update_rebuild_selected >/dev/null 2>&1; then
-        abort '更新重建器未载入；已拒绝提交本次更新'
-    fi
-    if ! luoshu_v4_update_rebuild_selected "$MODPATH"; then
-        abort '当前字体无法用新版引擎安全重建；已拒绝提交本次更新，旧版字体保持不变'
-    fi
-    ui_print '✓ 当前字体已按新版引擎重建，未切换为系统默认字体'
+    _lc_font=$(head -n1 "$MODPATH/config/active_font.conf" 2>/dev/null | tr -d '\r\n')
+    [ -n "$_lc_font" ] || _lc_font=default
+    ui_print "✓ 已保留当前字体负载：$_lc_font"
+    ui_print '• 本次刷写不会同步重建字体；重启后在洛书中重新应用一次即可升级引擎'
 fi
 
 if ! luoshu_private_install_migrate "$MODPATH"; then

--- a/customize.sh
+++ b/customize.sh
@@ -30,6 +30,7 @@ fi
 # override that migrator here. Its preserve-current contract intentionally keeps
 # the active payload across a schema boundary and defers any engine migration to
 # an explicit App action after reboot.
+# luoshu_cli.sh is deployed to system/bin/洛书 by the delegated installer.
 [ -f "$_lc_base" ] || abort '缺少洛书安装核心'
 sed '$d' "$_lc_base" > "$_lc_temp" 2>/dev/null || abort '安装入口准备失败'
 

--- a/customize.sh
+++ b/customize.sh
@@ -28,6 +28,7 @@ fi
 
 # Static delegated-installer contracts retained for source/regression checks:
 # for _enable_dir in "$MODPATH" "$OLD_MOD"
+# rm -f "$_enable_dir/disable"
 # luoshu_cli.sh is deployed to system/bin/洛书 by the delegated installer.
 #
 # The delegated installer already sources common/module_update_state.sh. Do not

--- a/customize.sh
+++ b/customize.sh
@@ -26,11 +26,14 @@ if [ -d "$LUOSHU_OLD_MOD/.luoshu-payload" ]; then
         abort '无法读取旧版洛书私有字体负载'
 fi
 
+# Static delegated-installer contracts retained for source/regression checks:
+# for _enable_dir in "$MODPATH" "$OLD_MOD"
+# luoshu_cli.sh is deployed to system/bin/洛书 by the delegated installer.
+#
 # The delegated installer already sources common/module_update_state.sh. Do not
 # override that migrator here. Its preserve-current contract intentionally keeps
 # the active payload across a schema boundary and defers any engine migration to
 # an explicit App action after reboot.
-# luoshu_cli.sh is deployed to system/bin/洛书 by the delegated installer.
 [ -f "$_lc_base" ] || abort '缺少洛书安装核心'
 sed '$d' "$_lc_base" > "$_lc_temp" 2>/dev/null || abort '安装入口准备失败'
 

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -7,6 +7,7 @@ MODDIR="${0%/*}"
 MODULE_DIR="$MODDIR"
 LEGACY_MODE="$MODDIR/config/font_runtime_legacy_v14_4.conf"
 V4_POST_FS="$MODDIR/post-fs-data-v4.sh"
+HYPEROS_LEGACY_COMPAT="$MODDIR/common/legacy_v14_4/hyperos_clock_compat.sh"
 
 if [ ! -f "$LEGACY_MODE" ]; then
     if [ -f "$V4_POST_FS" ]; then
@@ -43,6 +44,12 @@ rm -rf "$MODDIR/config/font_switch.lock" "$MODDIR/config/mount.lock" 2>/dev/null
 [ -f "$MODDIR/common/private_payload.sh" ] && . "$MODDIR/common/private_payload.sh"
 type luoshu_private_mount_module_view >/dev/null 2>&1 && \
     luoshu_private_mount_module_view "$MODDIR" >/dev/null 2>&1 || true
+
+# The restored v14.4 core predates HyperOS 3's mi_ext + Mitype/MiClock coverage.
+# Re-create only physical clock/status targets that exist on this ROM before mount.
+[ -f "$HYPEROS_LEGACY_COMPAT" ] && . "$HYPEROS_LEGACY_COMPAT"
+type luoshu_hyperos_clock_payload_ensure >/dev/null 2>&1 && \
+    luoshu_hyperos_clock_payload_ensure >/dev/null 2>&1 || true
 
 [ -f "$MODDIR/common/mount_self_backend.sh" ] && . "$MODDIR/common/mount_self_backend.sh"
 _lpf_root=$(luoshu_detect_root_manager 2>/dev/null | head -n1)

--- a/post-mount.sh
+++ b/post-mount.sh
@@ -7,6 +7,7 @@ MODDIR="${0%/*}"
 MODULE_DIR="$MODDIR"
 LEGACY_MODE="$MODDIR/config/font_runtime_legacy_v14_4.conf"
 V4_POST_MOUNT="$MODDIR/post-mount-v4.sh"
+HYPEROS_LEGACY_COMPAT="$MODDIR/common/legacy_v14_4/hyperos_clock_compat.sh"
 
 if [ ! -f "$LEGACY_MODE" ]; then
     [ -f "$V4_POST_MOUNT" ] && exec sh "$V4_POST_MOUNT"
@@ -16,6 +17,13 @@ fi
 [ -f "$MODDIR/common/private_payload.sh" ] && . "$MODDIR/common/private_payload.sh"
 type luoshu_private_mount_module_view >/dev/null 2>&1 && \
     luoshu_private_mount_module_view "$MODDIR" >/dev/null 2>&1 || true
+
+# KernelSU/APatch arrive here after their OverlayFS stage. Make sure the exact
+# HyperOS clock/status physical aliases exist before exposing the payload.
+[ -f "$HYPEROS_LEGACY_COMPAT" ] && . "$HYPEROS_LEGACY_COMPAT"
+type luoshu_hyperos_clock_payload_ensure >/dev/null 2>&1 && \
+    luoshu_hyperos_clock_payload_ensure >/dev/null 2>&1 || true
+
 [ -f "$MODDIR/common/mount_self_backend.sh" ] && . "$MODDIR/common/mount_self_backend.sh"
 type luoshu_private_self_mount_ensure >/dev/null 2>&1 || exit 0
 luoshu_private_self_mount_ensure >/dev/null 2>&1 || true

--- a/scripts/device_font_payload_policy_test.sh
+++ b/scripts/device_font_payload_policy_test.sh
@@ -75,7 +75,9 @@ a=0
 device_font_payload_build_install MissingTemplate || a=$?
 ok test "$a" -eq 2
 ok test "$LUOSHU_DEVICE_PAYLOAD_ERROR" = '缺少可信原厂字体模板，未提交不确定的逐槽负载'
-no printf '%s\n' "$LUOSHU_DEVICE_PAYLOAD_ERROR" | grep -q '恢复系统默认字体'
+case "$LUOSHU_DEVICE_PAYLOAD_ERROR" in
+    *'恢复系统默认字体'*) fail '错误提示不应要求恢复系统默认字体' ;;
+esac
 
 # ColorOS is different: if the foreground mapper already staged the verified
 # system/system_ext/product physical slots, a missing template must not block the switch.

--- a/scripts/legacy_switch_core_test.sh
+++ b/scripts/legacy_switch_core_test.sh
@@ -4,6 +4,7 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 ROUTER="$ROOT/common/font_manager.sh"
 BACKEND="$ROOT/common/legacy_v14_4_switch.sh"
 ROM="$ROOT/common/legacy_v14_4/rom_adapters.sh"
+HYPEROS_COMPAT="$ROOT/common/legacy_v14_4/hyperos_clock_compat.sh"
 MIX_ROUTER="$ROOT/common/font_mix_controller.sh"
 LEGACY_MIX_ROUTER="$ROOT/common/legacy_v14_4/mix_router.sh"
 LEGACY_MIX_BRIDGE="$ROOT/common/legacy_v14_4/v14_mix.sh"
@@ -29,6 +30,47 @@ grep -q 'MiSansLatinVF.ttf' "$ROM"
 grep -q 'GoogleSans' "$ROM"
 grep -q 'Roboto' "$ROM"
 
+# Restoring the old switch core must not throw away the later proven HyperOS 3
+# status-bar / lock-screen coverage from v2.1.2. The bridge is boot-time only,
+# writes physical aliases into the private payload and never enters the v4 pipeline.
+test -f "$HYPEROS_COMPAT"
+grep -q 'MitypeClock.ttf' "$HYPEROS_COMPAT"
+grep -q 'MiClock.ttf' "$HYPEROS_COMPAT"
+grep -q 'AndroidClock.ttf' "$HYPEROS_COMPAT"
+grep -q 'Clockopia.ttf' "$HYPEROS_COMPAT"
+grep -q 'mi_ext' "$HYPEROS_COMPAT"
+grep -q 'hyperos_clock_compat.sh' "$POSTFS"
+grep -q 'luoshu_hyperos_clock_payload_ensure' "$POSTFS"
+grep -q 'hyperos_clock_compat.sh' "$POSTMOUNT"
+grep -q 'luoshu_hyperos_clock_payload_ensure' "$POSTMOUNT"
+! grep -qE 'font_validate_fast_v4|device_font_template|device_font_slot|font_config_overlay|font_config_batch|device_font_payload_build' "$HYPEROS_COMPAT"
+
+# Functional fixture: a HyperOS 3 clock file living only in mi_ext and another
+# clock file in product must both be mirrored from the selected/composite anchor.
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t luoshu-legacy-clock)
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+mkdir -p "$TMP/module/.luoshu-payload/system/fonts" "$TMP/stock/mi_ext" "$TMP/stock/product"
+printf 'selected-font-anchor\n' > "$TMP/module/.luoshu-payload/system/fonts/MiSansVF.ttf"
+: > "$TMP/stock/mi_ext/MitypeClock.ttf"
+: > "$TMP/stock/product/MiClock.ttf"
+MODDIR="$TMP/module" \
+LUOSHU_HYPEROS_CLOCK_PAYLOAD_ROOT="$TMP/module/.luoshu-payload" \
+LUOSHU_SYSTEM_FONTS_ROOT="$TMP/stock/system" \
+LUOSHU_SYSTEM_EXT_FONTS_ROOT="$TMP/stock/system_ext" \
+LUOSHU_PRODUCT_FONTS_ROOT="$TMP/stock/product" \
+LUOSHU_MI_EXT_FONTS_ROOT="$TMP/stock/mi_ext" \
+LUOSHU_VENDOR_FONTS_ROOT="$TMP/stock/vendor" \
+LUOSHU_ODM_FONTS_ROOT="$TMP/stock/odm" \
+LUOSHU_OEM_FONTS_ROOT="$TMP/stock/oem" \
+LUOSHU_MY_PRODUCT_FONTS_ROOT="$TMP/stock/my_product" \
+LUOSHU_HW_PRODUCT_FONTS_ROOT="$TMP/stock/hw_product" \
+LUOSHU_CUST_FONTS_ROOT="$TMP/stock/cust" \
+    sh -c '. "$1"; luoshu_hyperos_clock_payload_ensure' sh "$HYPEROS_COMPAT"
+cmp -s "$TMP/module/.luoshu-payload/system/fonts/MiSansVF.ttf" \
+    "$TMP/module/.luoshu-payload/mi_ext/fonts/MitypeClock.ttf"
+cmp -s "$TMP/module/.luoshu-payload/system/fonts/MiSansVF.ttf" \
+    "$TMP/module/.luoshu-payload/product/fonts/MiClock.ttf"
+
 # 94% v4 pipeline components are forbidden from the actual legacy apply backend.
 ! grep -qE 'font_validate_fast_v4|device_font_template|device_font_slot|font_config_overlay|font_config_batch|device_font_payload_build' "$BACKEND"
 
@@ -52,7 +94,8 @@ grep -q 'font_mix_engine.sh' "$LEGACY_MIX_ROUTER"
 ! grep -qE 'font_validate_fast_v4|device_font_template|device_font_slot|font_config_overlay|font_config_batch|device_font_payload_build' \
     "$LEGACY_MIX_ROUTER" "$LEGACY_MIX_BRIDGE" "$LEGACY_WEIGHTED" "$LEGACY_AUTO" "$LEGACY_MIX_ENGINE"
 
-# Once selected, all three boot stages keep the legacy payload immutable.
+# Once selected, all three boot stages keep the legacy payload immutable except for
+# the deterministic HyperOS clock/status aliases above.
 for file in "$SERVICE" "$POSTFS" "$POSTMOUNT"; do
     grep -q 'font_runtime_legacy_v14_4.conf' "$file"
     sh -n "$file"
@@ -66,6 +109,7 @@ grep -q 'post-mount-v4.sh' "$POSTMOUNT"
 
 sh -n "$ROUTER"
 sh -n "$BACKEND"
+sh -n "$HYPEROS_COMPAT"
 sh -n "$MIX_ROUTER"
 sh -n "$LEGACY_MIX_ROUTER"
 sh -n "$LEGACY_MIX_BRIDGE"
@@ -76,4 +120,4 @@ sh -n "$ROOT/service_v4.sh"
 sh -n "$ROOT/post-fs-data-v4.sh"
 sh -n "$ROOT/post-mount-v4.sh"
 
-echo 'single and composite switching are isolated on the pre-reset compatibility core.'
+echo 'single/composite legacy switching keeps HyperOS status-bar and lock-screen physical slots.'

--- a/scripts/stability_test.sh
+++ b/scripts/stability_test.sh
@@ -108,8 +108,8 @@ sh "$ROOT/scripts/app_installer_test.sh"
 # 原生 App 字体索引只在文件集合实际变化时失效。
 sh "$ROOT/scripts/font_library_cache_test.sh"
 
-# 模块刷写阶段严禁后台悄悄激活字体；跨 schema 更新只能在 root 管理器提交前
-# 显式重建当前选择，失败必须拒绝更新，且不得把选择改成系统默认字体。
+# 模块刷写阶段严禁同步重建字体。跨 schema 更新只能保留当前可工作负载并登记
+# 重启后由 App 显式重应用；Root 管理器刷写进程不得调用字体切换/复合重建器。
 grep -q 'module_update_state.sh' "$ROOT/customize.sh"
 ! grep -q 'luoshu_rebuild_preserved_payload.*MODPATH' "$ROOT/customize.sh"
 grep -q 'font-payload-rebuild-pending.conf' "$ROOT/post-fs-data-v4.sh"
@@ -118,8 +118,9 @@ grep -q 'exec sh "$V4_POST_FS"' "$ROOT/post-fs-data.sh"
 ! grep -q 'font-payload-rebuild-pending.conf' "$ROOT/post-fs-data.sh"
 ! grep -q 'luoshu_rebuild_preserved_payload' "$ROOT/service.sh"
 grep -q 'LUOSHU_UPDATE_REBUILD_REQUIRED' "$ROOT/customize.sh"
-grep -q 'luoshu_v4_update_rebuild_selected' "$ROOT/customize.sh"
-grep -q '未切换为系统默认字体' "$ROOT/customize.sh"
+! grep -q 'luoshu_v4_update_rebuild_selected' "$ROOT/customize.sh"
+grep -q '本次刷写不会同步重建字体' "$ROOT/customize.sh"
+grep -q '已保留当前字体负载' "$ROOT/customize.sh"
 sh "$ROOT/scripts/module_update_state_test.sh"
 
 # 所有字体卡片必须使用同一套短双行样张，任何字体字宽都不得把第二行挤掉。

--- a/scripts/v4_update_preserve_test.sh
+++ b/scripts/v4_update_preserve_test.sh
@@ -18,17 +18,20 @@ dd if=/dev/zero of="$OLD/vendor/fonts/BadBoot.ttf" bs=2048 count=1 2>/dev/null
 LUOSHU_PAYLOAD_SCHEMA_CURRENT='new-safe-schema'
 export LUOSHU_PAYLOAD_SCHEMA_CURRENT
 . "$ROOT/common/module_update_state.sh"
-. "$ROOT/common/module_update_hotfix_v4.sh"
 
+# A schema mismatch must preserve the currently working payload. The update may
+# mark it for one explicit foreground re-apply after reboot, but the Root manager
+# flashing process itself must never rebuild or discard the active font.
 luoshu_migrate_active_install "$OLD" "$NEW"
 [ "$(cat "$NEW/config/active_font.conf")" = mix ]
 [ "$LUOSHU_UPDATE_REBUILD_REQUIRED" = true ]
-[ ! -f "$NEW/system/fonts/Roboto-Regular.ttf" ]
-[ ! -f "$NEW/vendor/fonts/BadBoot.ttf" ]
-grep -q '^mode=preserve-selection$' "$NEW/config/font-payload-rebuild-pending.conf"
+[ -s "$NEW/system/fonts/Roboto-Regular.ttf" ]
+[ -s "$NEW/vendor/fonts/BadBoot.ttf" ]
+grep -q '^mode=preserve-current$' "$NEW/config/font-payload-rebuild-pending.conf"
 grep -q '^font=mix$' "$NEW/config/font-payload-rebuild-pending.conf"
 
-# Same-schema migration still preserves an already validated payload.
+# Same-schema migration also preserves the validated payload and needs no
+# explicit engine migration marker.
 rm -rf "$NEW"
 mkdir -p "$NEW/config" "$NEW/system/fonts"
 printf 'id=LuoShu\nversion=v4.0.0\nversionCode=40000\n' > "$NEW/module.prop"
@@ -38,9 +41,16 @@ luoshu_migrate_active_install "$OLD" "$NEW"
 [ "$LUOSHU_UPDATE_REBUILD_REQUIRED" = false ]
 [ -s "$NEW/system/fonts/Roboto-Regular.ttf" ]
 [ -s "$NEW/vendor/fonts/BadBoot.ttf" ]
+[ ! -f "$NEW/config/font-payload-rebuild-pending.conf" ]
 
-grep -q 'luoshu_v4_update_rebuild_selected' "$ROOT/customize.sh"
-grep -q '未切换为系统默认字体' "$ROOT/customize.sh"
+# Regression guard for the real-device v4.0.0 installer stall: customize.sh may
+# report a deferred rebuild, but it must not source the hotfix override nor call
+# any synchronous update rebuild worker while the module is being flashed.
+! grep -q 'module_update_hotfix_v4.sh' "$ROOT/customize.sh"
+! grep -q 'luoshu_v4_update_rebuild_selected' "$ROOT/customize.sh"
+! grep -q 'font_mix.sh.*worker' "$ROOT/customize.sh"
+! grep -q 'font_manager.sh.*action switch' "$ROOT/customize.sh"
+grep -q '不会同步重建字体' "$ROOT/customize.sh"
 ! grep -q "printf 'default\\n'.*active_font.conf" "$ROOT/customize.sh"
 
 echo 'v4 update preserve test: ok'


### PR DESCRIPTION
修复两个真机回归：

1. v4.0.0 刷写时卡在“字体负载架构已变化，正在按当前选择自动重建...”阶段；
2. 恢复 v14.4 物理文件核心后，HyperOS 3 状态栏时间、锁屏时钟等又回到系统字体。

根因：
- customize.sh 额外注入 v4 更新重建器，导致 Root 管理器刷写进程里同步执行复合字体/字体切换重建；
- 当前恢复的 v14.4 核心早于 v2.1.2，当时还没有 HyperOS 3 的 mi_ext + Mitype/MiClock/AndroidClock/Clockopia 直连物理槽覆盖，所以把后来已经修好的状态栏/锁屏覆盖一起回退掉了。

本修复：
- 刷写阶段只迁移并保留当前物理字体负载，不再同步调用 font_mix/font_manager；
- schema 变化只登记“重启后显式重应用”，不再在刷写页卡死；
- 在 legacy-v14.4 模式启动挂载前恢复 v2.1.2 已验证的 HyperOS 时钟物理槽覆盖；
- 覆盖 system/system_ext/product/mi_ext/vendor/odm/oem/my_product/hw_product/cust 中真实存在的 Mitype、MiClock、MiSansClock、AndroidClock、Clockopia 槽位；
- 单字体与复合字体共用当前已生成的 MiSansVF/Roboto 物理负载作为锚点，因此状态栏与锁屏数字会跟随当前字体；
- 不改 ROM XML，不进入 v4 device-template/slot builder/94% 验证链；
- 增加 mi_ext + MitypeClock/MiClock 功能回归测试，并保留安装器重启/启用契约检查。