### PR TITLE
fix(v4.0.0): repair private updates and full HyperOS physical coverage

### DIFF
--- a/common/legacy_v14_4/hyperos_clock_compat.sh
+++ b/common/legacy_v14_4/hyperos_clock_compat.sh
@@ -1,8 +1,8 @@
 #!/system/bin/sh
 # HyperOS compatibility bridge for the restored v14.4 physical-file runtime.
-# v14.4 predates the v2.1.2 HyperOS 3 mi_ext + Mitype/MiClock coverage, so
-# re-create those proven physical aliases in the private payload before mount.
-# No XML, device-template, provider hook or foreground rebuild is involved.
+# v14.4 predates the later HyperOS 3 physical-slot coverage work. Re-create the
+# proven MiSans/Roboto/GoogleSans/NotoSans/Mitype/clock aliases in the private
+# payload before self-mount, without entering the v4 template/XML/94% pipeline.
 set +e
 
 _lhcc_module_dir() {
@@ -22,6 +22,13 @@ _lhcc_payload_root() {
     fi
 }
 
+_lhcc_is_hyperos() {
+    [ "${IS_HYPEROS:-false}" = true ] && return 0
+    _lhcc_mios=$(getprop ro.mi.os.version.name 2>/dev/null | tr -d '\r\n')
+    _lhcc_miui=$(getprop ro.miui.ui.version.name 2>/dev/null | tr -d '\r\n')
+    [ -n "$_lhcc_mios$_lhcc_miui" ]
+}
+
 _lhcc_root_for_part() {
     case "$1" in
         system) printf '%s\n' "${LUOSHU_SYSTEM_FONTS_ROOT:-/system/fonts}" ;;
@@ -38,13 +45,41 @@ _lhcc_root_for_part() {
     esac
 }
 
-_lhcc_anchor() {
+_lhcc_weight_for_name() {
+    _lhcc_lower=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+    case "$_lhcc_lower" in
+        100.ttf|*thin*) printf '100\n' ;;
+        200.ttf|*extralight*|*extra-light*) printf '200\n' ;;
+        300.ttf|*light*) printf '300\n' ;;
+        350.ttf) printf '350\n' ;;
+        500.ttf|*medium*) printf '500\n' ;;
+        600.ttf|*semibold*|*semi-bold*|*demibold*) printf '600\n' ;;
+        700.ttf|*bold*) printf '700\n' ;;
+        800.ttf|*extrabold*|*extra-bold*) printf '800\n' ;;
+        900.ttf|*black*|*heavy*) printf '900\n' ;;
+        *) printf '400\n' ;;
+    esac
+}
+
+_lhcc_source_for_name() {
+    _lhcc_name="$1"
     _lhcc_payload="$(_lhcc_payload_root)"
+    _lhcc_system="$_lhcc_payload/system/fonts"
+
+    # Best source is the exact v14.4-generated alias. This preserves composite
+    # CJK/Latin/digit content and any selected weight without rebuilding anything.
+    [ -s "$_lhcc_system/$_lhcc_name" ] && {
+        printf '%s\n' "$_lhcc_system/$_lhcc_name"
+        return 0
+    }
+
+    _lhcc_weight=$(_lhcc_weight_for_name "$_lhcc_name")
     for _lhcc_file in \
-        "$_lhcc_payload/system/fonts/MiSansVF.ttf" \
-        "$_lhcc_payload/system/fonts/MiSansLatinVF.ttf" \
-        "$_lhcc_payload/system/fonts/Roboto-Regular.ttf" \
-        "$_lhcc_payload/system/fonts/400.ttf"; do
+        "$_lhcc_system/${_lhcc_weight}.ttf" \
+        "$_lhcc_system/400.ttf" \
+        "$_lhcc_system/Roboto-Regular.ttf" \
+        "$_lhcc_system/MiSansLatinVF.ttf" \
+        "$_lhcc_system/MiSansVF.ttf"; do
         [ -s "$_lhcc_file" ] || continue
         printf '%s\n' "$_lhcc_file"
         return 0
@@ -53,12 +88,101 @@ _lhcc_anchor() {
 }
 
 _lhcc_static_names() {
-    printf '%s\n' \
-        MitypeVF.ttf MitypeMonoVF.ttf MitypeClock.ttf MitypeClock.otf \
-        MitypeClockMono.ttf MitypeClockMono.otf \
-        MiClock.ttf MiClock.otf MiClockThin.ttf MiClockThin.otf \
-        MiClockMono.ttf MiClockMono.otf MiSansClock.ttf MiSansClockVF.ttf \
-        AndroidClock.ttf AndroidClock_Highlight.ttf AndroidClock_Solid.ttf Clockopia.ttf
+    cat <<'EOF_LHCC_STATIC'
+MiSansVF.ttf
+MiSansVF_Overlay.ttf
+MiSansLatinVF.ttf
+MiSansTCVF.ttf
+MiSansL3.otf
+100.ttf
+200.ttf
+300.ttf
+350.ttf
+400.ttf
+500.ttf
+600.ttf
+700.ttf
+800.ttf
+900.ttf
+Roboto-Thin.ttf
+Roboto-ExtraLight.ttf
+Roboto-Light.ttf
+Roboto-Regular.ttf
+Roboto-Medium.ttf
+Roboto-SemiBold.ttf
+Roboto-Bold.ttf
+Roboto-ExtraBold.ttf
+Roboto-Black.ttf
+RobotoFlex-Regular.ttf
+RobotoStatic-Regular.ttf
+GoogleSans-Regular.ttf
+GoogleSans-Medium.ttf
+GoogleSans-SemiBold.ttf
+GoogleSans-Bold.ttf
+GoogleSans-Black.ttf
+GoogleSansText-Regular.ttf
+GoogleSansText-Medium.ttf
+GoogleSansText-SemiBold.ttf
+GoogleSansText-Bold.ttf
+GoogleSansText-Black.ttf
+GoogleSansText-VF.ttf
+GoogleSansTextVF.ttf
+GoogleSans-VF.ttf
+GoogleSansFlex-Regular.ttf
+NotoSans-Regular.ttf
+NotoSans-Medium.ttf
+NotoSans-SemiBold.ttf
+NotoSans-Bold.ttf
+NotoSans-Black.ttf
+NotoSansUI-Regular.ttf
+NotoSansUI-Medium.ttf
+NotoSansUI-Bold.ttf
+SourceSansPro-Regular.ttf
+SourceSansPro-Medium.ttf
+SourceSansPro-SemiBold.ttf
+SourceSansPro-Bold.ttf
+DroidSans.ttf
+MitypeVF.ttf
+MitypeMonoVF.ttf
+MitypeClock.ttf
+MitypeClock.otf
+MitypeClockMono.ttf
+MitypeClockMono.otf
+MiClock.ttf
+MiClock.otf
+MiClockThin.ttf
+MiClockThin.otf
+MiClockMono.ttf
+MiClockMono.otf
+MiSansClock.ttf
+MiSansClockVF.ttf
+AndroidClock.ttf
+AndroidClock_Highlight.ttf
+AndroidClock_Solid.ttf
+Clockopia.ttf
+EOF_LHCC_STATIC
+}
+
+_lhcc_safe_dynamic_name() {
+    _lhcc_name="$1"
+    case "$_lhcc_name" in
+        *Italic*|*Oblique*|*Emoji*|*Symbol*|*Icon*|*Serif*) return 1 ;;
+        *Arabic*|*Hebrew*|*Thai*|*Devanagari*|*Bengali*|*Tamil*|*Telugu*|*Malayalam*|*Gujarati*|*Gurmukhi*|*Kannada*|*Khmer*|*Lao*|*Tibetan*|*Myanmar*) return 1 ;;
+    esac
+    case "$_lhcc_name" in
+        MiSansVF.ttf|MiSansVF_Overlay.ttf|MiSansLatinVF.ttf|MiSansTCVF.ttf|MiSansL3.otf|\
+        [1-9]00.ttf|350.ttf|\
+        Roboto*.ttf|Roboto*.otf|GoogleSans*.ttf|GoogleSans*.otf|\
+        NotoSans-Regular.ttf|NotoSans-Medium.ttf|NotoSans-SemiBold.ttf|NotoSans-Bold.ttf|NotoSans-Black.ttf|\
+        NotoSansUI-Regular.ttf|NotoSansUI-Medium.ttf|NotoSansUI-Bold.ttf|\
+        SourceSansPro*.ttf|SourceSansPro*.otf|DroidSans.ttf|\
+        Mitype*.ttf|Mitype*.otf|MiClock*.ttf|MiClock*.otf|\
+        MiSans*Clock*.ttf|MiSans*Clock*.otf|AndroidClock*.ttf|AndroidClock*.otf|Clockopia.ttf|\
+        MiLanPro*.ttf|MiLanPro*.otf|XiaomiSans*.ttf|XiaomiSans*.otf)
+            return 0
+            ;;
+    esac
+    return 1
 }
 
 _lhcc_names_for_root() {
@@ -66,15 +190,10 @@ _lhcc_names_for_root() {
     {
         _lhcc_static_names
         [ -d "$_lhcc_real" ] || exit 0
-        for _lhcc_path in \
-            "$_lhcc_real"/Mitype*.ttf "$_lhcc_real"/Mitype*.otf \
-            "$_lhcc_real"/MiClock*.ttf "$_lhcc_real"/MiClock*.otf \
-            "$_lhcc_real"/MiSans*Clock*.ttf "$_lhcc_real"/MiSans*Clock*.otf \
-            "$_lhcc_real"/AndroidClock*.ttf "$_lhcc_real"/AndroidClock*.otf \
-            "$_lhcc_real"/Clockopia.ttf; do
+        for _lhcc_path in "$_lhcc_real"/*; do
             [ -f "$_lhcc_path" ] || continue
             _lhcc_name=${_lhcc_path##*/}
-            case "$_lhcc_name" in *Italic*|*Oblique*|*Emoji*|*Symbol*|*Icon*) continue ;; esac
+            _lhcc_safe_dynamic_name "$_lhcc_name" || continue
             printf '%s\n' "$_lhcc_name"
         done
     } | awk 'NF && !seen[$0]++'
