### PR TITLE
fix: align HyperOS safe-stage font metrics

### DIFF
--- a/common/hyperos_stage_complete.sh
+++ b/common/hyperos_stage_complete.sh
@@ -22,6 +22,7 @@ export MODULE_DIR MODDIR USER_FONTS_DIR
 [ -f "$REALMOD/common/util_functions.sh" ] && . "$REALMOD/common/util_functions.sh"
 [ -f "$REALMOD/common/rom_adapters.sh" ] && . "$REALMOD/common/rom_adapters.sh"
 [ -f "$REALMOD/common/hyperos_global.sh" ] && . "$REALMOD/common/hyperos_global.sh"
+[ -f "$REALMOD/common/legacy_v14_4/hyperos_metric_stage.sh" ] && . "$REALMOD/common/legacy_v14_4/hyperos_metric_stage.sh"
 
 type _hyperos_core_files >/dev/null 2>&1 || exit 2
 type _hyperos_weight_files >/dev/null 2>&1 || exit 2
@@ -30,6 +31,7 @@ type _hyperos_clock_ui_files >/dev/null 2>&1 || exit 2
 
 stage_font_dir="$PAYLOAD_ROOT/system/fonts"
 [ -d "$stage_font_dir" ] || exit 1
+metric_log="$REALMOD/logs/fontswitch.log"
 
 pick_anchor() {
     _name="$1"
@@ -43,6 +45,7 @@ pick_anchor() {
             800.ttf) _weight=800 ;; 900.ttf) _weight=900 ;; *) _weight=400 ;;
         esac
     fi
+    _raw=''
     for _candidate in \
         "$stage_font_dir/LuoShu-${_weight}.ttf" \
         "$stage_font_dir/.luoshu-font-store/wght-${_weight}.font" \
