### PR TITLE
fix: allow repeated font switching after activation

### DIFF
--- a/common/legacy_v14_4/font_switch_safe.sh
+++ b/common/legacy_v14_4/font_switch_safe.sh
@@ -100,6 +100,14 @@ cleanup_stage() {
     rm -rf "$STAGE_PAYLOAD" 2>/dev/null || true
 }
 
+cleanup_stale_stages() {
+    for _stale_stage in "$MODDIR"/.luoshu-payload-stage.*; do
+        [ -e "$_stale_stage" ] || continue
+        [ "$_stale_stage" = "$STAGE_PAYLOAD" ] && continue
+        rm -rf "$_stale_stage" 2>/dev/null || true
+    done
+}
+
 trap 'cleanup_stage; lock_cleanup' EXIT
 trap 'cleanup_stage; lock_cleanup; exit 129' HUP
 trap 'cleanup_stage; lock_cleanup; exit 130' INT
@@ -140,13 +148,69 @@ validate_global() {
     return 1
 }
 
-stage_clone_live() {
-    [ -d "$LIVE_PAYLOAD" ] || { safe_error '私有字体负载不存在，请重新刷入当前洛书版本'; return 1; }
+payload_clone_source() {
+    if [ -d "$LIVE_PAYLOAD" ]; then
+        printf '%s\n' "$LIVE_PAYLOAD"
+        return 0
+    fi
+
+    # If an early-boot activation was interrupted after retiring the previous tree,
+    # recover from the activation record instead of permanently blocking future
+    # switches. Only trust retired paths owned by this module.
+    _activated="$CONFIG_DIR/font-payload-activated.conf"
+    _retired=$(read_state_value "$_activated" retired)
+    case "$_retired" in
+        "$MODDIR"/.luoshu-retired/*)
+            [ -d "$_retired" ] && { printf '%s\n' "$_retired"; return 0; }
+            ;;
+    esac
+    return 1
+}
+
+clone_payload_tree() {
+    _clone_source="$1"
     cleanup_stage
     mkdir -p "$STAGE_PAYLOAD" 2>/dev/null || return 1
-    cp -al "$LIVE_PAYLOAD/." "$STAGE_PAYLOAD/" 2>/dev/null || \
-        cp -af "$LIVE_PAYLOAD/." "$STAGE_PAYLOAD/" 2>/dev/null || \
-        cp -rfp "$LIVE_PAYLOAD/." "$STAGE_PAYLOAD/" 2>/dev/null || return 1
+
+    # Hard-link cloning is fastest on the normal /data/adb path, but after a payload
+    # has been activated and used as a mount source some kernels/root managers reject
+    # link or metadata-preserving copies. Retry from a clean stage with a plain
+    # recursive copy so a successful first switch never makes the second one unusable.
+    if cp -al "$_clone_source/." "$STAGE_PAYLOAD/" 2>/dev/null; then
+        return 0
+    fi
+
+    cleanup_stage
+    mkdir -p "$STAGE_PAYLOAD" 2>/dev/null || return 1
+    if cp -R "$_clone_source/." "$STAGE_PAYLOAD/" 2>/dev/null; then
+        find "$STAGE_PAYLOAD" -type d -exec chmod 0755 {} \; 2>/dev/null || true
+        find "$STAGE_PAYLOAD" -type f -exec chmod 0644 {} \; 2>/dev/null || true
+        return 0
+    fi
+
+    cleanup_stage
+    mkdir -p "$STAGE_PAYLOAD" 2>/dev/null || return 1
+    if cp -rf "$_clone_source/." "$STAGE_PAYLOAD/" 2>/dev/null; then
+        find "$STAGE_PAYLOAD" -type d -exec chmod 0755 {} \; 2>/dev/null || true
+        find "$STAGE_PAYLOAD" -type f -exec chmod 0644 {} \; 2>/dev/null || true
+        return 0
+    fi
+
+    cleanup_stage
+    return 1
+}
+
+stage_clone_live() {
+    _clone_source=$(payload_clone_source) || {
+        safe_error '当前启动字体负载不可读取，请重新刷入当前洛书版本'
+        return 1
+    }
+    if ! clone_payload_tree "$_clone_source"; then
+        printf '[%s] [SAFE-SWITCH] clone failed source=%s live=%s next=%s\n' \
+            "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" \
+            "$_clone_source" "$LIVE_PAYLOAD" "$NEXT_PAYLOAD" >> "$LOG_FILE" 2>/dev/null || true
+        return 1
+    fi
     return 0
 }
 
@@ -299,6 +363,7 @@ switch_font() {
 
     progress 4 '正在获取字体切换锁'
     lock_acquire || return 1
+    cleanup_stale_stages
     resolve_previous_state
 
     _source=''

--- a/scripts/legacy_switch_core_test.sh
+++ b/scripts/legacy_switch_core_test.sh
@@ -25,10 +25,17 @@ grep -q 'exec sh "$SAFE_SWITCH" "$@"' "$ROUTER"
 grep -q 'exec sh "$CURRENT_MANAGER" "$@"' "$ROUTER"
 
 # Foreground switching may read/clone live payload but must never rename, delete,
-# or rewrite it. It can only move the isolated staging tree into -next.
+# or rewrite it. It can only move the isolated staging tree into -next. Repeated
+# switches must be able to clone an already activated payload even when hard-link
+# or metadata-preserving copies are rejected by the current root/kernel setup.
 grep -q 'STAGE_PAYLOAD=.*\.luoshu-payload-stage' "$SAFE_BACKEND"
 grep -q 'NEXT_PAYLOAD=.*\.luoshu-payload-next' "$SAFE_BACKEND"
-grep -q 'cp -al "$LIVE_PAYLOAD/\." "$STAGE_PAYLOAD/"' "$SAFE_BACKEND"
+grep -q 'payload_clone_source' "$SAFE_BACKEND"
+grep -q 'cleanup_stale_stages' "$SAFE_BACKEND"
+grep -q 'cp -al "$_clone_source/\." "$STAGE_PAYLOAD/"' "$SAFE_BACKEND"
+grep -q 'cp -R "$_clone_source/\." "$STAGE_PAYLOAD/"' "$SAFE_BACKEND"
+grep -q 'cp -rf "$_clone_source/\." "$STAGE_PAYLOAD/"' "$SAFE_BACKEND"
+grep -q '\.luoshu-retired/\*' "$SAFE_BACKEND"
 grep -q 'mv "$STAGE_PAYLOAD" "$NEXT_PAYLOAD"' "$SAFE_BACKEND"
 ! grep -q 'mv "$LIVE_PAYLOAD"' "$SAFE_BACKEND"
 ! grep -q 'rm -rf "$LIVE_PAYLOAD"' "$SAFE_BACKEND"
@@ -188,4 +195,4 @@ sh -n "$ROOT/service_v4.sh"
 sh -n "$ROOT/post-fs-data-v4.sh"
 sh -n "$ROOT/post-mount-v4.sh"
 
-echo 'foreground switch never mutates live payload; early boot activates next payload; real self-mount runtime is loaded before legacy boot mount; HyperOS physical UI coverage remains guarded.'
+echo 'foreground switch supports repeat payload staging without mutating live payload; early boot activates next payload; real self-mount runtime is loaded before legacy boot mount; HyperOS physical UI coverage remains guarded.'


### PR DESCRIPTION
修复最新版“第一次字体切换后，第二次切换/重启后再次切换无法创建下一启动字体负载”的回归。

- 安全切换核心不再只依赖 hardlink/保留元数据复制；失败时从干净 stage 自动降级到普通递归复制。
- 清理异常退出遗留的 `.luoshu-payload-stage.*`，避免旧暂存状态干扰下一次切换。
- 当早期启动激活在 live payload 迁移阶段中断时，仅从当前模块受信任的 retired payload 恢复克隆源。
- 保持 `.luoshu-payload` 当前启动只读不动，重复选择只替换 `.luoshu-payload-next`，因此同一次开机可反复改选下一次启动要使用的字体。
- 更新 legacy safe-switch 回归门禁，要求 repeat clone fallback 持续存在。