@@ -83,6 +202,7 @@ _lhcc_names_for_root() {
 _lhcc_link_or_copy() {
     _lhcc_source="$1"
     _lhcc_dest="$2"
+    [ "$_lhcc_source" = "$_lhcc_dest" ] && return 0
     rm -f "$_lhcc_dest" 2>/dev/null || true
     ln "$_lhcc_source" "$_lhcc_dest" 2>/dev/null || \
         cp -f "$_lhcc_source" "$_lhcc_dest" 2>/dev/null || return 1
@@ -91,34 +211,46 @@ _lhcc_link_or_copy() {
 }
 
 luoshu_hyperos_clock_payload_ensure() {
-    _lhcc_anchor_file="$(_lhcc_anchor)" || return 0
+    _lhcc_is_hyperos || return 0
     _lhcc_payload="$(_lhcc_payload_root)"
+    [ -d "$_lhcc_payload/system/fonts" ] || return 0
     _lhcc_count=0
+    _lhcc_parts=0
 
-    # The current v14.4 payload already proves this is a selected text font. Only
-    # mirror into physical files that really exist on the ROM, so other ROMs no-op.
+    # Mirror only names that exist on this exact ROM. The source always comes from
+    # the already-built v14.4 payload, so this is fast and cannot re-enter the v4
+    # template/slot builder/validation path that previously stalled at 94%.
     for _lhcc_part in system system_ext product mi_ext vendor odm oem my_product hw_product cust; do
         _lhcc_real="$(_lhcc_root_for_part "$_lhcc_part")" || continue
         [ -d "$_lhcc_real" ] || continue
         _lhcc_overlay="$_lhcc_payload/$_lhcc_part/fonts"
+        _lhcc_part_count=0
         while IFS= read -r _lhcc_name; do
             [ -n "$_lhcc_name" ] || continue
             [ -e "$_lhcc_real/$_lhcc_name" ] || continue
+            _lhcc_source="$(_lhcc_source_for_name "$_lhcc_name")" || continue
             mkdir -p "$_lhcc_overlay" 2>/dev/null || continue
-            if _lhcc_link_or_copy "$_lhcc_anchor_file" "$_lhcc_overlay/$_lhcc_name"; then
+            if _lhcc_link_or_copy "$_lhcc_source" "$_lhcc_overlay/$_lhcc_name"; then
                 _lhcc_count=$((_lhcc_count + 1))
+                _lhcc_part_count=$((_lhcc_part_count + 1))
             fi
         done <<EOF_LHCC_NAMES
 $(_lhcc_names_for_root "$_lhcc_real")
 EOF_LHCC_NAMES
+        [ "$_lhcc_part_count" -gt 0 ] 2>/dev/null && _lhcc_parts=$((_lhcc_parts + 1))
     done
 
     _lhcc_module="$(_lhcc_module_dir)"
     if [ "$_lhcc_count" -gt 0 ]; then
         mkdir -p "$_lhcc_module/logs" 2>/dev/null || true
-        printf '[%s] HyperOS legacy clock/status slots restored: %s\n' \
-            "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null)" "$_lhcc_count" \
+        printf '[%s] HyperOS legacy physical UI slots restored: %s targets / %s partitions\n' \
+            "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null)" "$_lhcc_count" "$_lhcc_parts" \
             >> "$_lhcc_module/logs/fontswitch.log" 2>/dev/null || true
     fi
     return 0
+}
+
+# New semantic name for callers/tests; keep the old function as compatibility API.
+luoshu_hyperos_legacy_payload_ensure() {
+    luoshu_hyperos_clock_payload_ensure "$@"
 }

--- a/common/module_status.sh
+++ b/common/module_status.sh
@@ -1,5 +1,6 @@
 #!/system/bin/sh
-# 洛书 v2.0.0：在 Root 管理器中显示简洁的当前字体状态。
+# 洛书：在 Root 管理器中显示简洁的当前字体状态。
+# module.prop 的“当前字体”只描述用户实际选择/挂载结果，不承担设备可信验证 UI。
 set +e
 
 MODDIR="${MODDIR:-}"
@@ -35,20 +36,17 @@ EFFECTIVE_DISPLAY="$DISPLAY"
 if [ "$ACTIVE" != default ]; then
     VERIFY="$MODDIR/config/device-font-load-verification.conf"
     VERIFY_STATE=$(sed -n 's/^state=//p' "$VERIFY" 2>/dev/null | head -n1)
-    VERIFY_MODE=$(sed -n 's/^mode=//p' "$VERIFY" 2>/dev/null | head -n1)
-    VERIFY_ACTIVE=$(sed -n 's/^activeFont=//p' "$VERIFY" 2>/dev/null | head -n1)
     MOUNT_STATE=$(sed -n 's/^state=//p' "$MODDIR/config/self-mount.conf" 2>/dev/null | head -n1)
+
+    # Root 管理器这里显示的是“当前字体”，不是验收页面。旧逻辑在字体已经肉眼生效时
+    # 仍会因为 v4 验证文件缺失/模式不同而长期写“待验证”，造成错误状态。现在只在
+    # 明确等待重启或明确失败时附加状态；其余情况直接显示当前字体。
     if [ -f "$MODDIR/config/text_reboot_required.conf" ]; then
         EFFECTIVE_DISPLAY="已配置：$DISPLAY（等待重启）"
     elif [ "$MOUNT_STATE" = failed ] || [ "$VERIFY_STATE" = failed ]; then
         EFFECTIVE_DISPLAY="系统默认字体（$DISPLAY 未生效）"
-    elif [ "$VERIFY_ACTIVE" = "$ACTIVE" ] && [ "$VERIFY_STATE" = verified ]; then
-        case "$VERIFY_MODE" in
-            aligned|mount-verified) EFFECTIVE_DISPLAY="$DISPLAY" ;;
-            *) EFFECTIVE_DISPLAY="已配置：$DISPLAY（待验证）" ;;
-        esac
     else
