### PR TITLE
fix: restore v3.3.6 HyperOS compact metrics

### DIFF
--- a/common/hyperos_stage_complete.sh
+++ b/common/hyperos_stage_complete.sh
@@ -31,6 +31,56 @@ type _hyperos_clock_ui_files >/dev/null 2>&1 || exit 2
 stage_font_dir="$PAYLOAD_ROOT/system/fonts"
 [ -d "$stage_font_dir" ] || exit 1
 
+# v3.3.6 used one compact line contract for HyperOS physical slots instead of
+# feeding each user's raw hhea/OS2 metrics directly to SystemUI and app controls.
+# That release is already device-proven to have substantially less vertical drift.
+# Reuse the exact old ratios here, but cache once per selected weight so this does
+# not repeat the expensive per-target Python work that caused the later regression.
+hyperos_336_compact_anchor() {
+    _source="$1"
+    _weight="$2"
+    [ -s "$_source" ] || return 1
+    _store="$stage_font_dir/.luoshu-font-store"
+    _output="$_store/hyperos-336-wght-${_weight}.font"
+    if [ -s "$_output" ]; then
+        printf '%s\n' "$_output"
+        return 0
+    fi
+
+    _pyroot="$REALMOD/common/python"
+    _python="$_pyroot/bin/luoshu-python"
+    [ -x "$_python" ] && [ -f "$REALMOD/common/font_metrics_normalize.py" ] || return 1
+    mkdir -p "$_store" 2>/dev/null || return 1
+    rm -f "$_output" 2>/dev/null || true
+
+    PYTHONHOME="$_pyroot" \
+    PYTHONPATH="$REALMOD/common:$_pyroot/lib/python3.14:$_pyroot/lib/python3.14/site-packages" \
+    LD_LIBRARY_PATH="$_pyroot/lib:$_pyroot/lib/python3.14/lib-dynload${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+        "$_python" - "$_source" "$_output" <<'PY_COMPACT' >/dev/null 2>&1
+import sys
+from pathlib import Path
+import font_metrics_normalize as metrics
+
+# Exact HyperOS compact line contract used by LuoShu v3.3.6.
+metrics.TYPO_ASCENDER_RATIO = 0.98
+metrics.TYPO_DESCENDER_RATIO = 0.30
+metrics.WIN_ASCENT_CAP_RATIO = 0.98
+metrics.WIN_DESCENT_CAP_RATIO = 0.35
+metrics.HHEA_ASCENT_CAP_RATIO = 0.98
+metrics.HHEA_DESCENT_CAP_RATIO = 0.30
+metrics._outline_extremes = lambda font: None
+metrics.normalize_path(Path(sys.argv[1]), Path(sys.argv[2]))
+PY_COMPACT
+    _rc=$?
+    if [ "$_rc" -eq 0 ] && [ -s "$_output" ]; then
+        chmod 0644 "$_output" 2>/dev/null || true
+        printf '%s\n' "$_output"
+        return 0
+    fi
+    rm -f "$_output" 2>/dev/null || true
+    return 1
+}
+
 pick_anchor() {
     _name="$1"
     _weight=400
@@ -43,6 +93,7 @@ pick_anchor() {
             800.ttf) _weight=800 ;; 900.ttf) _weight=900 ;; *) _weight=400 ;;
         esac
     fi
+    _raw=''
     for _candidate in \
         "$stage_font_dir/LuoShu-${_weight}.ttf" \
         "$stage_font_dir/.luoshu-font-store/wght-${_weight}.font" \
