### PR TITLE
fix: allow repeated composite font staging

### DIFF
--- a/common/legacy_v14_4/mix_router.sh
+++ b/common/legacy_v14_4/mix_router.sh
@@ -41,14 +41,72 @@ force_link() {
     fi
 }
 
+mix_clone_source() {
+    if [ -d "$LIVE_PAYLOAD" ]; then
+        printf '%s\n' "$LIVE_PAYLOAD"
+        return 0
+    fi
+
+    # Match the normal safe-switch recovery path: if early boot retired the live
+    # payload and was interrupted before completing activation, recover only from
+    # the retired tree recorded by this module.
+    _activated="$REALMOD/config/font-payload-activated.conf"
+    _retired=$(read_value "$_activated" retired)
+    case "$_retired" in
+        "$REALMOD"/.luoshu-retired/*)
+            [ -d "$_retired" ] && { printf '%s\n' "$_retired"; return 0; }
+            ;;
+    esac
+    return 1
+}
+
+clone_mix_tree() {
+    _source="$1"
+    rm -rf "$MIX_STAGE" 2>/dev/null || true
+    mkdir -p "$MIX_STAGE" 2>/dev/null || return 1
+
+    # Activated payloads can be active mount sources. Some kernels/root managers
+    # reject hard-link or metadata-preserving copies after first activation, which
+    # used to make the next composite switch fail immediately. Retry each method
+    # from a completely clean stage and finally fall back to plain recursive copy.
+    if cp -al "$_source/." "$MIX_STAGE/" 2>/dev/null; then
+        return 0
+    fi
+
+    rm -rf "$MIX_STAGE" 2>/dev/null || true
+    mkdir -p "$MIX_STAGE" 2>/dev/null || return 1
+    if cp -R "$_source/." "$MIX_STAGE/" 2>/dev/null; then
+        find "$MIX_STAGE" -type d -exec chmod 0755 {} \; 2>/dev/null || true
+        find "$MIX_STAGE" -type f -exec chmod 0644 {} \; 2>/dev/null || true
+        return 0
+    fi
+
+    rm -rf "$MIX_STAGE" 2>/dev/null || true
+    mkdir -p "$MIX_STAGE" 2>/dev/null || return 1
+    if cp -rf "$_source/." "$MIX_STAGE/" 2>/dev/null; then
+        find "$MIX_STAGE" -type d -exec chmod 0755 {} \; 2>/dev/null || true
+        find "$MIX_STAGE" -type f -exec chmod 0644 {} \; 2>/dev/null || true
+        return 0
+    fi
+
+    rm -rf "$MIX_STAGE" 2>/dev/null || true
+    return 1
+}
+
 prepare_mix_stage() {
     mkdir -p "$REALMOD/config" "$REALMOD/cache" "$REALMOD/logs" 2>/dev/null || return 1
     rm -rf "$MIX_STAGE" 2>/dev/null || true
     mkdir -p "$MIX_STAGE" 2>/dev/null || return 1
     if [ -d "$LIVE_PAYLOAD" ]; then
-        cp -al "$LIVE_PAYLOAD/." "$MIX_STAGE/" 2>/dev/null || \
-            cp -af "$LIVE_PAYLOAD/." "$MIX_STAGE/" 2>/dev/null || \
-            cp -rfp "$LIVE_PAYLOAD/." "$MIX_STAGE/" 2>/dev/null || return 1
+        _clone_source="$LIVE_PAYLOAD"
+    else
+        _clone_source=$(mix_clone_source 2>/dev/null || true)
+    fi
+    if [ -n "$_clone_source" ] && ! clone_mix_tree "$_clone_source"; then
+        printf '[%s] [MIX] stage clone failed source=%s live=%s next=%s\n' \
+            "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" \
+            "$_clone_source" "$LIVE_PAYLOAD" "$NEXT_PAYLOAD" >> "$LOG_FILE" 2>/dev/null || true
+        return 1
     fi
 
     _previous=$(head -n1 "$ACTIVE_CONF" 2>/dev/null | tr -d '\r\n')

--- a/scripts/legacy_switch_core_test.sh
+++ b/scripts/legacy_switch_core_test.sh
@@ -155,6 +155,16 @@ grep -q '不裁剪 ROM 字体槽' "$LEGACY_MIX_ENGINE"
 grep -q '\.legacy-v14-runtime' "$LEGACY_MIX_ROUTER"
 grep -q '\.luoshu-payload' "$LEGACY_MIX_ROUTER"
 grep -q 'font_mix_engine.sh' "$LEGACY_MIX_ROUTER"
+# Composite staging must have the same repeat-switch fallback as normal font
+# staging. A live payload that is already an active mount source must not make the
+# second composite attempt fail just because hard-link/preserve copy is rejected.
+grep -q 'mix_clone_source' "$LEGACY_MIX_ROUTER"
+grep -q 'clone_mix_tree' "$LEGACY_MIX_ROUTER"
+grep -q 'cp -al "$_source/\." "$MIX_STAGE/"' "$LEGACY_MIX_ROUTER"
+grep -q 'cp -R "$_source/\." "$MIX_STAGE/"' "$LEGACY_MIX_ROUTER"
+grep -q 'cp -rf "$_source/\." "$MIX_STAGE/"' "$LEGACY_MIX_ROUTER"
+grep -q '\.luoshu-retired/\*' "$LEGACY_MIX_ROUTER"
+! grep -q 'cp -af "$LIVE_PAYLOAD/\." "$MIX_STAGE/"' "$LEGACY_MIX_ROUTER"
 ! grep -qE 'font_validate_fast_v4|device_font_template|device_font_slot|font_config_overlay|font_config_batch|device_font_payload_build' \
     "$LEGACY_MIX_ROUTER" "$LEGACY_MIX_BRIDGE" "$LEGACY_WEIGHTED" "$LEGACY_AUTO" "$LEGACY_MIX_ENGINE"
 
@@ -195,4 +205,4 @@ sh -n "$ROOT/service_v4.sh"
 sh -n "$ROOT/post-fs-data-v4.sh"
 sh -n "$ROOT/post-mount-v4.sh"
 
-echo 'foreground switch supports repeat payload staging without mutating live payload; early boot activates next payload; real self-mount runtime is loaded before legacy boot mount; HyperOS physical UI coverage remains guarded.'
+echo 'foreground switch and composite staging both support repeat payload cloning without mutating live payload; early boot activates next payload; real self-mount runtime is loaded before legacy boot mount; HyperOS physical UI coverage remains guarded.'


### PR DESCRIPTION
修复 v4.0.0 组合字体页面报“无法创建复合字体下一启动暂存负载”的回归。

根因与普通字体连续切换相同：`mix_router.sh` 仍使用旧的 `cp -al -> cp -af -> cp -rfp` 克隆已激活 `.luoshu-payload`。部分内核/Root 管理器在该目录已作为挂载源后会拒绝 hardlink 或保留元数据复制，导致第一次切换后再次创建组合字体 stage 直接失败。

本 PR：
- 组合字体 stage 改为每次从干净目录重新尝试 `cp -al`，失败后降级 `cp -R`、`cp -rf`。
- 普通复制成功后统一修正目录/文件权限。
- live payload 在早期启动迁移中断时，可从当前模块 activation 记录里的可信 `.luoshu-retired/*` 恢复克隆源。
- 克隆失败写入 fontswitch 日志，保留真实 source/live/next 路径用于诊断。
- `legacy_switch_core_test.sh` 增加组合字体 repeat-stage 门禁，防止以后只修普通字体又漏掉组合字体分支。