@@ -54,10 +57,32 @@ pick_anchor() {
         "$stage_font_dir/MiSansVF.ttf" \
         "$stage_font_dir/Roboto-Regular.ttf"; do
         [ -s "$_candidate" ] || continue
-        printf '%s\n' "$_candidate"
-        return 0
+        _raw="$_candidate"
+        break
     done
-    find "$stage_font_dir" -maxdepth 2 -type f \( -iname '*.ttf' -o -iname '*.otf' \) -print -quit 2>/dev/null
+    if [ -z "$_raw" ]; then
+        _raw=$(find "$stage_font_dir" -maxdepth 2 -type f \( -iname '*.ttf' -o -iname '*.otf' \) -print -quit 2>/dev/null)
+    fi
+    [ -s "$_raw" ] || return 1
+
+    # The v4 safe switch used to hard-link this raw source directly into every
+    # HyperOS slot. That bypassed LuoShu's metric normalizer and produced the exact
+    # status-bar / QQ / Coolapk vertical offset regression seen on HyperOS 3.
+    if type luoshu_hyperos_stage_metric_anchor >/dev/null 2>&1; then
+        _aligned=$(luoshu_hyperos_stage_metric_anchor "$_raw" "$_name" "$stage_font_dir" 2>/dev/null || true)
+        if [ -s "$_aligned" ]; then
+            printf '%s\n' "$_aligned"
+            return 0
+        fi
+        mkdir -p "${metric_log%/*}" 2>/dev/null || true
+        printf '[%s] [HYPEROS-METRIC] alignment fallback target=%s source=%s\n' \
+            "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo unknown)" "$_name" "$_raw" \
+            >> "$metric_log" 2>/dev/null || true
+    fi
+
+    # Safety fallback: a metric helper failure must never make the next-boot payload
+    # unbootable. Keep the previous physical mapping rather than failing the switch.
+    printf '%s\n' "$_raw"
 }
 
 link_font() {

--- a/common/legacy_v14_4/hyperos_metric_align.py
+++ b/common/legacy_v14_4/hyperos_metric_align.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Align staged HyperOS fonts to the ROM's real UI/clock metric contracts.
+
+The safe v4 switch path intentionally stages fonts off-line.  It used to hard-link
+one raw regular/composite font into every MiSans/Mitype/MiClock slot, which bypassed
+LuoShu's metric normalizer and the per-slot alignment engine.  This helper restores
+those contracts without touching the payload mounted by the current boot.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from fontTools.ttLib import TTCollection, TTFont
+
+COMMON_DIR = Path(__file__).resolve().parents[1]
+if str(COMMON_DIR) not in sys.path:
+    sys.path.insert(0, str(COMMON_DIR))
+
+import font_metrics_normalize as metrics_normalizer  # noqa: E402
+import device_font_template as template_engine  # noqa: E402
+import device_font_slot_plan as slot_planner  # noqa: E402
+import device_font_slot_build as slot_builder  # noqa: E402
+
+DIGIT_PROBES = tuple(map(ord, "0123456789"))
+LATIN_PROBES = tuple(map(ord, "AHIOXahiox"))
+
+
+class AlignError(RuntimeError):
+    pass
+
+
+def _is_collection(path: Path) -> bool:
+    with path.open("rb") as stream:
+        return stream.read(4) == b"ttcf"
+
+
+def _stock_face(path: Path) -> int:
+    if not _is_collection(path):
+        return -1
+    collection = TTCollection(str(path), lazy=True)
+    try:
+        count = len(collection.fonts)
+    finally:
+        collection.close()
+    best: tuple[int, int] | None = None
+    for index in range(count):
+        font = TTFont(str(path), fontNumber=index, lazy=True, recalcTimestamp=False)
+        try:
+            cmap = font.getBestCmap() or {}
+            score = sum(1 for cp in DIGIT_PROBES if cp in cmap) * 4 + sum(1 for cp in LATIN_PROBES if cp in cmap)
+        finally:
+            font.close()
+        if best is None or score > best[0]:
+            best = (score, index)
+    return best[1] if best is not None else 0
+
+
+def _stock_contract(path: Path) -> dict[str, Any]:
+    face = _stock_face(path)
+    kwargs: dict[str, Any] = {"lazy": True, "recalcTimestamp": False}
+    if face >= 0:
+        kwargs["fontNumber"] = face
+    font = TTFont(str(path), **kwargs)
+    try:
+        if "head" not in font or "hhea" not in font:
+            raise AlignError("原厂目标字体缺少 head/hhea")
+        upem = int(font["head"].unitsPerEm)
+        ascent = int(font["hhea"].ascent)
+        descent = int(font["hhea"].descent)
+        if upem <= 0 or ascent <= 0 or descent >= 0:
+            raise AlignError("原厂目标字体度量无效")
+        return {
+            "source": "stock-slot",
+            "slot": str(path),
+            "buildKey": "",
+            "upem": upem,
+            "ascent": ascent,
+            "descent": descent,
+            "ascentRatio": ascent / upem,
+            "descentRatio": abs(descent) / upem,
+        }
+    finally:
+        font.close()
+
+
+def _target_weight(path: Path) -> int:
+    face = _stock_face(path)
+    kwargs: dict[str, Any] = {"lazy": True, "recalcTimestamp": False}
+    if face >= 0:
+        kwargs["fontNumber"] = face
+    font = TTFont(str(path), **kwargs)
+    try:
+        if "OS/2" in font:
+            value = int(getattr(font["OS/2"], "usWeightClass", 400) or 400)
+            return max(1, min(1000, value))
+        return 400
+    finally:
+        font.close()
+
+
+def _exact_slot_align(source: Path, stock: Path, output: Path, role: str) -> dict[str, Any]:
+    source_profile = template_engine.inspect_font(source, -1, hash_fonts=False)
+    stock_face = _stock_face(stock)
+    stock_profile = template_engine.inspect_font(stock, stock_face, hash_fonts=False)
+    roles = ["mono", "global-ui"] if role == "mono" else ["clock", "global-ui"]
+    slot = {
+        "family": f"physical-{stock.name}",
+        "familyNormalized": f"physical-{stock.name}".lower(),
+        "familyAttributes": {},
+        "sourceXml": "",
+        "declared": stock.name,
+        "postScriptName": "",
+        "weight": _target_weight(stock),
+        "style": "normal",
+        "index": 0,
+        "axes": "",
+        "roles": roles,
+        "replaceable": True,
+        "resolvedPath": str(stock),
+        "directPhysical": True,
+        "font": stock_profile,
+    }
+    plan = slot_planner.slot_plan(slot, source_profile)
+    if plan.get("status") != "ready":
+        raise AlignError(f"逐槽位计划不可用：{plan.get('status')}:{plan.get('reason', '')}")
+    report = slot_builder.build_slot(source, -1, plan, output)
+    return {"mode": "slot", "plan": plan, "build": report}
+
+
+def align(source: Path, output: Path, role: str, inventory: Path | None, stock: Path | None) -> dict[str, Any]:
+    if not source.is_file() or source.stat().st_size < 1024:
+        raise AlignError(f"字体源不可用：{source}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    # Clock/mono slots are the visible HyperOS status-bar/lock-screen problem.  Use
+    # the existing exact per-slot engine first so digit ink, advances and line box all
+    # follow the real ROM font.  CFF/unsupported sources safely fall back to line metrics.
+    if role in {"clock", "mono"} and stock is not None and stock.is_file():
+        try:
+            report = _exact_slot_align(source, stock, output, role)
+            return {"status": "ok", "role": role, "source": str(source), "stock": str(stock), "output": str(output), **report}
+        except Exception as exact_error:
+            contract = _stock_contract(stock)
+            normalized = metrics_normalizer.normalize_path(
+                source,
+                output,
+                monospaced=(role == "mono"),
+                inventory=inventory,
+                target_contract=contract,
+            )
+            return {
+                "status": "ok",
+                "role": role,
+                "mode": "stock-metrics-fallback",
+                "source": str(source),
+                "stock": str(stock),
+                "output": str(output),
+                "exactError": str(exact_error),
+                "normalize": normalized,
+            }
+
+    normalized = metrics_normalizer.normalize_path(
+        source,
+        output,
+        monospaced=(role == "mono"),
+        inventory=inventory,
+    )
+    return {
+        "status": "ok",
+        "role": role,
+        "mode": "ui-metrics",
+        "source": str(source),
+        "stock": str(stock) if stock is not None else "",
+        "output": str(output),
+        "normalize": normalized,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--role", choices=("ui", "clock", "mono"), default="ui")
+    parser.add_argument("--inventory", type=Path)
+    parser.add_argument("--stock", type=Path)
+    args = parser.parse_args()
+    try:
+        report = align(args.source, args.output, args.role, args.inventory, args.stock)
+        print(json.dumps(report, ensure_ascii=False, separators=(",", ":")))
+        return 0
+    except Exception as error:
+        args.output.unlink(missing_ok=True)
+        print(json.dumps({"status": "error", "message": str(error) or error.__class__.__name__}, ensure_ascii=False, separators=(",", ":")), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/common/legacy_v14_4/hyperos_metric_stage.sh
+++ b/common/legacy_v14_4/hyperos_metric_stage.sh
@@ -1,0 +1,100 @@
+#!/system/bin/sh
+# HyperOS staged metric alignment for the safe next-boot payload path.
+# Never touches the payload mounted by the current boot.
+set +e
+
+_lhms_module_dir() {
+    printf '%s\n' "${LUOSHU_REAL_MODDIR:-${MODULE_DIR:-${MODDIR:-/data/adb/modules/LuoShu}}}"
+}
+
+_lhms_role_for_target() {
+    _lhms_lower=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+    case "$_lhms_lower" in
+        *mono*) printf 'mono\n' ;;
+        *clock*|clockopia.ttf) printf 'clock\n' ;;
+        *) printf 'ui\n' ;;
+    esac
+}
+
+_lhms_source_key() {
+    _lhms_source="$1"
+    if command -v stat >/dev/null 2>&1; then
+        _lhms_key=$(stat -c '%d-%i-%s-%Y' "$_lhms_source" 2>/dev/null)
+    elif command -v toybox >/dev/null 2>&1; then
+        _lhms_key=$(toybox stat -c '%d-%i-%s-%Y' "$_lhms_source" 2>/dev/null)
+    else
+        _lhms_key=''
+    fi
+    if [ -z "$_lhms_key" ]; then
+        _lhms_key=$(basename "$_lhms_source" | tr -c 'A-Za-z0-9._-' '_')
+    fi
+    printf '%s\n' "$_lhms_key" | tr -c 'A-Za-z0-9._-' '_'
+}
+
+_lhms_stock_for_target() {
+    _lhms_name="$1"
+    _lhms_state="${LUOSHU_SELF_MOUNT_STATE_ROOT:-/data/adb/luoshu/self-mount}"
+    for _lhms_part in system system_ext product mi_ext vendor odm oem my_product hw_product cust; do
+        for _lhms_candidate in \
+            "$_lhms_state/lower/${_lhms_part}-fonts/$_lhms_name" \
+            "/debug_ramdisk/.magisk/mirror/${_lhms_part}/fonts/$_lhms_name" \
+            "/sbin/.magisk/mirror/${_lhms_part}/fonts/$_lhms_name" \
+            "/data/adb/magisk/mirror/${_lhms_part}/fonts/$_lhms_name"; do
+            [ -s "$_lhms_candidate" ] || continue
+            printf '%s\n' "$_lhms_candidate"
+            return 0
+        done
+    done
+    return 1
+}
+
+_lhms_python_align() {
+    _lhms_source="$1"; _lhms_output="$2"; _lhms_role="$3"; _lhms_stock="$4"
+    _lhms_module="$(_lhms_module_dir)"
+    _lhms_pyroot="$_lhms_module/common/python"
+    _lhms_python="$_lhms_pyroot/bin/luoshu-python"
+    _lhms_helper="$_lhms_module/common/legacy_v14_4/hyperos_metric_align.py"
+    _lhms_inventory="$_lhms_module/config/device_font_inventory.json"
+    [ -x "$_lhms_python" ] && [ -f "$_lhms_helper" ] || return 1
+
+    set -- --source "$_lhms_source" --output "$_lhms_output" --role "$_lhms_role" --inventory "$_lhms_inventory"
+    [ -n "$_lhms_stock" ] && set -- "$@" --stock "$_lhms_stock"
+    PYTHONHOME="$_lhms_pyroot" \
+    PYTHONPATH="$_lhms_module/common:$_lhms_module/common/legacy_v14_4:$_lhms_pyroot/lib/python3.14:$_lhms_pyroot/lib/python3.14/site-packages" \
+    LD_LIBRARY_PATH="$_lhms_pyroot/lib:$_lhms_pyroot/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+        "$_lhms_python" "$_lhms_helper" "$@" >/dev/null 2>&1
+}
+
+# Usage: luoshu_hyperos_stage_metric_anchor SOURCE TARGET_NAME STAGE_FONT_DIR
+# Prints an aligned font path on success. UI fonts share one normalized cache per source;
+# clock/mono fonts keep a target-specific cache because their stock contracts differ.
+luoshu_hyperos_stage_metric_anchor() {
+    _lhms_source="$1"; _lhms_target="$2"; _lhms_stage_fonts="$3"
+    [ -s "$_lhms_source" ] && [ -n "$_lhms_target" ] && [ -d "$_lhms_stage_fonts" ] || return 1
+    _lhms_role=$(_lhms_role_for_target "$_lhms_target")
+    _lhms_key=$(_lhms_source_key "$_lhms_source")
+    _lhms_store="$_lhms_stage_fonts/.luoshu-font-store"
+    mkdir -p "$_lhms_store" 2>/dev/null || return 1
+
+    if [ "$_lhms_role" = ui ]; then
+        _lhms_output="$_lhms_store/hyperos-ui-${_lhms_key}.font"
+        _lhms_stock=''
+    else
+        _lhms_safe_target=$(printf '%s' "$_lhms_target" | tr -c 'A-Za-z0-9._-' '_')
+        _lhms_output="$_lhms_store/hyperos-${_lhms_role}-${_lhms_safe_target}-${_lhms_key}.font"
+        _lhms_stock=$(_lhms_stock_for_target "$_lhms_target" 2>/dev/null || true)
+    fi
+
+    if [ -s "$_lhms_output" ]; then
+        printf '%s\n' "$_lhms_output"
+        return 0
+    fi
+    rm -f "$_lhms_output" 2>/dev/null || true
+    if _lhms_python_align "$_lhms_source" "$_lhms_output" "$_lhms_role" "$_lhms_stock" && [ -s "$_lhms_output" ]; then
+        chmod 0644 "$_lhms_output" 2>/dev/null || true
+        printf '%s\n' "$_lhms_output"
+        return 0
+    fi
+    rm -f "$_lhms_output" 2>/dev/null || true
+    return 1
+}

--- a/common/legacy_v14_4/hyperos_metric_stage.sh
+++ b/common/legacy_v14_4/hyperos_metric_stage.sh
@@ -11,7 +11,7 @@ _lhms_role_for_target() {
     _lhms_lower=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
     case "$_lhms_lower" in
         *mono*) printf 'mono\n' ;;
-        *clock*|clockopia.ttf) printf 'clock\n' ;;
+        *mitype*|*clock*|clockopia.ttf) printf 'clock\n' ;;
         *) printf 'ui\n' ;;
     esac
 }