@@ -54,10 +105,22 @@ pick_anchor() {
         "$stage_font_dir/MiSansVF.ttf" \
         "$stage_font_dir/Roboto-Regular.ttf"; do
         [ -s "$_candidate" ] || continue
-        printf '%s\n' "$_candidate"
-        return 0
+        _raw="$_candidate"
+        break
     done
-    find "$stage_font_dir" -maxdepth 2 -type f \( -iname '*.ttf' -o -iname '*.otf' \) -print -quit 2>/dev/null
+    if [ -z "$_raw" ]; then
+        _raw=$(find "$stage_font_dir" -maxdepth 2 -type f \( -iname '*.ttf' -o -iname '*.otf' \) -print -quit 2>/dev/null)
+    fi
+    [ -s "$_raw" ] || return 1
+
+    _compact=$(hyperos_336_compact_anchor "$_raw" "$_weight" 2>/dev/null || true)
+    if [ -s "$_compact" ]; then
+        printf '%s\n' "$_compact"
+    else
+        # Never make font switching fail merely because normalization failed on an
+        # unusual font. The old raw physical mapping remains the safety fallback.
+        printf '%s\n' "$_raw"
+    fi
 }
 
 link_font() {

--- a/scripts/hyperos_global_mapping_test.sh
+++ b/scripts/hyperos_global_mapping_test.sh
@@ -98,6 +98,23 @@ ok grep -qF "$LUOSHU_ODM_FONTS_ROOT|$MODULE_DIR/odm/fonts" "$ROOT/hyperos-root-p
 ok grep -qF "$LUOSHU_CUST_FONTS_ROOT|$MODULE_DIR/cust/fonts" "$ROOT/hyperos-root-pairs"
 printf 'HyperOS global mapping and compact-anchor reuse tests passed.\n'
 
+# Safe next-boot staging intentionally restores the exact v3.3.6 compact line
+# contract. Keep it weight-cached: the later per-target metric experiment caused a
+# real-device switching regression and must not return here.
+CASE='HyperOS v3.3.6 紧凑行框安全暂存链'
+STAGE_HELPER="$REPO_ROOT/common/hyperos_stage_complete.sh"
+ok grep -q 'hyperos_336_compact_anchor' "$STAGE_HELPER"
+ok grep -q 'TYPO_ASCENDER_RATIO = 0.98' "$STAGE_HELPER"
+ok grep -q 'TYPO_DESCENDER_RATIO = 0.30' "$STAGE_HELPER"
+ok grep -q 'WIN_DESCENT_CAP_RATIO = 0.35' "$STAGE_HELPER"
+ok grep -q 'HHEA_ASCENT_CAP_RATIO = 0.98' "$STAGE_HELPER"
+ok grep -q 'HHEA_DESCENT_CAP_RATIO = 0.30' "$STAGE_HELPER"
+ok grep -q 'hyperos-336-wght-${_weight}.font' "$STAGE_HELPER"
+no grep -q 'device_font_slot_plan' "$STAGE_HELPER"
+no grep -q 'device_font_slot_build' "$STAGE_HELPER"
+sh -n "$STAGE_HELPER"
+printf 'HyperOS v3.3.6 compact staging regression gates passed.\n'
+
 # Keep OEM partition regressions in the always-on source gate.
 sh "$REPO_ROOT/scripts/coloros_partition_mapping_test.sh"
 sh "$REPO_ROOT/scripts/originos_flyme_mapping_test.sh"


### PR DESCRIPTION
基于用户 HyperOS 实机反馈：v3.3.6 的字体纵向偏移明显轻于当前 v4.0.0。

对比后确认：
- v3.3.6 在 HyperOS 物理槽映射前会先应用固定紧凑行框：typo/hhea ascent 0.98em、descent 0.30em，win descent 0.35em；
- 当前 v4.0.0 将 `_hyperos_compact_normalize` 改成了纯 ln/cp，直接保留用户字体原始 metrics，导致极端 ascent/descent 直接进入 SystemUI、QQ、酷安等控件；
- PR #214 的逐槽度量实验已因实机切换回归撤回，本 PR 不恢复那套逻辑。

本修复只在 `hyperos_stage_complete.sh` 中恢复 v3.3.6 已验证过的 compact line contract：
- 每个选中字重最多归一化一次并缓存为 `hyperos-336-wght-*.font`；
- MiSans/Roboto/GoogleSans/Mitype/MiClock 继续走现有物理槽覆盖；
- 不做逐槽 Python 生成，不接 device_font_slot_plan/build；
- 归一化失败时直接回退当前 raw 映射，不能阻塞字体切换；
- 加入回归门禁锁定 v3.3.6 的精确比例并禁止逐槽实验逻辑重新混入。

目标：先恢复 3.3.6 在 HyperOS 上更稳定的纵向表现，同时不破坏 PR #212/#213 的连续切换与组合负载修复。