-        EFFECTIVE_DISPLAY="已配置：$DISPLAY（待验证）"
+        EFFECTIVE_DISPLAY="$DISPLAY"
     fi
 fi
 

--- a/common/private_payload.sh
+++ b/common/private_payload.sh
@@ -79,35 +79,82 @@ luoshu_private_mount_module_view() {
     _lpp_root=$(_luoshu_private_root "$_lpp_module")
     _lpp_state=$(_luoshu_private_state_root)
     _lpp_list="$_lpp_state/module-view.mounts"
+    _lpp_symlinks="$_lpp_state/module-view.symlinks"
     [ -d "$_lpp_root" ] || return 1
     mkdir -p "$_lpp_state" 2>/dev/null || return 1
     : > "$_lpp_list" 2>/dev/null || return 1
+    : > "$_lpp_symlinks" 2>/dev/null || return 1
 
+    _lpp_sources=0
+    _lpp_exposed=0
     for _lpp_part in $(luoshu_private_partitions); do
         _lpp_source="$_lpp_root/$_lpp_part"
         _lpp_target="$_lpp_module/$_lpp_part"
         [ -d "$_lpp_source" ] || continue
+        _lpp_sources=$((_lpp_sources + 1))
+
+        if [ -L "$_lpp_target" ]; then
+            _lpp_link=$(readlink "$_lpp_target" 2>/dev/null)
+            if [ "$_lpp_link" = "$_lpp_source" ]; then
+                printf '%s|%s\n' "$_lpp_target" "$_lpp_source" >> "$_lpp_symlinks" 2>/dev/null || true
+                _lpp_exposed=$((_lpp_exposed + 1))
+                continue
+            fi
+            rm -f "$_lpp_target" 2>/dev/null || true
+        fi
+
         mkdir -p "$_lpp_target" 2>/dev/null || continue
         if _luoshu_private_is_mountpoint "$_lpp_target"; then
             printf '%s\n' "$_lpp_target" >> "$_lpp_list" 2>/dev/null || true
+            _lpp_exposed=$((_lpp_exposed + 1))
             continue
         fi
         if _luoshu_private_mount_cmd -o bind "$_lpp_source" "$_lpp_target" >/dev/null 2>&1; then
             printf '%s\n' "$_lpp_target" >> "$_lpp_list" 2>/dev/null || true
+            _lpp_exposed=$((_lpp_exposed + 1))
+            continue
+        fi
+
+        # KernelSU/SukiSU 的模块刷写进程可能没有 CAP_SYS_ADMIN，bind mount 会失败。
+        # 更新迁移只需要读取旧私有负载，因此目标目录为空时用临时符号链接投影。
+        if rmdir "$_lpp_target" 2>/dev/null && ln -s "$_lpp_source" "$_lpp_target" 2>/dev/null; then
+            printf '%s|%s\n' "$_lpp_target" "$_lpp_source" >> "$_lpp_symlinks" 2>/dev/null || true
+            _lpp_exposed=$((_lpp_exposed + 1))
+        else
+            [ -d "$_lpp_target" ] || mkdir -p "$_lpp_target" 2>/dev/null || true
         fi
     done
-    return 0
+
+    [ "$_lpp_sources" -eq 0 ] 2>/dev/null && return 0
+    [ "$_lpp_exposed" -gt 0 ] 2>/dev/null
 }
 
 luoshu_private_unmount_module_view() {
     _lpp_module="${1:-$(_luoshu_private_module)}"
-    _lpp_list="$(_luoshu_private_state_root)/module-view.mounts"
-    [ -s "$_lpp_list" ] || return 0
-    awk '{ item[NR]=$0 } END { for (i=NR; i>=1; i--) print item[i] }' "$_lpp_list" 2>/dev/null | \
-    while IFS= read -r _lpp_target; do
-        case "$_lpp_target" in "${_lpp_module%/}"/*) ;; *) continue ;; esac
-        _luoshu_private_umount_cmd "$_lpp_target" >/dev/null 2>&1 || true
-    done
+    _lpp_state=$(_luoshu_private_state_root)
+    _lpp_list="$_lpp_state/module-view.mounts"
+    _lpp_symlinks="$_lpp_state/module-view.symlinks"
+
+    if [ -s "$_lpp_list" ]; then
+        awk '{ item[NR]=$0 } END { for (i=NR; i>=1; i--) print item[i] }' "$_lpp_list" 2>/dev/null | \
+        while IFS= read -r _lpp_target; do
+            case "$_lpp_target" in "${_lpp_module%/}"/*) ;; *) continue ;; esac
+            _luoshu_private_umount_cmd "$_lpp_target" >/dev/null 2>&1 || true
+        done
+    fi
     : > "$_lpp_list" 2>/dev/null || true
+
+    if [ -s "$_lpp_symlinks" ]; then
+        while IFS='|' read -r _lpp_target _lpp_source; do
+            [ -n "$_lpp_target" ] || continue
+            case "$_lpp_target" in "${_lpp_module%/}"/*) ;; *) continue ;; esac
+            if [ -L "$_lpp_target" ]; then
+                _lpp_link=$(readlink "$_lpp_target" 2>/dev/null)
+                [ "$_lpp_link" = "$_lpp_source" ] && rm -f "$_lpp_target" 2>/dev/null || true
+            fi
+            [ -e "$_lpp_target" ] || mkdir -p "$_lpp_target" 2>/dev/null || true
+        done < "$_lpp_symlinks"
+    fi
+    : > "$_lpp_symlinks" 2>/dev/null || true
     return 0
 }

--- a/customize.sh
+++ b/customize.sh
@@ -66,7 +66,11 @@ sed -e 's/^[[:space:]]*exit 1[[:space:]]*$/        return 1/' \
 . "$_lc_temp"
 _lc_rc=$?
 rm -f "$_lc_temp" 2>/dev/null || true
-luoshu_private_unmount_module_view "$LUOSHU_OLD_MOD" >/dev/null 2>&1 || true
+# Some sh implementations can propagate a sourced helper's top-level return through
+# the caller when the function is invoked during installer unwinding. Keep cleanup in
+# a child shell: filesystem symlink cleanup and umounts still take effect, while an
+# unexpected helper exit can no longer terminate the Root manager's parent script.
+( luoshu_private_unmount_module_view "$LUOSHU_OLD_MOD" >/dev/null 2>&1 ) || true
 if [ "$_lc_rc" -ne 0 ]; then
     # APatch sources customize.sh into its installer process. Returning here keeps
     # the manager's commit phase alive; direct execution still exits with the

--- a/customize.sh
+++ b/customize.sh
@@ -19,11 +19,24 @@ _lc_temp="$MODPATH/.customize-v227.$$.sh"
 [ -f "$_lc_helper" ] || _lc_helper="$_lc_source_dir/common/private_payload.sh"
 [ -f "$_lc_helper" ] && . "$_lc_helper"
 
+# Magisk/KernelSU/APatch provide ui_print/abort while flashing. Host-side safety
+# tests and a few nonstandard installers may not. Missing presentation helpers
+# must never turn a successful migration into exit 127/2 after all payload work
+# completed, so provide harmless portable fallbacks only when the manager did not.
+if ! command -v ui_print >/dev/null 2>&1; then
+    ui_print() { printf '%s\n' "$*"; }
+fi
+if ! command -v abort >/dev/null 2>&1; then
+    abort() { ui_print "! $*"; return 1; }
+fi
+
 # Existing private-payload installations are exposed only for the duration of
 # the verified update migrator, then hidden again.
 if [ -d "$LUOSHU_OLD_MOD/.luoshu-payload" ]; then
-    luoshu_private_mount_module_view "$LUOSHU_OLD_MOD" >/dev/null 2>&1 || \
+    if ! luoshu_private_mount_module_view "$LUOSHU_OLD_MOD" >/dev/null 2>&1; then
         abort '无法读取旧版洛书私有字体负载'
+        return 1 2>/dev/null || exit 1
+    fi
 fi
 
 # Static delegated-installer contracts retained for source/regression checks:
@@ -35,8 +48,14 @@ fi
 # override that migrator here. Its preserve-current contract intentionally keeps
 # the active payload across a schema boundary and defers any engine migration to
 # an explicit App action after reboot.
-[ -f "$_lc_base" ] || abort '缺少洛书安装核心'
-sed '$d' "$_lc_base" > "$_lc_temp" 2>/dev/null || abort '安装入口准备失败'
+if [ ! -f "$_lc_base" ]; then
+    abort '缺少洛书安装核心'
+    return 1 2>/dev/null || exit 1
+fi
+sed '$d' "$_lc_base" > "$_lc_temp" 2>/dev/null || {
+    abort '安装入口准备失败'
+    return 1 2>/dev/null || exit 1
+}
 
 . "$_lc_temp"
 _lc_rc=$?
@@ -62,6 +81,7 @@ fi
 
 if ! luoshu_private_install_migrate "$MODPATH"; then
     abort '洛书私有挂载树部署失败'
+    return 1 2>/dev/null || exit 1
 fi
 ui_print '✓ 私有字体负载已部署'
 ui_print '✓ 洛书将独立完成字体挂载'

--- a/customize.sh
+++ b/customize.sh
@@ -52,7 +52,13 @@ if [ ! -f "$_lc_base" ]; then
     abort '缺少洛书安装核心'
     return 1 2>/dev/null || exit 1
 fi
-sed '$d' "$_lc_base" > "$_lc_temp" 2>/dev/null || {
+# Run the delegated installer by sourcing it so its migration state remains visible
+# to this wrapper, but convert its top-level exit statements into returns. This is
+# essential for APatch (which sources customize.sh) and also guarantees cleanup of
+# the temporary private-payload view on a controlled migration rejection.
+sed -e 's/^[[:space:]]*exit 1[[:space:]]*$/        return 1/' \
+    -e 's/^[[:space:]]*exit 0[[:space:]]*$/return 0/' \
+    "$_lc_base" > "$_lc_temp" 2>/dev/null || {
     abort '安装入口准备失败'
     return 1 2>/dev/null || exit 1
 }

--- a/scripts/customize_reenable_test.sh
+++ b/scripts/customize_reenable_test.sh
@@ -15,7 +15,11 @@ printf 'state=quarantined\n' > "$OLD/config/font-payload-quarantine.conf"
 
 # customize.sh intentionally tolerates unavailable Android commands during host-side tests. The
 # regression contract is that a flash immediately re-enables both the active and staged trees.
-MODPATH="$NEW" LUOSHU_OLD_MOD="$OLD" sh "$ROOT/customize.sh" >/dev/null 2>&1
+if ! MODPATH="$NEW" LUOSHU_OLD_MOD="$OLD" sh "$ROOT/customize.sh" >"$TMP/direct.log" 2>&1; then
+    cat "$TMP/direct.log" >&2
+    echo 'direct customize execution failed' >&2
+    exit 1
+fi
 
 test ! -e "$OLD/disable"
 test ! -e "$NEW/disable"
@@ -25,10 +29,14 @@ test ! -e "$OLD/config/font-payload-quarantine.conf"
 # APatch sources customize.sh. The wrapper must return to the manager instead of
 # exiting its parent shell before the staged module is committed.
 SOURCED_MARKER="$TMP/source-continued"
-MODPATH="$NEW" LUOSHU_OLD_MOD="$OLD" sh -c '
-    . "$1" >/dev/null 2>&1
+if ! MODPATH="$NEW" LUOSHU_OLD_MOD="$OLD" sh -c '
+    . "$1" >"$3" 2>&1
     printf "continued\n" > "$2"
-' sh "$ROOT/customize.sh" "$SOURCED_MARKER"
+' sh "$ROOT/customize.sh" "$SOURCED_MARKER" "$TMP/sourced.log"; then
+    cat "$TMP/sourced.log" >&2 || true
+    echo 'sourced customize execution failed' >&2
+    exit 1
+fi
 test "$(cat "$SOURCED_MARKER")" = continued
 
 echo 'Module flash re-enable and APatch source-safety checks passed.'

--- a/scripts/customize_reenable_test.sh
+++ b/scripts/customize_reenable_test.sh
@@ -15,7 +15,7 @@ printf 'state=quarantined\n' > "$OLD/config/font-payload-quarantine.conf"
 
 # customize.sh intentionally tolerates unavailable Android commands during host-side tests. The
 # regression contract is that a flash immediately re-enables both the active and staged trees.
-if ! MODPATH="$NEW" LUOSHU_OLD_MOD="$OLD" sh "$ROOT/customize.sh" >"$TMP/direct.log" 2>&1; then
+if ! MODPATH="$NEW" LUOSHU_OLD_MOD="$OLD" sh -x "$ROOT/customize.sh" >"$TMP/direct.log" 2>&1; then
     cat "$TMP/direct.log" >&2
     echo 'direct customize execution failed' >&2
     exit 1
@@ -29,7 +29,7 @@ test ! -e "$OLD/config/font-payload-quarantine.conf"
 # APatch sources customize.sh. The wrapper must return to the manager instead of
 # exiting its parent shell before the staged module is committed.
 SOURCED_MARKER="$TMP/source-continued"
-if ! MODPATH="$NEW" LUOSHU_OLD_MOD="$OLD" sh -c '
+if ! MODPATH="$NEW" LUOSHU_OLD_MOD="$OLD" sh -x -c '
     . "$1" >"$3" 2>&1
     printf "continued\n" > "$2"
 ' sh "$ROOT/customize.sh" "$SOURCED_MARKER" "$TMP/sourced.log"; then

--- a/scripts/legacy_switch_core_test.sh
+++ b/scripts/legacy_switch_core_test.sh
@@ -30,14 +30,18 @@ grep -q 'MiSansLatinVF.ttf' "$ROM"
 grep -q 'GoogleSans' "$ROM"
 grep -q 'Roboto' "$ROM"
 
-# Restoring the old switch core must not throw away the later proven HyperOS 3
-# status-bar / lock-screen coverage from v2.1.2. The bridge is boot-time only,
-# writes physical aliases into the private payload and never enters the v4 pipeline.
+# Restoring the old switch core must not throw away later proven HyperOS 3 physical
+# coverage. The bridge runs before self-mount, writes only aliases into the private
+# payload and never enters the v4 template/XML/94% validation pipeline.
 test -f "$HYPEROS_COMPAT"
 grep -q 'MitypeClock.ttf' "$HYPEROS_COMPAT"
 grep -q 'MiClock.ttf' "$HYPEROS_COMPAT"
 grep -q 'AndroidClock.ttf' "$HYPEROS_COMPAT"
 grep -q 'Clockopia.ttf' "$HYPEROS_COMPAT"
+grep -q 'GoogleSansText-Regular.ttf' "$HYPEROS_COMPAT"
+grep -q 'NotoSansUI-Regular.ttf' "$HYPEROS_COMPAT"
+grep -q 'MiLanPro' "$HYPEROS_COMPAT"
+grep -q 'XiaomiSans' "$HYPEROS_COMPAT"
 grep -q 'mi_ext' "$HYPEROS_COMPAT"
 grep -q 'hyperos_clock_compat.sh' "$POSTFS"
 grep -q 'luoshu_hyperos_clock_payload_ensure' "$POSTFS"
@@ -45,14 +49,22 @@ grep -q 'hyperos_clock_compat.sh' "$POSTMOUNT"
 grep -q 'luoshu_hyperos_clock_payload_ensure' "$POSTMOUNT"
 ! grep -qE 'font_validate_fast_v4|device_font_template|device_font_slot|font_config_overlay|font_config_batch|device_font_payload_build' "$HYPEROS_COMPAT"
 
-# Functional fixture: a HyperOS 3 clock file living only in mi_ext and another
-# clock file in product must both be mirrored from the selected/composite anchor.
+# Functional fixture: cover status/lock-screen slots and ordinary HyperOS UI slots
+# living outside system/fonts. Every alias must come from the already-built selected
+# payload, so no foreground rebuild or second validation pipeline is needed.
 TMP=$(mktemp -d 2>/dev/null || mktemp -d -t luoshu-legacy-clock)
 trap 'rm -rf "$TMP"' EXIT HUP INT TERM
-mkdir -p "$TMP/module/.luoshu-payload/system/fonts" "$TMP/stock/mi_ext" "$TMP/stock/product"
+mkdir -p \
+    "$TMP/module/.luoshu-payload/system/fonts" \
+    "$TMP/stock/system" "$TMP/stock/system_ext" "$TMP/stock/product" \
+    "$TMP/stock/mi_ext" "$TMP/stock/vendor"
 printf 'selected-font-anchor\n' > "$TMP/module/.luoshu-payload/system/fonts/MiSansVF.ttf"
 : > "$TMP/stock/mi_ext/MitypeClock.ttf"
 : > "$TMP/stock/product/MiClock.ttf"
+: > "$TMP/stock/system_ext/GoogleSansText-Regular.ttf"
+: > "$TMP/stock/product/NotoSansUI-Medium.ttf"
+: > "$TMP/stock/vendor/MiLanProVF.ttf"
+IS_HYPEROS=true \
 MODDIR="$TMP/module" \
 LUOSHU_HYPEROS_CLOCK_PAYLOAD_ROOT="$TMP/module/.luoshu-payload" \
 LUOSHU_SYSTEM_FONTS_ROOT="$TMP/stock/system" \
@@ -66,10 +78,14 @@ LUOSHU_MY_PRODUCT_FONTS_ROOT="$TMP/stock/my_product" \
 LUOSHU_HW_PRODUCT_FONTS_ROOT="$TMP/stock/hw_product" \
 LUOSHU_CUST_FONTS_ROOT="$TMP/stock/cust" \
     sh -c '. "$1"; luoshu_hyperos_clock_payload_ensure' sh "$HYPEROS_COMPAT"
-cmp -s "$TMP/module/.luoshu-payload/system/fonts/MiSansVF.ttf" \
-    "$TMP/module/.luoshu-payload/mi_ext/fonts/MitypeClock.ttf"
-cmp -s "$TMP/module/.luoshu-payload/system/fonts/MiSansVF.ttf" \
-    "$TMP/module/.luoshu-payload/product/fonts/MiClock.ttf"
+for generated in \
+    "$TMP/module/.luoshu-payload/mi_ext/fonts/MitypeClock.ttf" \
+    "$TMP/module/.luoshu-payload/product/fonts/MiClock.ttf" \
+    "$TMP/module/.luoshu-payload/system_ext/fonts/GoogleSansText-Regular.ttf" \
+    "$TMP/module/.luoshu-payload/product/fonts/NotoSansUI-Medium.ttf" \
+    "$TMP/module/.luoshu-payload/vendor/fonts/MiLanProVF.ttf"; do
+    cmp -s "$TMP/module/.luoshu-payload/system/fonts/MiSansVF.ttf" "$generated"
+done
 
 # 94% v4 pipeline components are forbidden from the actual legacy apply backend.
 ! grep -qE 'font_validate_fast_v4|device_font_template|device_font_slot|font_config_overlay|font_config_batch|device_font_payload_build' "$BACKEND"
@@ -95,7 +111,7 @@ grep -q 'font_mix_engine.sh' "$LEGACY_MIX_ROUTER"
     "$LEGACY_MIX_ROUTER" "$LEGACY_MIX_BRIDGE" "$LEGACY_WEIGHTED" "$LEGACY_AUTO" "$LEGACY_MIX_ENGINE"
 
 # Once selected, all three boot stages keep the legacy payload immutable except for
-# the deterministic HyperOS clock/status aliases above.
+# deterministic HyperOS physical UI aliases generated immediately before self-mount.
 for file in "$SERVICE" "$POSTFS" "$POSTMOUNT"; do
     grep -q 'font_runtime_legacy_v14_4.conf' "$file"
     sh -n "$file"
@@ -120,4 +136,4 @@ sh -n "$ROOT/service_v4.sh"
 sh -n "$ROOT/post-fs-data-v4.sh"
 sh -n "$ROOT/post-mount-v4.sh"
 
-echo 'single/composite legacy switching keeps HyperOS status-bar and lock-screen physical slots.'
+echo 'single/composite legacy switching keeps full HyperOS physical UI coverage.'

--- a/scripts/stability_test.sh
+++ b/scripts/stability_test.sh
@@ -13,7 +13,8 @@ cp "$ROOT/common/font_mix_controller.sh" "$MODULE/common/font_mix_controller.sh"
 cp "$ROOT/common/font_mix.sh" "$MODULE/common/font_mix.sh"
 cp "$ROOT/module.prop" "$MODULE/module.prop"
 
-# 状态查询不得触发真正的字体切换。
+# 状态查询不得触发真正的字体切换；Root 管理器的“当前字体”也不得在字体已
+# 选择/生效后长期显示“待验证”。可信验证属于 App 验收页，不污染模块描述。
 printf '#!/bin/sh\ntouch "%s/manager-called"\nprintf '\''{"status":"ok"}\n'\''\n' "$TMP" > "$MODULE/common/font_manager.sh"
 chmod 0755 "$MODULE/common"/*
 cat > "$MODULE/config/switch_task.conf" <<'EOT'
@@ -27,8 +28,8 @@ EOT
 TASK=$(MODDIR="$MODULE" sh "$MODULE/common/font_switch_task.sh" status test-task)
 printf '%s' "$TASK" | grep -q '"state":"success"'
 test ! -e "$TMP/manager-called"
-grep -q '当前字体：已配置：Beta' "$MODULE/module.prop"
-grep -q 'Beta（待验证）' "$MODULE/module.prop"
+grep -q '当前字体：Beta$' "$MODULE/module.prop"
+! grep -q '待验证' "$MODULE/module.prop"
 
 printf 'state=failed\nbackend=rollback\n' >"$MODULE/config/self-mount.conf"
 printf 'state=verified\nmode=mount-verified\nactiveFont=Beta\n' \
@@ -60,8 +61,28 @@ EOT
 MIX=$(MODDIR="$MODULE" sh "$MODULE/common/font_mix_controller.sh" status mix-task)
 printf '%s' "$MIX" | grep -q '"cjk":"中文甲"'
 test ! -e "$TMP/manager-called"
-grep -q '当前字体：已配置：组合：中文甲 / Latin B / DIN C' "$MODULE/module.prop"
-grep -q 'DIN C（待验证）' "$MODULE/module.prop"
+grep -q '当前字体：组合：中文甲 / Latin B / DIN C$' "$MODULE/module.prop"
+! grep -q '待验证' "$MODULE/module.prop"
+
+# 私有字体负载更新不能依赖刷写进程拥有 bind-mount 权限。KernelSU/SukiSU 的
+# 安装命名空间禁止 mount 时，旧 .luoshu-payload 必须通过只读式临时符号链接
+# 投影给迁移器，结束后恢复为空目录。
+PRIVATE_MODULE="$TMP/private-module"
+PRIVATE_STATE="$TMP/private-state"
+mkdir -p "$PRIVATE_MODULE/.luoshu-payload/system/fonts" "$PRIVATE_MODULE/system"
+printf 'font-payload\n' > "$PRIVATE_MODULE/.luoshu-payload/system/fonts/Roboto-Regular.ttf"
+MODULE_DIR="$PRIVATE_MODULE" \
+LUOSHU_PRIVATE_STATE_ROOT="$PRIVATE_STATE" \
+LUOSHU_PRIVATE_MOUNT_COMMAND=false \
+    sh -c '
+        . "$1/common/private_payload.sh"
+        luoshu_private_mount_module_view "$MODULE_DIR"
+        test -L "$MODULE_DIR/system"
+        test -s "$MODULE_DIR/system/fonts/Roboto-Regular.ttf"
+        luoshu_private_unmount_module_view "$MODULE_DIR"
+        test -d "$MODULE_DIR/system"
+        test ! -L "$MODULE_DIR/system"
+    ' sh "$ROOT"
 
 # 原生 App 字体管理器必须使用原生索引，且不再携带 WebUI 预览、热刷新或回滚入口。
 grep -q 'native_font_index.json' "$ROOT/common/font_manager.sh"


### PR DESCRIPTION
修复用户真机连续回归：

1. KernelSU/SukiSU 覆盖刷入 v4.0.0 时，旧字体负载位于 `.luoshu-payload`，刷写命名空间又无法 bind mount，导致迁移器看不到当前 `mix` 负载并报“无法安全迁移当前字体”；
2. Root 管理器明明已经显示新字体，模块描述仍长期标记“待验证”；
3. 恢复 v14.4 切换核心后只补了时钟槽，HyperOS 仍有大量普通 UI / 英文 / 数字物理槽没有覆盖。

本修复：
- 私有负载视图在 bind mount 不可用时使用临时符号链接投影，迁移完成立即恢复空目录，覆盖刷写不再因 KernelSU 安装命名空间缺少 mount 权限而误判失败；
- `module.prop` 的“当前字体”只显示实际选择/明确失败/等待重启，不再把设备可信验收状态写成“待验证”；
- legacy-v14.4 启动挂载前按真机实际存在文件补齐 HyperOS 物理 UI 槽，覆盖 `system/system_ext/product/mi_ext/vendor/odm/oem/my_product/hw_product/cust`；
- 覆盖 MiSans 核心与数字字重、Roboto、GoogleSans、NotoSansUI、SourceSansPro、DroidSans、Mitype/MiClock/AndroidClock/Clockopia，并动态识别 MiLanPro/XiaomiSans；
- 所有新增目标只复用当前已经生成好的单字体/复合字体物理负载，不进入 device-template/XML/94% 验证链，不同步重建字体；
- 增加 KernelSU 无 bind 权限的私有更新回归测试，以及 HyperOS 普通 UI + 状态栏/锁屏跨分区覆盖测试。