--- a/scripts/hyperos_global_mapping_test.sh
+++ b/scripts/hyperos_global_mapping_test.sh
@@ -98,6 +98,26 @@ ok grep -qF "$LUOSHU_ODM_FONTS_ROOT|$MODULE_DIR/odm/fonts" "$ROOT/hyperos-root-p
 ok grep -qF "$LUOSHU_CUST_FONTS_ROOT|$MODULE_DIR/cust/fonts" "$ROOT/hyperos-root-pairs"
 printf 'HyperOS global mapping and compact-anchor reuse tests passed.\n'
 
+# Safe v4 staging must not regress to hard-linking the raw regular/composite font into
+# every HyperOS target. The dedicated helper normalizes general UI slots and routes
+# MiClock/Mitype clock/mono slots through the existing stock-aligned slot engine first.
+CASE='HyperOS 安全暂存度量对齐链'
+METRIC_STAGE="$REPO_ROOT/common/legacy_v14_4/hyperos_metric_stage.sh"
+METRIC_ALIGN="$REPO_ROOT/common/legacy_v14_4/hyperos_metric_align.py"
+ok test -s "$METRIC_STAGE"
+ok test -s "$METRIC_ALIGN"
+ok grep -q 'hyperos_metric_stage.sh' "$REPO_ROOT/common/hyperos_stage_complete.sh"
+ok grep -q 'luoshu_hyperos_stage_metric_anchor' "$REPO_ROOT/common/hyperos_stage_complete.sh"
+ok grep -q 'font_metrics_normalize' "$METRIC_ALIGN"
+ok grep -q 'device_font_slot_plan' "$METRIC_ALIGN"
+ok grep -q 'device_font_slot_build' "$METRIC_ALIGN"
+python3 -m py_compile "$METRIC_ALIGN"
+. "$METRIC_STAGE"
+ok test "$(_lhms_role_for_target MiClock.otf)" = clock
+ok test "$(_lhms_role_for_target MitypeClockMono.ttf)" = mono
+ok test "$(_lhms_role_for_target Roboto-Regular.ttf)" = ui
+printf 'HyperOS safe-stage metric alignment regression gates passed.\n'
+
 # Keep OEM partition regressions in the always-on source gate.
 sh "$REPO_ROOT/scripts/coloros_partition_mapping_test.sh"
 sh "$REPO_ROOT/scripts/originos_flyme_mapping_test.sh"


### PR DESCRIPTION
修复 v4.0.0 安全切换链路在 HyperOS 上绕过字体度量归一化的问题。

根因：`font_manager.sh` 当前最终切换走 legacy safe-stage；`hyperos_stage_complete.sh` 会把 raw regular/composite anchor 直接硬链接到 MiSans/Roboto/GoogleSans/Mitype/MiClock 等物理槽，绕过现有 `font_metrics_normalize.py` 和 per-slot stock alignment engine。这个回归与截图中的状态栏、QQ 输入框、酷安标题/热度纵向偏移一致。

改动：
- 一般 HyperOS UI 槽在 next-boot stage 中先按设备 inventory 归一化 hhea/OS2 行框；
- Mitype/MiClock/AndroidClock/Clockopia/mono 槽优先调用现有 `device_font_slot_plan` + `device_font_slot_build`，按原厂字体的 line contract、digit bounds 与 advance 逐槽对齐；
- 不支持逐槽生成的 CFF/异常源自动降级为原厂 stock hhea contract 的安全归一化；
- 对齐失败保留原 raw physical mapping，不让修复本身导致无法启动；
- 增加 HyperOS safe-stage 回归门禁与 helper Python 语法检查。

不改当前 boot 已挂载 payload，只生成 `.luoshu-payload-next` / composite stage。